### PR TITLE
Define battery charging standard attribute

### DIFF
--- a/docs/entity_index.md
+++ b/docs/entity_index.md
@@ -82,6 +82,7 @@ The following `device_state_attributes` are considered standard and should follo
 
 | Name | Type | Unit | Constant | Description
 | ---- | ---- | ---- | -------- | -----------
+| battery_charging | boolean | N/A | `ATTR_BATTERY_CHARGING` | Battery charging status of the entity, shown as a boolean `true` or `false`. If charging is not supported, then this attribute should not be created.
 | battery_level | integer | % | `ATTR_BATTERY_LEVEL` | Battery level of the entity, shown as an integer percentage between 0-100.
 
 ## Lifecycle hooks


### PR DESCRIPTION
- A continuation of my earlier [PR](https://github.com/home-assistant/developers.home-assistant/pull/23) and in parallel with a HomeKit [PR](https://github.com/home-assistant/home-assistant/pull/14288) to add battery tracking.
- This was already discussed and agreed [here](https://github.com/home-assistant/architecture/issues/25).