### PR TITLE
Fix script name of script to set up docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Documentation is build using [Docusaurus](https://docusaurus.io/docs/en/doc-mark
 
 ### Preparing environment
 
-Running the documentation locally requires [NodeJS](https://nodejs.org/en/) and [Yarn](https://yarnpkg.com/) to be installed. Inside a cloned fork of this repository, run `script/setup`.
+Running the documentation locally requires [NodeJS](https://nodejs.org/en/) and [Yarn](https://yarnpkg.com/) to be installed. Inside a cloned fork of this repository, run `script/bootstrap`.
 
 ### Running docs locally
 


### PR DESCRIPTION
* Run `script/bootstrap` to set up the docs.