### PR TITLE
Add dev documentation for media player source

### DIFF
--- a/docs/entity_media_player.md
+++ b/docs/entity_media_player.md
@@ -14,7 +14,7 @@ sidebar_label: Media Player
 | sound_mode | string | None | The current sound mode of the media player
 | sound_mode_list | list | None | Dynamic list of available sound modes (set by platform, empty means sound mode not supported)
 | source | string | None | The currently selected input source for the media player.
-| source_list | list | None | The list of possible input sources for the media player. (This list should contain user-friendly names)
+| source_list | list | None | The list of possible input sources for the media player. (This list should contain human readable names, suitible for frontend display)
 
 
 ## Methods
@@ -33,11 +33,11 @@ Optional. Switch the sound mode of the media player.
 ### Select source
 Optional. Switch the selected input source for the media player.
 
-        class MyMediaPlayer(MediaPlayerDevice):
-          # Implement one of these methods.
-      
-          def select_source(self, source):
-              """Select input source."""
+    class MyMediaPlayer(MediaPlayerDevice):
+      # Implement one of these methods.
 
-          def async_select_source(self, source):
-              """Select input source."""
+      def select_source(self, source):
+          """Select input source."""
+
+      def async_select_source(self, source):
+          """Select input source."""

--- a/docs/entity_media_player.md
+++ b/docs/entity_media_player.md
@@ -13,6 +13,8 @@ sidebar_label: Media Player
 | ---- | ---- | ------- | -----------
 | sound_mode | string | None | The current sound mode of the media player
 | sound_mode_list | list | None | Dynamic list of available sound modes (set by platform, empty means sound mode not supported)
+| source | string | None | The currently selected input source for the media player.
+| source_list | list | None | The list of possible input sources for the media player. (This list should contain user-friendly names)
 
 
 ## Methods
@@ -26,4 +28,16 @@ Optional. Switch the sound mode of the media player.
           """Switch the sound mode of the entity."""
 
       def async_select_sound_mode(self, sound_mode):
-         """Switch the sound mode of the entity."""
+          """Switch the sound mode of the entity."""
+
+### Select source
+Optional. Switch the selected input source for the media player.
+
+        class MyMediaPlayer(MediaPlayerDevice):
+          # Implement one of these methods.
+      
+          def select_source(self, source):
+              """Select input source."""
+
+          def async_select_source(self, source):
+              """Select input source."""


### PR DESCRIPTION
## Description
This PR adds developer documentation for the media player `source` and `source_list` properties, as well as the `select_source` service implementation. This PR clarifies that the source list should contain user friendly names.

Fixes https://github.com/home-assistant/architecture/issues/47