### PR TITLE
Add virtual environment info to testing (tox) doc

### DIFF
--- a/docs/development_testing.md
+++ b/docs/development_testing.md
@@ -2,7 +2,12 @@
 title: "Testing your code"
 ---
 
-As it states in the [Style guidelines section](development_guidelines.md) all code is checked to verify all that the unit tests pass and that the code passes the checks from the linting tools. Local testing is done using Tox, which has been installed as part of running `script/setup` in the [virtual environment](development_environment.md). To start the tests, activate the virtual environment and simply run the command:
+As it states in the [Style guidelines section](development_guidelines.md) all code is checked to verify the following:
+
+- All the unit tests pass
+- All code passes the checks from the linting tools
+
+Local testing is done using Tox, which has been installed as part of running `script/setup` in the [virtual environment](development_environment.md). To start the tests, activate the virtual environment and simply run the command:
 
 ```bash
 $ tox

--- a/docs/development_testing.md
+++ b/docs/development_testing.md
@@ -2,7 +2,7 @@
 title: "Testing your code"
 ---
 
-As it states in the [Style guidelines section](development_guidelines.md) all code is checked to verify all the unit tests pass and that the code passes the linting tools. Local testing is done using Tox, which has been installed as part of running `script/setup` in the [virtual environment](development_environment.md). To start the tests, activate the virtual environment and simply run the command:
+As it states in the [Style guidelines section](development_guidelines.md) all code is checked to verify all that the unit tests pass and that the code passes the checks from the linting tools. Local testing is done using Tox, which has been installed as part of running `script/setup` in the [virtual environment](development_environment.md). To start the tests, activate the virtual environment and simply run the command:
 
 ```bash
 $ tox

--- a/docs/development_testing.md
+++ b/docs/development_testing.md
@@ -2,7 +2,7 @@
 title: "Testing your code"
 ---
 
-As states in the [Style guidelines section](development_guidelines.md) all code is checked to verify all unit tests pass and that the code passes the linting tools. Local testing is done using Tox, which has been installed as part of running `script/setup` in the [virtual environment](development_environment.md). To start the tests, activate the virtual environment and simply run the command:
+As it states in the [Style guidelines section](development_guidelines.md) all code is checked to verify all the unit tests pass and that the code passes the linting tools. Local testing is done using Tox, which has been installed as part of running `script/setup` in the [virtual environment](development_environment.md). To start the tests, activate the virtual environment and simply run the command:
 
 ```bash
 $ tox

--- a/docs/development_testing.md
+++ b/docs/development_testing.md
@@ -2,7 +2,7 @@
 title: "Testing your code"
 ---
 
-As states in the [Style guidelines section](development_guidelines.md) all code is checked to verify all unit tests pass and that the code passes the linting tools. Local testing is done using Tox, which has been installed as part of running `script/setup`. To start the tests, simply run it:
+As states in the [Style guidelines section](development_guidelines.md) all code is checked to verify all unit tests pass and that the code passes the linting tools. Local testing is done using Tox, which has been installed as part of running `script/setup` in the [virtual environment](development_environment.md). To start the tests, activate the virtual environment and simply run the command:
 
 ```bash
 $ tox


### PR DESCRIPTION
Being new to python, pip and virtual environments, I tried running `tox` without activating the virtual environment. This should make it a little bit more clear for newcomers.