### PR TITLE
Instruct OSX developers to install autoconf

### DIFF
--- a/docs/development_environment.md
+++ b/docs/development_environment.md
@@ -60,7 +60,7 @@ $ pip install --upgrade setuptools
 Install [Homebrew](https://brew.sh/), then use that to install Python 3:
 
 ```bash
-$ brew install python3
+$ brew install python3 autoconf
 ```
 
 ## Setup Local Repository


### PR DESCRIPTION
When running `tox` on OSX as instructed at https://developers.home-assistant.io/docs/en/development_testing.html an error is received stating `error: [Errno 2] No such file or directory: 'autoconf': 'autoconf'`. 

By installing `autoconf` via `homebrew`, this error goes away, and the `tox` tests pass. Telling OSX developers to install `autoconf` at this point in the development environment setup procedure (rather than calling it out on the testing page) seemed to make sense to me.