### PR TITLE
Type boolean requires documentation default.

### DIFF
--- a/docs/documentation_create_page.md
+++ b/docs/documentation_create_page.md
@@ -89,7 +89,7 @@ required: inclusive       #=> Inclusive
 required: exclusive       #=> Exclusive
 required: any string here #=> Any string here
 ```
-- **`type:`**: The type of the variable. Allowed entries: `boolean`, `string`, `integer`, `float`, `time`, `template`, `device_class`, `icon` or `map`/`list` (for a list of entries). For multiple possibilities use `[string, integer]`. If you use `map`/`list` then you need to define `keys:` (see the [`template` sensor](https://www.home-assistant.io/components/sensor.template/) for an example).
+- **`type:`**: The type of the variable. Allowed entries: `boolean`, `string`, `integer`, `float`, `time`, `template`, `device_class`, `icon` or `map`/`list` (for a list of entries). For multiple possibilities use `[string, integer]`. If you use `map`/`list` then should define `keys:` (see the [`template` sensor](https://www.home-assistant.io/components/sensor.template/) for an example). If you use `boolean`, then `default:` must be defined.
 - **`default:`**: The default value for the variable.
 
 ### Embedding Code


### PR DESCRIPTION
- Adding a boolean type in the configuration variables requires the use of `default:`.
- Added in a small working change to a `map`/`list` to "should define", since some "legacy" components cannot be described that way.


