### PR TITLE
fix misleading style guide

### DIFF
--- a/docs/development_guidelines.md
+++ b/docs/development_guidelines.md
@@ -90,3 +90,11 @@ Prefer [new style string formatting](https://www.python.org/dev/peps/pep-3101/) 
 "{} {}".format('New', 'style')
 "%s %s" % ('Old', 'style')
 ```
+
+Except when doing logging here the format is:
+
+```python
+_LOGGER.exception(
+            "Can't connect to the webservice. %s %s %s",
+            error.code(), error.type(), error.message()
+```


### PR DESCRIPTION
style guide stated to use new format style on strings, but when using logging `pylint` is configured to
enforce `%s` usage for lazy log evaluation.