### PR TITLE
ResinOS is deprecated

### DIFF
--- a/docs/architecture_hassio.md
+++ b/docs/architecture_hassio.md
@@ -15,7 +15,7 @@ This is a daemon running on the host machine that allows the supervisor to contr
 
 ## Host
 
-Our pre-build images are based on [HASSOS] which is based on [BuildRoot]. Any Linux machine can be turned into a Hass.io host by running [the installer][linux].
+Our pre-build images are based on [HassOS] which is based on [BuildRoot]. Any Linux machine can be turned into a Hass.io host by running [the installer][linux].
 
 ## Supervisor
 
@@ -25,6 +25,6 @@ The supervisor offers an API to manage the host and running the Docker container
 
 The configuration panel lives inside the supervisor but is accessible via the Home Assistant user interface. The configuration panel allows the user to manage the installation.
 
-[HASSOS]: https://github.com/home-assistant/hassos
+[HassOS]: https://github.com/home-assistant/hassos
 [BuildRoot]: https://buildroot.org/
 [linux]: https://www.home-assistant.io/hassio/installation/#alternative-install-on-generic-linux-server

--- a/docs/architecture_hassio.md
+++ b/docs/architecture_hassio.md
@@ -15,7 +15,7 @@ This is a daemon running on the host machine that allows the supervisor to contr
 
 ## Host
 
-Our pre-build images are based on [ResinOS]. Any Linux machine can be turned into a Hass.io host by running [the installer][linux].
+Our pre-build images are based on [HASSOS] which is based on [BuildRoot]. Any Linux machine can be turned into a Hass.io host by running [the installer][linux].
 
 ## Supervisor
 
@@ -25,5 +25,6 @@ The supervisor offers an API to manage the host and running the Docker container
 
 The configuration panel lives inside the supervisor but is accessible via the Home Assistant user interface. The configuration panel allows the user to manage the installation.
 
-[ResinOS]: https://resinos.io/
+[HASSOS]: https://github.com/home-assistant/hassos
+[BuildRoot]: https://buildroot.org/
 [linux]: https://www.home-assistant.io/hassio/installation/#alternative-install-on-generic-linux-server


### PR DESCRIPTION
Links to HASSOS and BuildRoot due to ResinOS deprecation within the Hassio project