### PR TITLE
Use single quotes

### DIFF
--- a/docs/development_validation.md
+++ b/docs/development_validation.md
@@ -21,7 +21,7 @@ Some things to keep in mind:
 - Use the constants defined in `const.py`
 - Import `PLATFORM_SCHEMA` from the parent component and extend it
 - Preferred order is `required` first and `optional` second
-- Starting with Home Assistant 0.64 `voluptuous` requires default values for optional configuration keys to be valid values. Don't use a default which is `None` like `vol.Optional(CONF_SOMETHING, default=None): cv.string`, set the default to `default=""` if required.
+- Starting with Home Assistant 0.64 `voluptuous` requires default values for optional configuration keys to be valid values. Don't use a default which is `None` like `vol.Optional(CONF_SOMETHING, default=None): cv.string`, set the default to `default=''` if required.
 
 ### Snippets
 


### PR DESCRIPTION
According to [the styleguide](https://developers.home-assistant.io/docs/en/development_guidelines.html#quotes) we should

> Use single quotes ' for single word and " for multiple words or sentences.

I think an empty string should be handled as a single word,
most of the current code seems to do it like this already.