### PR TITLE
Fixed example for run_coroutine_threadsafe util

### DIFF
--- a/docs/asyncio_working_with_async.md
+++ b/docs/asyncio_working_with_async.md
@@ -78,7 +78,7 @@ from homeassistant.util.async_ import run_coroutine_threadsafe
 
 def say_hello(hass, target):
     return run_coroutine_threadsafe(
-        hass.loop, async_say_hello, target).result()
+        async_say_hello(hass, target), hass.loop).result()
 
 async def async_say_hello(hass, target):
     return "Hello {}!".format(target)


### PR DESCRIPTION
Based on the detailed docs `run_coroutine_threadsafe` have 2 params now: `coro` and `loop`, so the example is kinda wrong I think. Reference: https://dev-docs.home-assistant.io/en/master/api/util.html#homeassistant.util.async_.run_coroutine_threadsafe

I've ran the example code and it seems to work correct, the previous version raised `TypeError('A coroutine object is required')`.

Thanks!