### PR TITLE
Add note about naming events for components

### DIFF
--- a/docs/creating_component_code_review.md
+++ b/docs/creating_component_code_review.md
@@ -49,3 +49,6 @@ status = bridge.status()
 
 ### 5. Limit platforms included in initial pull request
 Large pull requests mean there is a larger chance of finding problems that need to be addressed, and more code that needs to be reviewed between every requested change. If your new component will have multiple platforms, try and limit your initial pull request to a single platform. Once the initial component is merged, you can submit additional PRs for the remaining platforms. This allows reviewers to sign off on smaller chunks of code one at a time, and lets us get your new feature in sooner. Pull requests containing large code dumps will not be a priority for review.
+
+### 6. Event names
+Prefix component event names with component name. For example for `xiaomi_aqara` component use `xiaomi_aqara.click` instead of `click`.

--- a/docs/creating_component_code_review.md
+++ b/docs/creating_component_code_review.md
@@ -51,4 +51,4 @@ status = bridge.status()
 Large pull requests mean there is a larger chance of finding problems that need to be addressed, and more code that needs to be reviewed between every requested change. If your new component will have multiple platforms, try and limit your initial pull request to a single platform. Once the initial component is merged, you can submit additional PRs for the remaining platforms. This allows reviewers to sign off on smaller chunks of code one at a time, and lets us get your new feature in sooner. Pull requests containing large code dumps will not be a priority for review.
 
 ### 6. Event names
-Prefix component event names with component name. For example for `xiaomi_aqara` component use `xiaomi_aqara.click` instead of `click`.
+Prefix component event names with component name itself. For example, use `xiaomi_aqara.click` instead of `click` for the `xiaomi_aqara` component.


### PR DESCRIPTION
Added a note to Creating components code review that reflects actual state of event names

reference: https://github.com/home-assistant/home-assistant/pull/17354#issuecomment-439686613