### PR TITLE
Add shebang to script/server to avoid errors

### DIFF
--- a/script/server
+++ b/script/server
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 set -e
 
 cd "$(dirname "$0")/.."


### PR DESCRIPTION
added #!/bin/sh to script/server

```
Failed to execute process './script/server'. Reason:
exec: Exec format error
The file './script/server' is marked as an executable but could not be run by the operating system.
```