### PR TITLE
Update unit_of_measurement Unit in temperature

### DIFF
--- a/docs/entity_sensor.md
+++ b/docs/entity_sensor.md
@@ -24,6 +24,6 @@ If specifying a device class, your sensor entity will need to also return the co
 | battery | % | % of battery that is left.
 | humidity | % | % of humidity in the air.
 | illuminance | lx/lm | Light level.
-| temperature | C/F | Temperature.
+| temperature | °C/°F | Temperature.
 | timestamp | ISO8601 | Timestamp
 | pressure | hPa,mbar | Pressure.


### PR DESCRIPTION
It reads in Homekit component code that the unit_of_measurement should be °C/°F. This updates the docs to match that. 

ref: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/homekit/type_sensors.py#L52