### PR TITLE
Dependencies: Always link to their documentation

### DIFF
--- a/docs/creating_component_code_review.md
+++ b/docs/creating_component_code_review.md
@@ -16,7 +16,7 @@ A checklist of things to do when you're adding a new component.
 
  1. Requirement version pinned: `REQUIREMENTS = ['phue==0.8.1']`
  2. We no longer want requirements hosted on GitHub. Please upload to PyPi.
- 3. Requirements should only be imported inside functions. This is necessary because requirements are installed on the fly.
+ 3. Requirements should [only be imported inside functions](creating_component_deps_and_reqs.md). This is necessary because requirements are installed on the fly.
 
 ### 2. Configuration
 

--- a/docs/creating_platform_code_review.md
+++ b/docs/creating_platform_code_review.md
@@ -17,7 +17,7 @@ A checklist of things to do when you're adding a new platform.
 
  1. Requirement version should be pinned: `REQUIREMENTS = ['phue==0.8.1']`
  2. We no longer want requirements hosted on GitHub. Please upload to PyPi.
- 3. Requirements should only be imported inside functions. This is necessary because requirements are installed on the fly.
+ 3. Requirements should [only be imported inside functions](creating_component_deps_and_reqs.md). This is necessary because requirements are installed on the fly.
 
 ### 2. Dependencies
 

--- a/docs/development_checklist.md
+++ b/docs/development_checklist.md
@@ -6,7 +6,7 @@ title: "Development Checklist"
 Before you commit any changes, check your work against these requirements:
 
 - All communication to external devices or services must be wrapped in an external Python library hosted on [pypi](https://pypi.python.org/pypi).
-- All dependencies from [pypi](https://pypi.python.org/pypi) are included via the `REQUIREMENTS` variable in your platform or component and only imported inside functions that use them
+- All dependencies from [pypi](https://pypi.python.org/pypi) are included via the `REQUIREMENTS` variable in your platform or component and [only imported inside functions](creating_component_deps_and_reqs.md) that use them
 - New dependencies are added to `requirements_all.txt` (if applicable), using `script/gen_requirements_all.py`
 - The `.coveragerc` file is updated to exclude your platform if there are no tests available or your new code uses a third-party library for communication with the device, service, or sensor
 - Documentation is developed for [home-assistant.io](/)


### PR DESCRIPTION
Adding some links to make the checklists easier to follow.

I was thinking about adding a good/bad example too, but adding those consequently to the checklist might make the lists unwieldy.