### PR TITLE
Update internationalization_custom_component_localization.md

### DIFF
--- a/docs/internationalization_custom_component_localization.md
+++ b/docs/internationalization_custom_component_localization.md
@@ -3,7 +3,7 @@ title: "Custom Component Localization"
 ---
 
 ## Translation Strings
-Unlike localized strings merged in the home-assistant repository, custom components cannot take advantage of Lokalise for user submitted translations. However, custom component authors can still include translation with their components. These will be read from the `.translations` directory, adjacent to the component source file. They are named `<component/platform name>.<language_code>.json`, unless the custom component exists in its own directory, in which case the file is simply named `<language_code>.json` in the `.translations` directory.
+Unlike localized strings merged in the home-assistant repository, custom components cannot take advantage of Lokalise for user submitted translations. However, custom component authors can still include translation with their components. These will be read from the `.translations` directory, adjacent to the component source file. They are named `<component/component name>.<language_code>.json`, unless the custom component exists in its own directory, in which case the file is simply named `<language_code>.json` in the `.translations` directory.
 
 These files follow the same formatting as [backend translation string files](internationalization_backend_localization.md), but a copy will exist for each translated language.
 

--- a/docs/internationalization_custom_component_localization.md
+++ b/docs/internationalization_custom_component_localization.md
@@ -3,7 +3,7 @@ title: "Custom Component Localization"
 ---
 
 ## Translation Strings
-Unlike localized strings merged in the home-assistant repository, custom components cannot take advantage of Lokalise for user submitted translations. However, custom component authors can still include translation with their components. These will be read from the `.translations` directory, adjacent to the component source file. They are named `<component/component name>.<language_code>.json`, unless the custom component exists in its own directory, in which case the file is simply named `<language_code>.json` in the `.translations` directory.
+Unlike localized strings merged in the `home-assistant` repository, custom components cannot take advantage of Lokalise for user submitted translations. However, custom component authors can still include translations with their components. These will be read from the `.translations` directory, adjacent to the component source. They are named `<platform name>.<language_code>.json`, e.g., for the German translation of a sensor `sensor.de.json`, unless the translation is for the custom component only, in which case the file is simply named `<language_code>.json` in the `.translations` directory.
 
 These files follow the same formatting as [backend translation string files](internationalization_backend_localization.md), but a copy will exist for each translated language.
 


### PR DESCRIPTION
After creating a custom sensor implementation and trying to translate the returned states to Dutch, I noticed that Hass is looking for a file called sensor.nl.json instead of platformname.nl.json in the .translations folder.