### PR TITLE
Update to show optional for custom components

### DIFF
--- a/docs/creating_integration_manifest.md
+++ b/docs/creating_integration_manifest.md
@@ -3,7 +3,7 @@ title: "Integration Manifest"
 sidebar_label: "Manifest"
 ---
 
-Since 0.92.0, every integration has a manifest file to specify basic information about an integration. This file is stored as `manifest.json` in your integration directory. It is required to add such a file, including for custom components.
+Since 0.92.0, every integration has a manifest file to specify basic information about an integration. This file is stored as `manifest.json` in your integration directory. It is mandatory requirement for an integration, but optional for custom components.
 
 ```json
 {


### PR DESCRIPTION
This conflicted with https://developers.home-assistant.io/blog/2019/04/12/new-integration-structure.html as this says the manifest.json is an optional file for custom components