### PR TITLE
Document the removal of Python REST API 

### DIFF
--- a/docs/external_api_rest_python.md
+++ b/docs/external_api_rest_python.md
@@ -1,0 +1,7 @@
+---
+title: "REST API - Python bindings"
+---
+
+# This API is deprecated and was removed since Home Assistant 0.77.0
+
+More information can be found in the [blog](../../../blog/2018/08/13/deprecating-remote-package.html).

--- a/docs/external_api_rest_python.md
+++ b/docs/external_api_rest_python.md
@@ -2,6 +2,6 @@
 title: "REST API - Python bindings"
 ---
 
-# This API is deprecated and was removed since Home Assistant 0.77.0
+This API is deprecated and was removed since Home Assistant 0.77.0
 
-More information can be found in the [blog](../../../blog/2018/08/13/deprecating-remote-package.html).
+More information can be found in this [blog post](../../../blog/2018/08/13/deprecating-remote-package.html).

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -261,6 +261,9 @@
         "title": "Weather Entity",
         "sidebar_label": "Weather"
       },
+      "external_api_rest_python": {
+        "title": "REST API - Python bindings"
+      },
       "external_api_rest": {
         "title": "REST API"
       },
@@ -810,6 +813,10 @@
         "title": "Data Entry Flow",
         "sidebar_label": "Introduction"
       },
+      "version-0.77.0/version-0.77.0-external_api_rest_python": {
+        "title": "REST API - Python bindings",
+        "sidebar_label": "REST API - Python bindings"
+      },
       "version-0.77.0/version-0.77.0-frontend_data": {
         "title": "Frontend data",
         "sidebar_label": "Data"
@@ -1334,6 +1341,71 @@
       },
       "version-0.91.2/version-0.91.2-maintenance": {
         "title": "Maintenance"
+      },
+      "version-0.92.0/version-0.92.0-app_integration_setup": {
+        "title": "Connecting to an instance"
+      },
+      "version-0.92.0/version-0.92.0-auth_auth_module": {
+        "title": "Multi-factor Authentication Modules"
+      },
+      "version-0.92.0/version-0.92.0-creating_integration_manifest": {
+        "title": "Integration Manifest",
+        "sidebar_label": "Manifest"
+      },
+      "version-0.92.0/version-0.92.0-creating_platform_index": {
+        "title": "Integration Platforms",
+        "sidebar_label": "Platforms"
+      },
+      "version-0.92.0/version-0.92.0-development_submitting": {
+        "title": "Submit your work"
+      },
+      "version-0.92.0/version-0.92.0-entity_climate": {
+        "title": "Climate Entity",
+        "sidebar_label": "Climate"
+      },
+      "version-0.92.0/version-0.92.0-entity_fan": {
+        "title": "Fan Entity",
+        "sidebar_label": "Fan"
+      },
+      "version-0.92.0/version-0.92.0-entity_media_player": {
+        "title": "Media Player Entity",
+        "sidebar_label": "Media Player"
+      },
+      "version-0.92.0/version-0.92.0-entity_registry_index": {
+        "title": "Entity Registry",
+        "sidebar_label": "Introduction"
+      },
+      "version-0.92.0/version-0.92.0-external_api_websocket": {
+        "title": "WebSocket API"
+      },
+      "version-0.92.0/version-0.92.0-hassio_addon_communication": {
+        "title": "Add-On Communication"
+      },
+      "version-0.92.0/version-0.92.0-hassio_addon_config": {
+        "title": "Add-On Configuration"
+      },
+      "version-0.92.0/version-0.92.0-hassio_addon_index": {
+        "title": "Developing an add-on",
+        "sidebar_label": "Introduction"
+      },
+      "version-0.92.0/version-0.92.0-hassio_addon_presentation": {
+        "title": "Presenting your add-on"
+      },
+      "version-0.92.0/version-0.92.0-hassio_addon_publishing": {
+        "title": "Publishing your add-on"
+      },
+      "version-0.92.0/version-0.92.0-hassio_addon_security": {
+        "title": "Add-on security"
+      },
+      "version-0.92.0/version-0.92.0-hassio_addon_testing": {
+        "title": "Local add-on testing"
+      },
+      "version-0.92.0/version-0.92.0-hassio_debugging": {
+        "title": "Debugging Hass.io"
+      },
+      "version-0.92.0/version-0.92.0-hassio_hass": {
+        "title": "Hass.io <> Home Assistant integration development",
+        "sidebar_label": "HASS Integration development"
       }
     },
     "links": {

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -110,6 +110,7 @@
     ],
     "External API": [
       "external_api_rest",
+      "external_api_rest_python",
       "external_api_websocket",
       "external_api_server_sent_events"
     ],

--- a/website/versioned_sidebars/version-0.77.0-sidebars.json
+++ b/website/versioned_sidebars/version-0.77.0-sidebars.json
@@ -103,6 +103,7 @@
     ],
     "External API": [
       "version-0.77.0-external_api_rest",
+      "version-0.77.0-external_api_rest_python",
       "version-0.77.0-external_api_websocket",
       "version-0.77.0-external_api_server_sent_events"
     ],

--- a/website/versioned_sidebars/version-0.78.0-sidebars.json
+++ b/website/versioned_sidebars/version-0.78.0-sidebars.json
@@ -107,6 +107,7 @@
     ],
     "External API": [
       "version-0.78.0-external_api_rest",
+      "version-0.78.0-external_api_rest_python",
       "version-0.78.0-external_api_websocket",
       "version-0.78.0-external_api_server_sent_events"
     ],

--- a/website/versioned_sidebars/version-0.79.0-sidebars.json
+++ b/website/versioned_sidebars/version-0.79.0-sidebars.json
@@ -110,6 +110,7 @@
     ],
     "External API": [
       "version-0.79.0-external_api_rest",
+      "version-0.79.0-external_api_rest_python",
       "version-0.79.0-external_api_websocket",
       "version-0.79.0-external_api_server_sent_events"
     ],

--- a/website/versioned_sidebars/version-0.80.0-sidebars.json
+++ b/website/versioned_sidebars/version-0.80.0-sidebars.json
@@ -112,6 +112,7 @@
     ],
     "External API": [
       "version-0.80.0-external_api_rest",
+      "version-0.80.0-external_api_rest_python",
       "version-0.80.0-external_api_websocket",
       "version-0.80.0-external_api_server_sent_events"
     ],

--- a/website/versioned_sidebars/version-0.83.0-sidebars.json
+++ b/website/versioned_sidebars/version-0.83.0-sidebars.json
@@ -112,6 +112,7 @@
     ],
     "External API": [
       "version-0.83.0-external_api_rest",
+      "version-0.83.0-external_api_rest_python",
       "version-0.83.0-external_api_websocket",
       "version-0.83.0-external_api_server_sent_events"
     ],

--- a/website/versioned_sidebars/version-0.87.0-sidebars.json
+++ b/website/versioned_sidebars/version-0.87.0-sidebars.json
@@ -116,6 +116,7 @@
     ],
     "External API": [
       "version-0.87.0-external_api_rest",
+      "version-0.87.0-external_api_rest_python",
       "version-0.87.0-external_api_websocket",
       "version-0.87.0-external_api_server_sent_events"
     ],

--- a/website/versioned_sidebars/version-0.89.0-sidebars.json
+++ b/website/versioned_sidebars/version-0.89.0-sidebars.json
@@ -117,6 +117,7 @@
     ],
     "External API": [
       "version-0.89.0-external_api_rest",
+      "version-0.89.0-external_api_rest_python",
       "version-0.89.0-external_api_websocket",
       "version-0.89.0-external_api_server_sent_events"
     ],

--- a/website/versioned_sidebars/version-0.91.2-sidebars.json
+++ b/website/versioned_sidebars/version-0.91.2-sidebars.json
@@ -110,6 +110,7 @@
     ],
     "External API": [
       "version-0.91.2-external_api_rest",
+      "version-0.91.2-external_api_rest_python",
       "version-0.91.2-external_api_websocket",
       "version-0.91.2-external_api_server_sent_events"
     ],


### PR DESCRIPTION
By doing so, we make sure that the documentation reflects the removal of the Python REST API since Home Assistant 0.77.0 .

I rewrote the history (how cool!) so that it correctly reflects the status of the API not only from the next version, but for previous versions down to and including 0.77.0
I am not proficient with Docusaurus. Thanks to crosschecks that:
- There is no cleaner way to link the blog post in `docs/external_api_rest_python.md`
- The modifications of `website/i18n/en.json` makes sense

Signed-off-by: Samuel Progin <samuel.progin@gmail.com>