### PR TITLE
 ✏️ Add note about using the redirect_from

### DIFF
--- a/docs/documentation_create_page.md
+++ b/docs/documentation_create_page.md
@@ -52,7 +52,11 @@ A couple of points to remember:
 
 If you have a component that is taking care of setting up platforms then you don't need to create a new page for every supported platform. Simply add all supported types to `ha_category:` and use `redirect_from:` to list the dummy URL of the platforms.
 
-```text
+<p class='note'>
+Use the `redirect_from` only if you want to redirect urls from existing pages. When you add documentation for a new component / integration, you don't need to add this and can even cause you to not see your page in the netlify builds.
+</p>
+
+```yaml
 ...
 ha_category:
   - DIY

--- a/docs/documentation_create_page.md
+++ b/docs/documentation_create_page.md
@@ -48,27 +48,6 @@ A couple of points to remember:
 - Add screenshots to support the user where it makes sense.
 - Add the type of the device(s) (incl. firmware) you have tested when you know that there are multiple out there.
 
-### Components and platforms
-
-If you have a component that is taking care of setting up platforms then you don't need to create a new page for every supported platform. Simply add all supported types to `ha_category:` and use `redirect_from:` to list the dummy URL of the platforms.
-
-<p class='note'>
-Use the `redirect_from` only if you want to redirect urls from existing pages. When you add documentation for a new component / integration, you don't need to add this and can even cause you to not see your page in the netlify builds.
-</p>
-
-```yaml
-...
-ha_category:
-  - DIY
-  - Binary Sensor
-  - Switch
-redirect_from:
-  - /components/binary_sensor.raspihats/
-  - /components/switch.raspihats/
----
-...
-```
-
 ### Configuration
 
 Every platform page should contain a configuration sample. This sample must contain only the **required** variables to make it easy to copy and paste it for users into their `configuration.yaml` file.


### PR DESCRIPTION
In recent weeks I have noticed that people add the `redirect_from` to the documentation for new integrations / components by **default** and do not really understand why this option exists (I think).

That is why I have now added a note (correct it if it can be improved), to point out to people not to do this by default and also that this can lead to not being able to see your pages in netlify.