### PR TITLE
Rename via_hub to via_device

### DIFF
--- a/docs/device_registry_index.md
+++ b/docs/device_registry_index.md
@@ -12,9 +12,11 @@ The device registry is a registry where Home Assistant keeps track of devices. A
 
 ## What is a device?
 
-A device in Home Assistant represents a physical device that has its own control unit. The control unit itself does not have to be smart, but it should be in control of what happens. For example, an Ecobee thermostat with 4 room sensors equals 5 devices in Home Assistant, one for the thermostat including all sensors inside it, and one for each sensor.
+A device in Home Assistant represents a physical device that has its own control unit. The control unit itself does not have to be smart, but it should be in control of what happens. For example, an Ecobee thermostat with 4 room sensors equals 5 devices in Home Assistant, one for the thermostat including all sensors inside it, and one for each sensor. Each device exists in a specific geographical area, and may have more than one input or output within that area.
 
 If you connect a sensor to another device to read some of its data, it should still be represented as two different devices. The reason for this is that the sensor could be moved to read the data of another device.
+
+A device that offers multiple endpoints, where parts of the device sense or output in different areas, should be split into separate devices and refer back to parent device with the `via_device` attribute. This allows the separate endpoints to be assigned to different areas in the building.
 
 > Although not currently available, we could consider offering an option to users to merge devices.
 
@@ -30,7 +32,7 @@ If you connect a sensor to another device to read some of its data, it should st
 | model | The model of the device.
 | config_entries | Config entries that are linked to this device.
 | sw_version | The firmware version of the device.
-| via_hub | Identifier of a device that routes messages between this device and Home Assistant. Examples of such devices are hubs. This is used to show device topology in Home Assistant.
+| via_device | Identifier of a device that routes messages between this device and Home Assistant. Examples of such devices are hubs, or parent devices of a sub-device. This is used to show device topology in Home Assistant.
 | area_id | The Area which the device is placed in.
 
 ## Defining devices
@@ -54,7 +56,7 @@ class HueLight(LightEntity):
             'manufacturer': self.light.manufacturername,
             'model': self.light.productname,
             'sw_version': self.light.swversion,
-            'via_hub': (hue.DOMAIN, self.api.bridgeid),
+            'via_device': (hue.DOMAIN, self.api.bridgeid),
         }
 
 ```


### PR DESCRIPTION
Documentation to go along with linked PRs / Issues

See also:
* home-assistant/home-assistant#24360
* home-assistant/home-assistant-polymer#3254
* home-assistant/architecture#212