### PR TITLE
Change OS X to macOS

### DIFF
--- a/docs/development_environment.md
+++ b/docs/development_environment.md
@@ -55,7 +55,7 @@ $ mkdir -p ../config
 $ hass -c ../config
 ```
 
-### Developing on OS X
+### Developing on macOS
 
 Install [Homebrew](https://brew.sh/), then use that to install Python 3:
 


### PR DESCRIPTION
Just updating name. It's been called macOS for a little over 3 years now (https://www.wired.com/2016/06/apple-os-x-dead-long-live-macos/).