### PR TITLE
Extra warning about use of SSH add-on

### DIFF
--- a/docs/hassio_debugging.md
+++ b/docs/hassio_debugging.md
@@ -35,6 +35,7 @@ Visual Studio Code config:
 You need set the dev mode on supervisor and enable debug with options. You need also install the Remote debug Add-on from Developer Repository to expose the debug port to Host.
 
 ## SSH access to the host
+> SSH access through the [SSH add-on] (which will give you SSH access through port 22) will not provide you with all the necessary privileges, and you will be asked for a username and password when typing the 'login' command. You need to follow the steps below, which will setup a separate SSH access through port 22222 with all necessary privileges.
 
 ### resinOS based Hass.io (deprecated)
 Create an `authorized_keys` file containing your public key, and place it in the root of the boot partition of your SD card. See [Generating SSH Keys](#generating-ssh-keys) section below if you need help generating keys. Once the device is booted, you can access your device as root over SSH on port 22222. 


### PR DESCRIPTION
I tried to make it clearer that the SSH setup here (port 22222) was different to the SSH add-on setup (port 22) and what issues would crop up if the later was used in this context. 

It took me a while to figure out what was going on and I felt that the doc needed this clarification.