### PR TITLE
Custom components require a manifest.json file when a library or modu…

### DIFF
--- a/docs/creating_integration_manifest.md
+++ b/docs/creating_integration_manifest.md
@@ -3,7 +3,7 @@ title: "Integration Manifest"
 sidebar_label: "Manifest"
 ---
 
-Since 0.92.0, every integration has a manifest file to specify basic information about an integration. This file is stored as `manifest.json` in your integration directory. It is required to add such a file, except for custom components.
+Since 0.92.0, every integration has a manifest file to specify basic information about an integration. This file is stored as `manifest.json` in your integration directory. It is required to add such a file, also for custom components that use libraries or modules that are as a default not available in Home Assistant. When the custom component does not have such REQUIREMENTS, the file can be omitted.
 
 ```json
 {


### PR DESCRIPTION
…le must be installed as REQUIREMENTS.

I was using a custom component that kept giving an error every time I updated HA, since 0.94.0 ( I think, could be since 0.92). The py-file of this custom component contained a REQUIREMENTS-line.
After several tries I finally managed to fix the issue; by moving the REQUIREMENTS-line from the py-file to the manifest. json file and leave the import-line and the calling of the used function in the py-file the same.

This actually makes sense but I was thrown off-course by the statement "except for custom components" which turned out not to be correct.