### PR TITLE
Fix named param typo in device_registry example

### DIFF
--- a/docs/device_registry_index.md
+++ b/docs/device_registry_index.md
@@ -70,7 +70,7 @@ from homeassistant.helpers import device_registry as dr
 device_registry = await dr.async_get_registry(hass)
 
 device_registry.async_get_or_create(
-    config_entry=entry.entry_id,
+    config_entry_id=entry.entry_id,
     connections={
         (dr.CONNECTION_NETWORK_MAC, config.mac)
     },


### PR DESCRIPTION
Param is `config_entry_id`, not `config_entry`

see: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/helpers/device_registry.py#L93