### PR TITLE
Add entity_id to camera_thumbnail

### DIFF
--- a/docs/external_api_websocket.md
+++ b/docs/external_api_websocket.md
@@ -345,7 +345,8 @@ Return a b64 encoded thumbnail of a camera entity.
 ```json
 {
   "id": 19,
-  "type": "camera_thumbnail"
+  "type": "camera_thumbnail",
+  "entity_id": "camera.driveway"
 }
 ```
 


### PR DESCRIPTION
It is required. Documentation: https://github.com/home-assistant/home-assistant/blob/4f8a93fb3e1cf61decc05a8e55fa254298168915/homeassistant/components/camera/__init__.py#L92