### PR TITLE
Update development_environment.md

### DIFF
--- a/docs/development_environment.md
+++ b/docs/development_environment.md
@@ -17,7 +17,7 @@ $ sudo apt-get install python3-pip python3-dev python3-venv
 In order to run `script/setup` below you will need some more dependencies.
 
 ```bash
-$ sudo apt-get install autoconf libssl-dev libxml2-dev libxslt1-dev libjpeg-dev libffi-dev libudev-dev zlib1g-dev
+$ sudo apt-get install autoconf libssl-dev libxml2-dev libxslt1-dev libjpeg-dev libffi-dev libudev-dev zlib1g-dev pkg-config
 $ sudo apt-get install -y libavformat-dev libavcodec-dev libavdevice-dev libavutil-dev libswscale-dev libavresample-dev libavfilter-dev
 ```
 


### PR DESCRIPTION
Add pkg-config to list of package dependencies to install.

Using Debian Buster I followed the [documentation](https://developers.home-assistant.io/docs/en/development_environment.html) to prepare my development environment, including installing the core and additional dependencies. When it came time to run `tox` for testing, the installation of the module requirements failed. I tracked it down to the `pkg-config` binary being missing. I installed the package and modules installed and the tests could run.