### PR TITLE
Update dead link in state tutorial

### DIFF
--- a/docs/dev_101_states.md
+++ b/docs/dev_101_states.md
@@ -21,7 +21,7 @@ To get started, create the file `<config dir>/custom_components/hello_state.py` 
 Support for showing text in the frontend.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/cookbook/python_component_basic_state/
+https://developers.home-assistant.io/docs/en/dev_101_states.html
 """
 import logging
 


### PR DESCRIPTION
Link provided 404s, replace with more useful link.