### PR TITLE
Clarify project location in WSL

### DIFF
--- a/docs/development_environment.md
+++ b/docs/development_environment.md
@@ -101,6 +101,8 @@ Running tasks like `Preview` can be restarted by opening the command pallet and 
 Visit the [Home Assistant repository](https://github.com/home-assistant/home-assistant) and click **Fork**.
 Once forked, setup your local copy of the source using the commands:
 
+_Windows users should be sure to clone to a path that inside the WSL (ex: ~/)._
+
 ```bash
 $ git clone https://github.com/YOUR_GIT_USERNAME/home-assistant.git
 $ cd home-assistant


### PR DESCRIPTION
`script/setup` will fail due to a path permissions issue if you do not clone the project to a location within the WSL filesytem.