### PR TITLE
Update Frontend development documentation

### DIFF
--- a/docs/hassio_hass.md
+++ b/docs/hassio_hass.md
@@ -14,16 +14,16 @@ To develop for the frontend, we're going to need API access to the supervisor.
 - Add our developer Add-on repository: https://github.com/home-assistant/hassio-addons-development
 - Install the Add-on "Remote API proxy"
 
-For some API commands you need explicit the Home Assistant API token, but 99% of the functionality work with `Remote API proxy`. This token change some times but you can read the current legal token on host system with:
+For some API commands you need explicit the Home Assistant API token, but 99% of the functionality work with `Remote API proxy`. This token change sometimes but you can read the current legal token on host system with:
 ```sh
 $ docker inspect homeassistant | grep HASSIO_TOKEN
 ```
 
  ## Having Home Assistant connect to remote Hass.io
 
- The connection with the supervisor is hidden inside the host and is only accessible from applications running on the host. So to make it accessible for our Home Assistant instance, we will need to route the connection to our computer running Home Assistant. We're going to do this by forwarding the API with "Remote API proxy" Add-on.
+ The connection with the supervisor is hidden inside the host and is only accessible from applications running on the host. So to make it accessible for our Home Assistant instance we will need to route the connection to our computer running Home Assistant. We're going to do this by forwarding the API with "Remote API proxy" add-on.
 
-First, make sure Home Assistant will load the Hass.io component by adding `hassio:` to your `configuration.yaml` file. Next, we will need to tell Hass.io component how to connect to the remote Hass.io instance, we do this by setting the `HASSIO` and `HASSIO_TOKEN` environment variables when starting Home Assistant. Note that the `HASSIO` value is not the same as the one that we saw above and the `HASSIO_TOKEN` is available inside log output of "Remote API Add-on" (This change every restart of this Add-on!).
+First, make sure Home Assistant will load the Hass.io component by adding `hassio:` to your `configuration.yaml` file. Next, we will need to tell the local Home Assistant instance how to connect to the remote Hass.io instance. We do this by setting the `HASSIO` and `HASSIO_TOKEN` environment variables when starting Home Assistant. Note that the `HASSIO` value is not the same as the one that we saw above and the `HASSIO_TOKEN` is available inside log output of "Remote API Add-on" (This changes every restart of the add-on!).
 
 ```bash
 HASSIO=<IP OF HASS.IO>:80 HASSIO_TOKEN=<VALUE OF HASSIO_TOKEN> hass
@@ -41,17 +41,17 @@ Update the Hass.io component configuration in your `configuration.yaml` to point
 
 ```yaml
 # configuration.yaml
-hassio:
+frontend:
   development_repo: /home/paulus/dev/hass/home-assistant-polymer
 ```
 
 To build a local version of the Hass.io panel, go to the frontend repository and run:
 
 ```bash
-cd hassio
-script/build_hassio
+script/bootstrap
+script/develop
 ```
 
 Now start Home Assistant as discussed in the previous section and it will now connect to the remote Hass.io but show your local frontend.
 
-We're currently transitioning in how we're building the frontend so we don't have an incremental development mode just yet. For now, after making a local change, run `script/build_hassio` again.
+Once you have `script/develop` the frontend will be rebuilt whenever you make changes to the source files.  See [frontend development](frontend_development.html#development) for more information.

--- a/docs/hassio_hass.md
+++ b/docs/hassio_hass.md
@@ -41,17 +41,17 @@ Update the Hass.io component configuration in your `configuration.yaml` to point
 
 ```yaml
 # configuration.yaml
-frontend:
+hassio:
   development_repo: /home/paulus/dev/hass/home-assistant-polymer
 ```
 
 To build a local version of the Hass.io panel, go to the frontend repository and run:
 
 ```bash
-script/bootstrap
+cd hassio
 script/develop
 ```
 
 Now start Home Assistant as discussed in the previous section and it will now connect to the remote Hass.io but show your local frontend.
 
-Once you have `script/develop` the frontend will be rebuilt whenever you make changes to the source files.  See [frontend development](frontend_development.html#development) for more information.
+Once you have `script/develop` the hassio panel will be rebuilt whenever you make changes to the source files.


### PR DESCRIPTION
I was going through this while trying to get the front end set up to work on another PR and noticed it was out of date and had trouble getting everything working.  I'm updating it to hopefully better reflect what I had to do to get it working and update the latter portion as it seems like manually building every time a change is made is no longer necessary.  Also updated the configuration.yaml example as the docs here https://developers.home-assistant.io/docs/en/frontend_development.html#configuring-home-assistant say to set up frontend.development_repo not hassio.development_repo.  

Hopefully this is correct but let me know if I'm completely misunderstanding this document as I'm pretty new to getting everything set up for local development. :)