### PR TITLE
Update documentation_create_page.md with more clear note html example

### DIFF
--- a/docs/documentation_create_page.md
+++ b/docs/documentation_create_page.md
@@ -112,7 +112,9 @@ Please note, if you want to use Markdown inside an HTML block, it has to be surr
 
 ```html
 <div class='note warning'>
+  
   You need to enable [**telnet**](https://en.wikipedia.org/wiki/Telnet) on your router.
+  
 </div>
 ```
 


### PR DESCRIPTION
Make the need for newlines more clear in the [example about note html section](https://developers.home-assistant.io/docs/en/documentation_create_page.html#html). 