### PR TITLE
Tiny renaming fix

### DIFF
--- a/docs/lovelace_custom_card.md
+++ b/docs/lovelace_custom_card.md
@@ -234,7 +234,7 @@ If an element does not exist in MWC, we default to using Paper Elements.
 - [Paper Elements](https://www.webcomponents.org/collection/PolymerElements/paper-elements)
 
 ## Advanced Resources
-Community Maintained Boiler Plate Card - Advanced Template (Typescript, Rollup, Linting, etc.)
+Community Maintained Boilerplate Card - Advanced Template (Typescript, Rollup, Linting, etc.)
 - [Boilerplate Card](https://github.com/custom-cards/boilerplate-card)
 
 Developer Documentation for [HACS](https://hacs.netlify.com/) (Home Assitant Community Store).


### PR DESCRIPTION
Correcting "Boiler Plate Card" to "Boilerplate Card"