### PR TITLE
Added docs link for "Has a code owner"

### DIFF
--- a/docs/integration_quality_scale_index.md
+++ b/docs/integration_quality_scale_index.md
@@ -38,7 +38,7 @@ This is a solid integration that is able to survive poor conditions and can be c
 - Entities have device info (if available) ([docs](device_registry_index.md#defining-devices))
 - States are translated in the frontend (text-based sensors only, [docs](internationalization_index.md))
 - Tests for reading data from/controlling the integration ([docs](development_testing.md))
-- Has a code owner
+- Has a code owner ([docs](creating_integration_manifest.md#code-owners))
 
 # Platinum 🏆
 


### PR DESCRIPTION
Added documentation link for "Has a code owner" in the Gold "Integration Quality Scale" standard.