### PR TITLE
Document increase of node heap size to prevent crashes

### DIFF
--- a/docs/frontend_development.md
+++ b/docs/frontend_development.md
@@ -57,6 +57,23 @@ $ nvm use
 $ script/develop
 ```
 
+The first build will take around a minute on a recent machine.
+
+If the development server crashes this may be due to a limit on the amount of
+memory the node process may use. If you get the following error message, you can
+increase the amount of memory that Node can use by setting an environment
+variable:
+```bash
+$ ./script/develop
+...
+FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
+...
+# Solve by running with larger heap size
+$ NODE_OPTIONS="--max-old-space-size=4096" ./script/develop
+```
+
+### Browser settings
+
 Make sure you have cache disabled and correct settings to avoid stale content:
 
 > Instructions are for Google Chrome


### PR DESCRIPTION
While building the frontend Node crashes due to being out of heap
space (on Fedora 30). I did not want to increase this for all users
by overriding _all_ their `NODE_OPTIONS` in `./script/server` so I decided
to document this.

Build runs out of memory with both v10.16.3 (system) as v12.1.0 (.nvmrc)

Proof:
![Screenshot from 2019-10-17 15-36-11](https://user-images.githubusercontent.com/199058/67015479-e2405a00-f0f6-11e9-80d9-b63bf636a6ff.png)
