### PR TITLE
Add instructions to install python-wheel-common

### DIFF
--- a/docs/development_environment.md
+++ b/docs/development_environment.md
@@ -11,7 +11,7 @@ You'll need to set up a development environment if you want to develop a new fea
 Install the core dependencies.
 
 ```bash
-$ sudo apt-get install python3-pip python3-dev python3-venv
+$ sudo apt-get install python3-pip python3-dev python3-venv python-wheel-common
 ```
 
 In order to run `script/setup` below you will need some more dependencies.


### PR DESCRIPTION
Following these instructions failed during `script/setup` unless I first installed python-wheel-common. The package provides the `bdist_wheel` command.

OS: Ubuntu Linux 19.04.