### PR TITLE
Corrected error in revoke token callback

### DIFF
--- a/docs/frontend_external_auth.md
+++ b/docs/frontend_external_auth.md
@@ -47,11 +47,11 @@ When the user presses the logout button on the profile page, the external app wi
 
 ```js
 window.externalApp.revokeExternalAuth({
-  callback: 'externalAuthSetToken'
+  callback: 'externalAuthRevokeToken'
 });
 // or
 window.webkit.messageHandlers.revokeExternalAuth.postMessage({
-  callback: 'externalAuthSetToken'
+  callback: 'externalAuthRevokeToken'
 });
 ```
 


### PR DESCRIPTION
Under the 'Revoke Token' Section the callbacks should be:

```javascript
window.externalApp.revokeExternalAuth({
  callback: 'externalAuthRevokeToken'
});
```
and
```javascript
window.webkit.messageHandlers.revokeExternalAuth.postMessage({
  callback: 'externalAuthRevokeToken'
});
```