### PR TITLE
Update hassio_addon_communication.md

### DIFF
--- a/docs/hassio_addon_communication.md
+++ b/docs/hassio_addon_communication.md
@@ -15,9 +15,9 @@ Use `hassio` for communication with the internal API.
 
 ## Home Assistant
 
-An add-on can talk to the [Home Assistant API][hass-api] using the internal proxy. This makes it very easy to communicate with the API without knowing the password, port or any other information about the Home Assistant instance. Using this URL: `http://hassio/homeassistant/api` ensures that internal communication is redirected to the right place. The next step is to add `homeassistant_api: true` to the `config.json` file and read the environment variable `HASSIO_TOKEN`. Use this as the Home-Assistant password.
+An add-on can talk to the [Home Assistant API][hass-api] using the internal proxy. This makes it very easy to communicate with the API without knowing the password, port or any other information about the Home Assistant instance. Using this URL: `http://hassio/homeassistant/api` ensures that internal communication is redirected to the right place. The next step is to add `homeassistant_api: true` to the `config.json` file and use [Home Assistant Authentication](https://developers.home-assistant.io/docs/en/auth_api.html) to authenticate the request. 
 
-There is also a proxy for the [Home Assistant Websocket API][hass-websocket] that works like the API proxy above and requires `HASSIO_TOKEN` as the password. Use this URL: `http://hassio/homeassistant/websocket`.
+There is also a proxy for the [Home Assistant Websocket API][hass-websocket] that works like the API proxy above and can also use [Home Assistant Authentication](https://developers.home-assistant.io/docs/en/auth_api.html) to authenticate the request. Use this URL: `http://hassio/homeassistant/websocket`.
 
 It is also possible to talk directly to the Home Assistant instance, which is named `homeassistant`, over the internal network. However, you'll need to know the configuration that is used by the running instance.
 


### PR DESCRIPTION
The `homeassistant_api` flag in hass.io add-ons doesn't authenticate to homeassistant (or at least, not anymore), it only allows access to the  /homeassistant/api URI, however the docs still very explicitly state otherwise.