### PR TITLE
Change example from notify.notify to notify.YOUR_NOTIFICATION_COMPONENT

### DIFF
--- a/docs/documentation_standards.md
+++ b/docs/documentation_standards.md
@@ -88,7 +88,7 @@ Use single quotes (`'`) for strings inside of a template. It is more obvious to 
 automation:
   ...
   action:
-    - service: notify.notify
+    - service: notify.YOUR_NOTIFICATION_COMPONENT
       data_template:
         message: "{% if trigger.to_state.name == 'Dale\'s Bedroom' %}Someone's in your base, killing your noobs!{% else %}It's just another door.{% endif %}"
 ```
@@ -99,7 +99,7 @@ automation:
 automation:
   ...
   action:
-    - service: notify.notify
+    - service: notify.YOUR_NOTIFICATION_COMPONENT
       data_template:
         message: '{% if trigger.to_state.name == "Dale's Bedroom" %}Someone's in your base, killing your noobs!{% else %}It's just another door.{% endif %}'
 ```
@@ -110,7 +110,7 @@ automation:
 automation:
   ...
   action:
-    - service: notify.notify
+    - service: notify.YOUR_NOTIFICATION_COMPONENT
       data_template:
         message: >-
           {% if trigger.to_state.name == 'Dale\'s Bedroom' %}


### PR DESCRIPTION
This might be more of a discussion, therefor marking it as "WIP".

The standard for docs sates:

> Use capital letters and `_` to indicate that the value needs to be replaced. E.g., `api_key: YOUR_API_KEY` or `api_key: REPLACE_ME`.

And then continues with an example that uses `service: notify.notify` which is misleading in my opinion since most service names have fixed names (for example `media_player.media_play`) but `notify.notify` is not.  Following the above rule I would like to suggest to change the example to:

```
service: notify.YOUR_NOTIFICATION_COMPONENT
```