### PR TITLE
Add method to return 'hass' object from browser console to docs

### DIFF
--- a/docs/frontend_data.md
+++ b/docs/frontend_data.md
@@ -11,11 +11,13 @@ Whenever a state changes, a new version of the objects that changed are created.
 const changed = newVal !== oldVal;
 ```
 
-In order to see the data available in the `hass` object, run the following command in your browser's developer tools console when on your HomeAssistant frontend (this should *NOT* be used in production code and is only useful as a potential initial step to understand what properties are available in the `hass` object):
+In order to see the data available in the `hass` object, visit your HomeAssistant frontend in your favorite browser and open the browser's developer tools. On the elements panel, select the `<home-assistant>` element, or any other element that has the `hass` property, and then run the following command in the console panel:
 
 ```js
 $0.hass
 ```
+
+This method of reading the `hass` object should only be used as a reference. In order to interact with `hass` in your code, make sure it is passed to your code correctly.
 
 ## Data
 

--- a/docs/frontend_data.md
+++ b/docs/frontend_data.md
@@ -11,6 +11,12 @@ Whenever a state changes, a new version of the objects that changed are created.
 const changed = newVal !== oldVal;
 ```
 
+In order to see the data contained in the `hass` object, run the following command in your browser's developer tools console when on your HomeAssistant frontend:
+
+```js
+document.querySelector("home-assistant").hass
+```
+
 ## Data
 
 ### `hass.states`

--- a/docs/frontend_data.md
+++ b/docs/frontend_data.md
@@ -11,10 +11,10 @@ Whenever a state changes, a new version of the objects that changed are created.
 const changed = newVal !== oldVal;
 ```
 
-In order to see the data available in the `hass` object, run the following command in your browser's developer tools console when on your HomeAssistant frontend:
+In order to see the data available in the `hass` object, run the following command in your browser's developer tools console when on your HomeAssistant frontend (this should *NOT* be used in production code and is only useful as a potential initial step to understand what properties are available in the `hass` object):
 
 ```js
-document.querySelector("home-assistant").hass
+$0.hass
 ```
 
 ## Data

--- a/docs/frontend_data.md
+++ b/docs/frontend_data.md
@@ -11,7 +11,7 @@ Whenever a state changes, a new version of the objects that changed are created.
 const changed = newVal !== oldVal;
 ```
 
-In order to see the data contained in the `hass` object, run the following command in your browser's developer tools console when on your HomeAssistant frontend:
+In order to see the data available in the `hass` object, run the following command in your browser's developer tools console when on your HomeAssistant frontend:
 
 ```js
 document.querySelector("home-assistant").hass


### PR DESCRIPTION
While trying to learn about how the frontend works, I was looking for a way to see what data was available in `hass` in the frontend, but I could not find a simple way to access it in the docs. I searched #devs_frontend in Discord and found this call suggested by @balloob (and originally @thomasloven). Thought it would be a good idea to add it to the docs for future devs