### PR TITLE
Update Developement Environment Docs for Windows

### DIFF
--- a/docs/development_environment.md
+++ b/docs/development_environment.md
@@ -41,7 +41,7 @@ When the Linux subsystem is set up, perform install as for Linux.
 
 ```bash
 $ sudo apt-get update
-$ sudo apt-get install python3-pip python3-dev python3-venv
+$ sudo apt-get install python3-pip python3.7-dev python3.7-venv python-wheel-common
 $ sudo apt-get install autoconf libssl-dev libxml2-dev libxslt1-dev libjpeg-dev libffi-dev libudev-dev zlib1g-dev
 $ sudo apt-get install -y libavformat-dev libavcodec-dev libavdevice-dev libavutil-dev libswscale-dev libavresample-dev libavfilter-dev
 ```
@@ -114,7 +114,7 @@ $ git remote add upstream https://github.com/home-assistant/home-assistant.git
 To isolate your environment from the rest of the system, set up a [`venv`](https://docs.python.org/3/library/venv.html). Within the `home-assistant` directory, create and activate your virtual environment.
 
 ```bash
-$ python3 -m venv venv
+$ python3.7 -m venv venv
 $ source venv/bin/activate
 ```
 


### PR DESCRIPTION
I was following the instructions, but they don't work at all for Windows.  Issues fixed:
* The old command would use python3.6, but home assistant requires 3.7
* Picks up the change in https://github.com/home-assistant/developers.home-assistant/pull/335 for the Windows section.
* Explicitly use 3.7 when setting up the venv, since on some systems `python3` points to 3.6, not 3.7