### PR TITLE
Be consistent with Home Assistant spelling

### DIFF
--- a/docs/frontend_development.md
+++ b/docs/frontend_development.md
@@ -93,7 +93,7 @@ $ git push -u fork HEAD
 
 If you're making changes to the way the frontend is packaged, it might be necessary to try out a new packaged build of the frontend in the main repository (instead of pointing it at the frontend repo). To do so, first build a production version of the frontend by running `script/build_frontend`.
 
-To test it out inside Home assistant, run the following command from the main Home Assistant repository:
+To test it out inside Home Assistant, run the following command from the main Home Assistant repository:
 
 ```bash
 $ pip3 install -e /path/to/home-assistant-polymer/

--- a/docs/hassio_hass.md
+++ b/docs/hassio_hass.md
@@ -1,6 +1,6 @@
 ---
 title: "Hass.io <> Home Assistant integration development"
-sidebar_label: "HASS Integration development"
+sidebar_label: "Integration development"
 ---
 
 These steps will help you connect your local Home Assistant to a remote Hass.io instance. You can then make changes locally to either the Hass.io component or the frontend and test it out against a real instance.

--- a/docs/lovelace_custom_card.md
+++ b/docs/lovelace_custom_card.md
@@ -84,7 +84,7 @@ customElements.define('content-card-example', ContentCardExample);
 
 ## Referencing your new card
 
-In our example card we defined a card with the tag `content-card-example` (see last line), so our card type will be `custom:content-card-example`. And because you created the file in your `<config>/www` directory, it will be accessible in your browser via the url `/local/` (if you have recently added the www folder you will need to re-start home assistant for files to be picked up).
+In our example card we defined a card with the tag `content-card-example` (see last line), so our card type will be `custom:content-card-example`. And because you created the file in your `<config>/www` directory, it will be accessible in your browser via the url `/local/` (if you have recently added the www folder you will need to re-start Home Assistant for files to be picked up).
 
 ```yaml
 # Example Lovelace configuration

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -373,7 +373,7 @@
       },
       "hassio_hass": {
         "title": "Hass.io <> Home Assistant integration development",
-        "sidebar_label": "HASS Integration development"
+        "sidebar_label": "Integration development"
       },
       "integration_quality_scale_index": {
         "title": "Integration Quality Scale"

--- a/website/i18n/no-NO.json
+++ b/website/i18n/no-NO.json
@@ -340,7 +340,7 @@
       },
       "hassio_hass": {
         "title": "Hass.io <> Home Assistant integration development",
-        "sidebar_label": "HASS Integration development"
+        "sidebar_label": "Integration development"
       },
       "integration_quality_scale_index": {
         "title": "Integration Quality Scale",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -53,7 +53,7 @@
     ],
     "Custom UI": ["lovelace_custom_card", "frontend_creating_custom_panels"]
   },
-  "Extending HASS": {
+  "Extending Home Assistant": {
     "Development Workflow": [
       "development_index",
       "development_environment",

--- a/website/translated_docs/no-NO/frontend_development.md
+++ b/website/translated_docs/no-NO/frontend_development.md
@@ -95,7 +95,7 @@ $ git push -u fork HEAD
 
 If you're making changes to the way the frontend is packaged, it might be necessary to try out a new packaged build of the frontend in the main repository (instead of pointing it at the frontend repo). To do so, first build a production version of the frontend by running `script/build_frontend`.
 
-To test it out inside Home assistant, run the following command from the main Home Assistant repository:
+To test it out inside Home Assistant, run the following command from the main Home Assistant repository:
 
 ```bash
 $ pip3 install -e /path/to/home-assistant-polymer/

--- a/website/translated_docs/no-NO/hassio_hass.md
+++ b/website/translated_docs/no-NO/hassio_hass.md
@@ -1,6 +1,6 @@
 ---
 title: "Hass.io <> Home Assistant integration development"
-sidebar_label: "HASS Integration development"
+sidebar_label: "Integration development"
 ---
 
 These steps will help you connect your local Home Assistant to a remote Hass.io instance. You can then make changes locally to either the Hass.io component or the frontend and test it out against a real instance.

--- a/website/translated_docs/no-NO/lovelace_custom_card.md
+++ b/website/translated_docs/no-NO/lovelace_custom_card.md
@@ -84,7 +84,7 @@ customElements.define('content-card-example', ContentCardExample);
 
 ## Referencing your new card
 
-In our example card we defined a card with the tag `content-card-example` (see last line), so our card type will be `custom:content-card-example`. And because you created the file in your `<config>/www` directory, it will be accessible in your browser via the url `/local/` (if you have recently added the www folder you will need to re-start home assistant for files to be picked up).
+In our example card we defined a card with the tag `content-card-example` (see last line), so our card type will be `custom:content-card-example`. And because you created the file in your `<config>/www` directory, it will be accessible in your browser via the url `/local/` (if you have recently added the www folder you will need to re-start Home Assistant for files to be picked up).
 
 ```yaml
 # Example Lovelace configuration


### PR DESCRIPTION
Otherwise trivial, but removed HASS altogether from Hass.io integration development sidebar entry, "Home Assistant" there would make the entry probably too wide, and I think it's not required.