### PR TITLE
Add language specific guidelines

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -47,3 +47,13 @@ Region specific translations (`en-US`, `fr-CA`) will only be included if transla
 2. Add the language tag and native name in `src/translations/translationMetadata.json`.  Examples: "Français", "Français (CA)"
 3. Add the new language in Lokalize.
 Note: Sometimes you have to change the tag in Lokalise (Language -> Language settings -> custom ISO code).
+
+## Language specific guidelines
+Most languages have multiple possibilities of translating a sentence. Please take a look at the guidelines for your language here, where you can also find some typical mistakes to prevent.
+The sections are written in their corresponding languages, as this makes explaining the grammar easier and only native speakers should submit translations (see [Rules](#rules)).
+
+### German
+- Du/Sie: Dutze in den Übersetzungen, und verwende nicht das formale "Sie".
+
+#### Typische Fehler
+- Achte auf den richtigen Imperativ. Der Imperativ ist die Befehlsform, z. B. "Gib mir das Wasser". Falsch wäre hier: "Gebe mir das Wasser" (siehe (Bildung des Imperativs)[https://www.duden.de/sprachwissen/sprachratgeber/Bildung-des-Imperativs]).

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -56,4 +56,4 @@ The sections are written in their corresponding languages, as this makes explain
 - Du/Sie: Dutze in den Übersetzungen, und verwende nicht das formale "Sie".
 
 #### Typische Fehler
-- Achte auf den richtigen Imperativ. Der Imperativ ist die Befehlsform, z. B. "Gib mir das Wasser". Falsch wäre hier: "Gebe mir das Wasser" (siehe (Bildung des Imperativs)[https://www.duden.de/sprachwissen/sprachratgeber/Bildung-des-Imperativs]).
+- Achte auf den richtigen Imperativ. Der Imperativ ist die Befehlsform, z. B. "Gib mir das Wasser". Falsch wäre hier: "Gebe mir das Wasser" (siehe [Bildung des Imperativs](https://www.duden.de/sprachwissen/sprachratgeber/Bildung-des-Imperativs)).

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -49,7 +49,7 @@ Region specific translations (`en-US`, `fr-CA`) will only be included if transla
 Note: Sometimes you have to change the tag in Lokalise (Language -> Language settings -> custom ISO code).
 
 ## Language specific guidelines
-Most languages have multiple possibilities of translating a sentence. Please take a look at the guidelines for your language here, where you can also find some typical mistakes to prevent.
+Most languages have multiple possible translations of a sentence. Please take a look at the guidelines for your language here, where you can also find some typical mistakes to prevent.
 The sections are written in their corresponding languages, as this makes explaining the grammar easier and only native speakers should submit translations (see [Rules](#rules)).
 
 ### German


### PR DESCRIPTION
Adds language specific guidelines to the developer documentation and set up some guidelines like the formal/informal addressing in German.

As discussed in https://github.com/home-assistant/architecture/issues/346.

I used the "Du-Form" for the German guidelines, but this can be discussed. @fabaff contributed many translations using the "Sie-Form", though I think the "Du-Form" would be more appropiate for us.