### PR TITLE
[documentation] fix typo in sending a delayed response example

### DIFF
--- a/docs/frontend_add_websocket_api.md
+++ b/docs/frontend_add_websocket_api.md
@@ -105,7 +105,7 @@ def websocket_handle_thumbnail(hass, connection, msg):
         )
 
     # Player exist. Queue up a job to send the thumbnail.
-    hass.async_add_job(send_image())
+    hass.async_add_job(send_image)
 ```
 
 ### Registering with the Websocket API


### PR DESCRIPTION
Hi,

Calling `hass.async_add_job(send_image())` will be synchronous  cause it first execute it (instead of just queueing it)

More over `async_add_job` is expecting Callable target, so it's definitely a typo. 