### PR TITLE
Add local build folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Production
 /build
+/website
 
 # Generated files
 .docusaurus


### PR DESCRIPTION
When running a local server, the `/website` folder is created, containing the static files.

However, this folder is not excluded in the `.gitignore` file, which made my vscode just crash on the git extension.

This PR adds the folder to `.gitignore`, since we should not commit it anyway.