### PR TITLE
'type: js' updated to 'type: module' (deprecation)

### DIFF
--- a/docs/lovelace_custom_card.md
+++ b/docs/lovelace_custom_card.md
@@ -90,7 +90,7 @@ In our example card we defined a card with the tag `content-card-example` (see l
 # Example Lovelace configuration
 resources:
   - url: /local/content-card-example.js
-    type: js
+    type: module
 views:
 - name: Example
   cards:


### PR DESCRIPTION
HACS is also proposing `module` and it has come to my attention that 'js' should go...