### PR TITLE
Re-enable RSS/Atom feed for the blog

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -73,6 +73,9 @@ module.exports = {
         },
         blog: {
           postsPerPage: 10,
+          feedOptions: {
+            type: 'all',
+          },
         },
       },
     ],


### PR DESCRIPTION
These feeds used to be available, but recently disappeared - possibly due to the move to docusaurus 2. This re-enables their generation ([see docs](https://v2.docusaurus.io/docs/blog/#feed)).