### PR TITLE
Update Linux core Python Dependency List

### DIFF
--- a/docs/development_environment.md
+++ b/docs/development_environment.md
@@ -11,7 +11,7 @@ You'll need to set up a development environment if you want to develop a new fea
 Install the core dependencies.
 
 ```shell
-$ sudo apt-get install python3-pip python3-dev python3-venv
+$ sudo apt-get install python3-pip python3.7-dev python3.7-venv
 ```
 
 In order to run `script/setup` below you will need some more dependencies.


### PR DESCRIPTION
As with Windows Ubuntu, normal Ubuntu/Linux also needs the Python version specifically called out to get the correct version for ./setup to succeed.