### PR TITLE
Add typing to style guidelines

### DIFF
--- a/docs/development_guidelines.md
+++ b/docs/development_guidelines.md
@@ -67,3 +67,7 @@ One exception is for logging which uses the percentage formatting. This is to av
 ```python
 _LOGGER.info("Can't connect to the webservice %s at %s", string1, string2)
 ```
+
+### Typing of functions
+
+Either completely type a function or do not type a function at all.


### PR DESCRIPTION
Adds notation about the preferred way of typing out functions, see https://github.com/home-assistant/core/pull/32255#discussion_r385644660

CC @MartinHjelmare 