### PR TITLE
Update translation example

### DIFF
--- a/docs/config_entries_config_flow_handler.md
+++ b/docs/config_entries_config_flow_handler.md
@@ -112,8 +112,8 @@ Translations for the config flow handlers are defined under the `config` key in 
 
 ```json
 {
+  "title": "Philips Hue Bridge",
   "config": {
-    "title": "Philips Hue Bridge",
     "step": {
       "init": {
         "title": "Pick Hue bridge",


### PR DESCRIPTION
Just updating the translation example by moving the `"title"` field outside of `"config"` so It matches the latest changes in the translations validator.