### PR TITLE
Clarify configuration section

### DIFF
--- a/docs/documentation_standards.md
+++ b/docs/documentation_standards.md
@@ -16,6 +16,7 @@ To ensure that the documentation for Home Assistant is consistent and easy to fo
 ## Integration and Platform Pages
 
 * The **Configuration Variables** section must use the `{% configuration %}` tag.
+* The **Configuration Variables** section is only used for YAML configuration.
 * Configuration variables must document the requirement status (`false` or `true`).
 * Configuration variables must document the default value, if any.
 * Configuration variables must document the accepted value types (see [Configuration variables details](documentation_create_page.md#configuration)).


### PR DESCRIPTION
According to this [comment](https://github.com/home-assistant/home-assistant.io/pull/13005#pullrequestreview-395308177), the configuration section is only for YAML configuration.  This isn't currently stated in the docs.

As a comment, there is no explanation on the preferred documentation style for config flows.  It would be helpful to have a set of standards here for consistencyn across the documentation.