### PR TITLE
Update Docker requirements

### DIFF
--- a/docs/development_environment.md
+++ b/docs/development_environment.md
@@ -13,7 +13,7 @@ The easiest way to get started with development is to use Visual Studio Code wit
 - [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - Docker
   -  For Linux, macOS, or Windows 10 Pro/Enterprise/Education use the [current release version of Docker](https://docs.docker.com/install/)
-  -   Windows 10 Home requires [WSL 2](https://docs.microsoft.com/windows/wsl/wsl2-install) and the current Edge version of Docker Desktop (see instructions [here](https://docs.docker.com/docker-for-windows/wsl-tech-preview/)). This can also be used for other Windows Pro/Enterprise/Education.
+  -   Windows 10 Home requires [WSL 2](https://docs.microsoft.com/windows/wsl/wsl2-install) and the current Edge version of Docker Desktop (see instructions [here](https://docs.docker.com/docker-for-windows/wsl-tech-preview/)). This can also be used for Windows Pro/Enterprise/Education.
 - [Visual Studio code](https://code.visualstudio.com/)
 - [Remote - Containers (VSC Extension)][extension-link]
 

--- a/docs/development_environment.md
+++ b/docs/development_environment.md
@@ -4,14 +4,15 @@ title: "Set up Development Environment"
 
 You'll need to set up a development environment if you want to develop a new feature or component for Home Assistant. Read on to learn how to set up.
 
-# Developing with Visual Studio Code + devcontainer
+## Developing with Visual Studio Code + devcontainer
 
 The easiest way to get started with development is to use Visual Studio Code with devcontainers. This approach will create a preconfigured development environment with all the tools you need. This approach is enabled for all Home Assistant repositories.
 
 **Prerequisites**
 
 - [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-- [Docker](https://docs.docker.com/install/) (Windows only: requires Windows Pro)
+- [Docker](https://docs.docker.com/install/)
+  - Windows 10 Home requires [WSL 2](https://docs.microsoft.com/windows/wsl/wsl2-install) and the current Edge version of Docker Desktop (see instructions [here](https://docs.docker.com/docker-for-windows/wsl-tech-preview/))
 - [Visual Studio code](https://code.visualstudio.com/)
 - [Remote - Containers (VSC Extension)][extension-link]
 
@@ -29,13 +30,13 @@ When you open this repository with Visual Studio code you are asked to "Reopen i
 
 _If you don't see this notification, open the command palette and select `Remote-Containers: Reopen Folder in Container`._
 
-## Tasks
+### Tasks
 
 The devcontainter comes with some useful tasks to help you with development, you can start these tasks by opening the command palette and select `Tasks: Run Task` then select the task you want to run.
 
 When a task is currently running (like `Preview` for the docs), it can be restarted by opening the command palette and selecting `Tasks: Restart Running Task`, then select the task you want to restart.
 
-# Preparing your environment
+## Preparing Your environment
 
 It is also possible to set up a more traditional development environment. See the section for your operating system.
 
@@ -119,7 +120,7 @@ $ git remote add upstream https://github.com/home-assistant/core.git
 
 Note that `core.git` should be replaced by the name of your fork (default being `core.git`). If unsure check your GitHub repository.
 
-## Setting up virtual environment
+## Setting Up Virtual Environment
 
 To isolate your environment from the rest of the system, set up a [`venv`](https://docs.python.org/3/library/venv.html). Within the `core` directory, create and activate your virtual environment.
 

--- a/docs/development_environment.md
+++ b/docs/development_environment.md
@@ -11,8 +11,9 @@ The easiest way to get started with development is to use Visual Studio Code wit
 **Prerequisites**
 
 - [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-- [Docker](https://docs.docker.com/install/)
-  - Windows 10 Home requires [WSL 2](https://docs.microsoft.com/windows/wsl/wsl2-install) and the current Edge version of Docker Desktop (see instructions [here](https://docs.docker.com/docker-for-windows/wsl-tech-preview/))
+- Docker
+  -  For Linux, macOS, or Windows 10 Pro/Enterprise/Education use the [current release version of Docker](https://docs.docker.com/install/)
+  -   Windows 10 Home requires [WSL 2](https://docs.microsoft.com/windows/wsl/wsl2-install) and the current Edge version of Docker Desktop (see instructions [here](https://docs.docker.com/docker-for-windows/wsl-tech-preview/)). This can also be used for other Windows Pro/Enterprise/Education.
 - [Visual Studio code](https://code.visualstudio.com/)
 - [Remote - Containers (VSC Extension)][extension-link]
 


### PR DESCRIPTION
With the Windows 10 20H1 going to the Release Preview, WSL 2 is now available in a stable form. WSL 2 is supported by edge builds of Docker Desktop and so we can use devcontainers on WIndows 10 Home 🎉

Little tweak to the instructions to cover this case. When 20H1 goes to release (May?) WSL 2 should probably be the recommended method for all levels of Windows.

Also, a minor tweak to the heading levels as Docusaurus assumes `#` are Page headings and doesn't put them in the TOC on the right. 

Also also, a minor correction to capitalisation of headings for consistency
