### PR TITLE
Update "Supervisor Architecture" URL on "Debugging the Home Assistant

### DIFF
--- a/docs/operating-system/debugging.md
+++ b/docs/operating-system/debugging.md
@@ -35,7 +35,7 @@ You will initially be logged in to Home Assistant CLI for HassOS where you can p
 
 [CLI functions]: https://www.home-assistant.io/hassio/commandline/
 [Home Assistant OS]: https://github.com/home-assistant/hassos
-[Supervisor Architecture]: https://developers.home-assistant.io/docs/en/architecture_hassio.html
+[Supervisor Architecture]: https://developers.home-assistant.io/docs/architecture_index/
 
 ## Checking the logs
 


### PR DESCRIPTION
Update "Supervisor Architecture" URL on ["Debugging the Home Assistant Operating System" page](https://developers.home-assistant.io/docs/operating-system/debugging/). The old URL pointed to a 404 and this new link seems to be the proper replacement.