### PR TITLE
Update the "website documentation" URL on the "Development Checklist"…

### DIFF
--- a/docs/development_checklist.md
+++ b/docs/development_checklist.md
@@ -11,4 +11,4 @@ Before you commit any changes, check your work against these requirements:
 - The `.coveragerc` file is updated to exclude your platform if there are no tests available or your new code uses a third-party library for communication with the device, service, or sensor
 - The code is formatted using Black, as per these [guidelines](https://developers.home-assistant.io/blog/2019/07/31/black.html). This can be done running the command `black --fast homeassistant`.
 - Documentation is developed for [home-assistant.io](https://home-assistant.io/)
-  - Visit the [website documentation](https://www.home-assistant.io/developers/documentation/) for more information about contributing to [home-assistant.io](https://github.com/home-assistant/home-assistant.io).
+  - Visit the [website documentation](/docs/documenting.html) for more information about contributing to [home-assistant.io](https://github.com/home-assistant/home-assistant.io).


### PR DESCRIPTION
Update the "website documentation" URL on the ["Development Checklist" page](https://developers.home-assistant.io/docs/development_checklist/). The old URL pointed to a 404 and this new link seems to be the proper replacement.