### PR TITLE
Update Authentication Provider URL on the "Multi-factor Authenticatio…

### DIFF
--- a/docs/auth_auth_module.md
+++ b/docs/auth_auth_module.md
@@ -2,7 +2,7 @@
 title: "Multi-factor Authentication Modules"
 ---
 
-Multi-factor Authentication Modules are used in conjunction with [Authentication Provider](auth_auth_provider.html) to provide a fully configurable authentication framework. Each MFA module may provide one multi-factor authentication function. User can enable multiple mfa modules, but can only select one module in login process.
+Multi-factor Authentication Modules are used in conjunction with [Authentication Provider](/docs/auth_auth_provider/) to provide a fully configurable authentication framework. Each MFA module may provide one multi-factor authentication function. User can enable multiple mfa modules, but can only select one module in login process.
 
 ## Defining an mfa auth module
 


### PR DESCRIPTION
Update Authentication Provider URL on the ["Multi-factor Authentication Modules" page](https://developers.home-assistant.io/docs/auth_auth_module/). The old URL pointed to a 404 and this new link seems to be the proper replacement.