### PR TITLE
Fix authentication message URL on Authentication API page

### DIFF
--- a/docs/auth_api.md
+++ b/docs/auth_api.md
@@ -179,7 +179,7 @@ Additionally, a long-lived access token can be created using the UI tool located
 
 Once you have an access token, you can make authenticated requests to the Home Assistant APIs.
 
-For the websocket connection, pass the access token in the [authentication message](https://developers.home-assistant.io/docs/en/external_api_websocket.html#authentication-phase).
+For the websocket connection, pass the access token in the [authentication message](/docs/api/websocket/#authentication-phase).
 
 For HTTP requests, pass the token type and access token as the authorization header:
 


### PR DESCRIPTION
Fix authentication message URL on [Authentication API page](https://developers.home-assistant.io/docs/auth_api/). The old URL pointed to a 404 and this new link seems to be the proper replacement.