### PR TITLE
Update the create page URL on the standards page

### DIFF
--- a/docs/documenting/standards.md
+++ b/docs/documenting/standards.md
@@ -66,7 +66,7 @@ some_key:
 
 ## Renaming Pages
 
-It can happen that an integration or platform is renamed, in this case the documentation needs to be updated as well. If you rename a page, add  `redirect_from:` to the file header and let it point to the old location/name of the page. Please consider to add details, like release number or old integration/platform name, to the page in a [note](/developers/documentation/create_page/#html).
+It can happen that an integration or platform is renamed, in this case the documentation needs to be updated as well. If you rename a page, add  `redirect_from:` to the file header and let it point to the old location/name of the page. Please consider to add details, like release number or old integration/platform name, to the page in a [note](/docs/documenting/create-page/#html).
 
 ```text
 ---


### PR DESCRIPTION
Update the create page URL on the [standards page](https://developers.home-assistant.io/docs/documenting/standards/). The old URL pointed to a 404 and this new link seems to be the proper replacement.