### PR TITLE
Update Lokalise key referencing URL on translation page

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -26,7 +26,7 @@ Some translation strings will contain special placeholders that will be replaced
 3. Don't translate or change proper nouns like `Home Assistant`, `Hass.io` or `Hue`.
 4. For a region specific translation, keys that will be the same as the base translation should be filled with `[VOID]`. These will be replaced during our translation build process.
 5. Translations under the `state_badge` keys will be used for the notification badge display. These translations should be short enough to fit in the badge label without overflowing. This can be tested in the Home Assistant UI either by editing the label text with your browsers development tools, or by using the States tab of developer tools in the Home Assistant UI. In the UI, enter a new entity ID (`device_tracker.test`), and enter the text you want to test in state.
-6. If text will be duplicated across different translation keys, make use of the Lokalise key reference feature where possible. The base translation provides examples of this underneath the `states` translations. Please see the [Lokalise key referencing](https://docs.lokalise.com/en/articles/1400528-key-referencing) documentation for more details.
+6. If text will be duplicated across different translation keys, make use of the Lokalise key reference feature where possible. The base translation provides examples of this underneath the `states` translations. Please see the [Lokalise key referencing](https://docs.lokalise.com/articles/1400528-key-referencing) documentation for more details.
 
 ## Adding a new language
 


### PR DESCRIPTION
Update Lokalise key referencing URL on [translation page](https://developers.home-assistant.io/docs/translations/). The old URL pointed to a 404 and this new link seems to be the proper replacement.