### PR TITLE
Update Python Requests Docs URL on REST API page

### DIFF
--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -22,7 +22,7 @@ curl -X GET \
   http://IP_ADDRESS:8123/ENDPOINT
 ```
 
-Another option is to use Python and the [Requests](http://docs.python-requests.org/en/latest/) module.
+Another option is to use Python and the [Requests](https://requests.readthedocs.io/en/master/) module.
 
 ```python
 from requests import get


### PR DESCRIPTION
Update Python Requests Docs URL on [REST API page](https://developers.home-assistant.io/docs/api/rest/). The old URL pointed to a 404 and this new link seems to be the proper replacement.