### PR TITLE
Propose to add `tag/write` to frontend external bus

### DIFF
--- a/docs/frontend/external-bus.md
+++ b/docs/frontend/external-bus.md
@@ -163,7 +163,7 @@ Payload structure:
 Available in: Home Assistant 0.115
 Type: `tag/write`
 Direction: frontend to external app
-Expect answer: no
+Expect answer: yes
 
 Tell the external app to open the UI to write to a tag. Name is the name of the tag as entered by the user. The name is `null` if no name has been set.
 
@@ -172,4 +172,10 @@ Tell the external app to open the UI to write to a tag. Name is the name of the 
   tag: string;
   name: string | null;
 }
+```
+
+Expected response payload is an empty object for now. We might add more later:
+
+```ts
+{}
 ```

--- a/docs/frontend/external-bus.md
+++ b/docs/frontend/external-bus.md
@@ -100,10 +100,12 @@ Expected response payload:
 ```ts
 {
   hasSettingsScreen: boolean;
+  canWriteTag: boolean;
 }
 ```
 
 - `hasSettingsScreen` set to true if the external app will show a configuration screen when it receives the command `config_screen/show`. If so, a new option will be added to the sidebar to trigger the configuration screen.
+- `canWriteTag` set to true if the external app is able to write tags and so can support the `tag/write` command.
 
 ### Show Config Screen `config_screen/show`
 
@@ -153,5 +155,21 @@ Payload structure:
     | "heavy"
     | "selection";
 
+}
+```
+
+### Write Tag `tag/write`
+
+Available in: Home Assistant 0.115
+Type: `tag/write`
+Direction: frontend to external app
+Expect answer: no
+
+Tell the external app to open the UI to write to a tag. Name is the name of the tag as entered by the user. The name is `null` if no name has been set.
+
+```ts
+{
+  tag: string;
+  name: string | null;
 }
 ```


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Propose to add a new external bus feature to allow frontend to trigger writing tags in the app.

CC @zacwest for iOS
CC @bramkragten for frontend
CC @JBassett for Android

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
