### PR TITLE
Improve water heater

### DIFF
--- a/.idea/developers.home-assistant.iml
+++ b/.idea/developers.home-assistant.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/developers.home-assistant.iml
+++ b/.idea/developers.home-assistant.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="PYTHON_MODULE" version="4">
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/docs/core/entity/water-heater.md
+++ b/docs/core/entity/water-heater.md
@@ -17,7 +17,7 @@ Properties should always only return information from memory and not do I/O (lik
 | `target_temperature`  | `float`     | `None`    | The temperature we are trying to reach.
 | `target_temperature_high` | `float` | `None`    | Upper bound of the temperature we are trying to reach.
 | `target_temperature_low` | `float`  | `None`    | Lower bound of the temperature we are trying to reach.
-| `temperature_unit`    | `str`       | System default | One of `"°C"`, `"°F"`, or `"°K"`.
+| `temperature_unit`    | `str`       | System default | One of `TEMP_CELSIUS`, `TEMP_FAHRENHEIT`, or `TEMP_KELVIN`.
 | `operation_mode`      | `string`    | `None`    | The current operation mode.
 | `operation_list`      | `List[str]` | `None`    | List of possible operation modes.
 | `supported_features`  | `List[str]` | `None`    | List of supported features.

--- a/docs/core/entity/water-heater.md
+++ b/docs/core/entity/water-heater.md
@@ -9,18 +9,21 @@ sidebar_label: Water Heater
 Properties should always only return information from memory and not do I/O (like network requests). Implement `update()` or `async_update()` to fetch data.
 :::
 
-| Name | Type | Default | Description
-| ---- | ---- | ------- | -----------
-| min_temp | float | 110°F | The minimum temperature that can be set.
-| max_temp | float | 140°F | The maximum temperature that can be set.
-| temperature | float | none | The current temperature in °C or °F.
-| operation_mode | string | none | The current operation mode.
-| operation_list | list | none | List of possible operation modes.
-| away_mode | string | none | The current status of away mode. (on, off)
+| Name                | Type      | Default | Description
+| ------------------- | --------- | ------- | -----------
+| min_temp            | float     | 110°F   | The minimum temperature that can be set.
+| max_temp            | float     | 140°F   | The maximum temperature that can be set.
+| current_temperature | float     | None    | The current temperature.
+| target_temperature  | float     | None    | The temperature we are trying to reach.
+| temperature_unit    | str       | None    | One of `"°C"`, `"°F"`, or `"°C or °K"`.
+| operation_mode      | string    | None    | The current operation mode.
+| operation_list      | List[str] | None    | List of possible operation modes.
+| supported_features  | List[str] | None    | List of supported features.
+| is_away_mode_on     | bool      | None    | The current status of away mode.
 
-The allowed operation modes are specified in the base component and implementations of the water_heater component cannot differ.
+The allowed operation modes are the states specified in the base component and implementations of the water_heater component cannot differ.
 
-Properties have to follow the units defined in the `unit_system`.
+Properties have to follow the units defined in the `temperature_unit`.
 
 ## States
 
@@ -33,6 +36,14 @@ Properties have to follow the units defined in the `unit_system`.
 | `STATE_HEAT_PUMP` | Slowest to heat, but uses less energy.
 | `STATE_GAS` | Gas only mode, uses the most energy.
 | `STATE_OFF` | The water heater is off.
+
+## Supported Features
+
+| Feature                      | Description
+| ---------------------------- | -----------
+| `SUPPORT_TARGET_TEMPERATURE` | Temperature can be set
+| `SUPPORT_OPERATION_MODE`     | Operation mode can be set
+| `SUPPORT_AWAY_MODE`          | Away mode can be set
 
 ## Methods
 

--- a/docs/core/entity/water-heater.md
+++ b/docs/core/entity/water-heater.md
@@ -21,7 +21,7 @@ Properties should always only return information from memory and not do I/O (lik
 | `current_operation`   | `string`    | `None`    | The current operation mode.
 | `operation_list`      | `List[str]` | `None`    | List of possible operation modes.
 | `supported_features`  | `List[str]` | `NotImplementedError` | List of supported features.
-| `is_away_mode_on`     | `bool`      | `NotImplementedError` | The current status of away mode.
+| `is_away_mode_on`     | `bool`      | `None`    | The current status of away mode.
 
 The allowed operation modes are the states specified in the base component and implementations of the water_heater component cannot differ.
 

--- a/docs/core/entity/water-heater.md
+++ b/docs/core/entity/water-heater.md
@@ -9,17 +9,19 @@ sidebar_label: Water Heater
 Properties should always only return information from memory and not do I/O (like network requests). Implement `update()` or `async_update()` to fetch data.
 :::
 
-| Name                | Type      | Default | Description
-| ------------------- | --------- | ------- | -----------
-| min_temp            | float     | 110°F   | The minimum temperature that can be set.
-| max_temp            | float     | 140°F   | The maximum temperature that can be set.
-| current_temperature | float     | None    | The current temperature.
-| target_temperature  | float     | None    | The temperature we are trying to reach.
-| temperature_unit    | str       | None    | One of `"°C"`, `"°F"`, or `"°C or °K"`.
-| operation_mode      | string    | None    | The current operation mode.
-| operation_list      | List[str] | None    | List of possible operation modes.
-| supported_features  | List[str] | None    | List of supported features.
-| is_away_mode_on     | bool      | None    | The current status of away mode.
+| Name                  | Type        | Default   | Description
+| --------------------- | ----------- | --------- | -----------
+| `min_temp`            | `float`     | 110°F     | The minimum temperature that can be set.
+| `max_temp`            | `float`     | 140°F     | The maximum temperature that can be set.
+| `current_temperature` | `float`     | `None`    | The current temperature.
+| `target_temperature`  | `float`     | `None`    | The temperature we are trying to reach.
+| `target_temperature_high` | `float` | `None`    | Upper bound of the temperature we are trying to reach.
+| `target_temperature_low` | `float`  | `None`    | Lowergit  bound of the temperature we are trying to reach.
+| `temperature_unit`    | `str`       | System default | One of `"°C"`, `"°F"`, or `"°C or °K"`.
+| `operation_mode`      | `string`    | `None`    | The current operation mode.
+| `operation_list`      | `List[str]` | `None`    | List of possible operation modes.
+| `supported_features`  | `List[str]` | `None`    | List of supported features.
+| `is_away_mode_on`     | `bool`      | `None`    | The current status of away mode.
 
 The allowed operation modes are the states specified in the base component and implementations of the water_heater component cannot differ.
 

--- a/docs/core/entity/water-heater.md
+++ b/docs/core/entity/water-heater.md
@@ -16,7 +16,7 @@ Properties should always only return information from memory and not do I/O (lik
 | `current_temperature` | `float`     | `None`    | The current temperature.
 | `target_temperature`  | `float`     | `None`    | The temperature we are trying to reach.
 | `target_temperature_high` | `float` | `None`    | Upper bound of the temperature we are trying to reach.
-| `target_temperature_low` | `float`  | `None`    | Lowergit  bound of the temperature we are trying to reach.
+| `target_temperature_low` | `float`  | `None`    | Lower bound of the temperature we are trying to reach.
 | `temperature_unit`    | `str`       | System default | One of `"°C"`, `"°F"`, or `"°C or °K"`.
 | `operation_mode`      | `string`    | `None`    | The current operation mode.
 | `operation_list`      | `List[str]` | `None`    | List of possible operation modes.

--- a/docs/core/entity/water-heater.md
+++ b/docs/core/entity/water-heater.md
@@ -17,11 +17,11 @@ Properties should always only return information from memory and not do I/O (lik
 | `target_temperature`  | `float`     | `None`    | The temperature we are trying to reach.
 | `target_temperature_high` | `float` | `None`    | Upper bound of the temperature we are trying to reach.
 | `target_temperature_low` | `float`  | `None`    | Lower bound of the temperature we are trying to reach.
-| `temperature_unit`    | `str`       | System default | One of `TEMP_CELSIUS`, `TEMP_FAHRENHEIT`, or `TEMP_KELVIN`.
+| `temperature_unit`    | `str`       | `NotImplementedError` | One of `TEMP_CELSIUS`, `TEMP_FAHRENHEIT`, or `TEMP_KELVIN`.
 | `operation_mode`      | `string`    | `None`    | The current operation mode.
 | `operation_list`      | `List[str]` | `None`    | List of possible operation modes.
 | `supported_features`  | `List[str]` | `None`    | List of supported features.
-| `is_away_mode_on`     | `bool`      | `None`    | The current status of away mode.
+| `is_away_mode_on`     | `bool`      | `NotImplementedError` | The current status of away mode.
 
 The allowed operation modes are the states specified in the base component and implementations of the water_heater component cannot differ.
 

--- a/docs/core/entity/water-heater.md
+++ b/docs/core/entity/water-heater.md
@@ -20,7 +20,7 @@ Properties should always only return information from memory and not do I/O (lik
 | `temperature_unit`    | `str`       | `NotImplementedError` | One of `TEMP_CELSIUS`, `TEMP_FAHRENHEIT`, or `TEMP_KELVIN`.
 | `current_operation`   | `string`    | `None`    | The current operation mode.
 | `operation_list`      | `List[str]` | `None`    | List of possible operation modes.
-| `supported_features`  | `List[str]` | `None`    | List of supported features.
+| `supported_features`  | `List[str]` | `NotImplementedError` | List of supported features.
 | `is_away_mode_on`     | `bool`      | `NotImplementedError` | The current status of away mode.
 
 The allowed operation modes are the states specified in the base component and implementations of the water_heater component cannot differ.

--- a/docs/core/entity/water-heater.md
+++ b/docs/core/entity/water-heater.md
@@ -17,7 +17,7 @@ Properties should always only return information from memory and not do I/O (lik
 | `target_temperature`  | `float`     | `None`    | The temperature we are trying to reach.
 | `target_temperature_high` | `float` | `None`    | Upper bound of the temperature we are trying to reach.
 | `target_temperature_low` | `float`  | `None`    | Lower bound of the temperature we are trying to reach.
-| `temperature_unit`    | `str`       | System default | One of `"°C"`, `"°F"`, or `"°C or °K"`.
+| `temperature_unit`    | `str`       | System default | One of `"°C"`, `"°F"`, or `"°K"`.
 | `operation_mode`      | `string`    | `None`    | The current operation mode.
 | `operation_list`      | `List[str]` | `None`    | List of possible operation modes.
 | `supported_features`  | `List[str]` | `None`    | List of supported features.

--- a/docs/core/entity/water-heater.md
+++ b/docs/core/entity/water-heater.md
@@ -18,7 +18,7 @@ Properties should always only return information from memory and not do I/O (lik
 | `target_temperature_high` | `float` | `None`    | Upper bound of the temperature we are trying to reach.
 | `target_temperature_low` | `float`  | `None`    | Lower bound of the temperature we are trying to reach.
 | `temperature_unit`    | `str`       | `NotImplementedError` | One of `TEMP_CELSIUS`, `TEMP_FAHRENHEIT`, or `TEMP_KELVIN`.
-| `operation_mode`      | `string`    | `None`    | The current operation mode.
+| `current_operation`   | `string`    | `None`    | The current operation mode.
 | `operation_list`      | `List[str]` | `None`    | List of possible operation modes.
 | `supported_features`  | `List[str]` | `None`    | List of supported features.
 | `is_away_mode_on`     | `bool`      | `NotImplementedError` | The current status of away mode.


### PR DESCRIPTION
## Proposed change

The documentation for the [Water Heater Entity](https://developers.home-assistant.io/docs/core/entity/water-heater/) differs significantly from what is actually implemented in [`WaterHeaterEntity`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/water_heater/__init__.py#L131).  This should bring them more into alignment.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

* Fix `temperature`  => `current_temperature` ([Code](https://github.com/home-assistant/core/blob/dev/homeassistant/components/water_heater/__init__.py#L222))
* Fix `away_mode` => `is_away_mode_on` and correct return type ([Code](https://github.com/home-assistant/core/blob/dev/homeassistant/components/water_heater/__init__.py#L242))
* Put backticks around, e.g., `str` and `None`
* Add missing properties:
  * [`target_temperature`, `target_temperature_high`, and `target_temperature_low`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/water_heater/__init__.py#L227)
  * [`temperature_unit`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/water_heater/__init__.py#L207)
  * [`supported_features`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/water_heater/__init__.py#L280)
* Document [supported features](https://github.com/home-assistant/core/blob/dev/homeassistant/components/water_heater/__init__.py#L51)


Other corrections

- This PR fixes or closes issue: Related to https://github.com/home-assistant/developers.home-assistant/issues/208
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/blob/dev/homeassistant/components/water_heater/__init__.py#L131
