### PR TITLE
Tweak "Long-Lived Access Tokens" documentation

### DIFF
--- a/docs/auth_api.md
+++ b/docs/auth_api.md
@@ -148,9 +148,9 @@ The request will always respond with an empty body and HTTP status 200, regardle
 
 ## Long-lived access token
 
-A long-lived access token is usually used for 3rd party API calls and webhook-ish integrations. To generate a long-lived access token, an active websocket connection has to be established.
+Long-lived access tokens are valid for 10 years. These are useful for integrating with third-party APIs and webhook-style integrations. Long-lived access tokens can be created using the **"Long-Lived Access Tokens"** section at the bottom of a user's Home Assistant profile page.
 
-Send websocket command `auth/long_lived_access_token` will create a long-lived access token for current user. Access token will not be saved in Home Assistant. User need to record the token in secure place.
+You can also generate a long-lived access token using the websocket command `auth/long_lived_access_token`, which will create a long-lived access token for current user. The access token string is not saved in Home Assistant; you must record it in a secure place.
 
 ```json
 {
@@ -162,7 +162,7 @@ Send websocket command `auth/long_lived_access_token` will create a long-lived a
 }
 ```
 
-Result will be a long-lived access token:
+The response includes a long-lived access token:
 
 ```json
 {
@@ -172,8 +172,6 @@ Result will be a long-lived access token:
     "result": "ABCDEFGH"
 }
 ```
-
-Additionally, a long-lived access token can be created using the UI tool located at the bottom of the user's Home Assistant profile page.
 
 ## Making authenticated requests
 


### PR DESCRIPTION
It's much easier to grab a long-lived access token via the web frontend, so mention that *first*.

It appears that the previous ordering was just an artifact of the fact that web frontend support was added later than websocket support. See #151.

## Proposed change

Mention the easy way to get a long-lived access token *first*; mention the hard way second.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
