### PR TITLE
Remove battery related attributes description

### DIFF
--- a/docs/core/entity.md
+++ b/docs/core/entity.md
@@ -104,7 +104,7 @@ Properties should always only return information from memory and not do I/O (lik
 | assumed_state           | boolean | `False` | Return `True` if the state is based on our assumption instead of reading it from the device.                                                                                                                                                                 |
 | available               | boolean | `True`  | Indicate if Home Assistant is able to read the state and control the underlying device.                                                                                                                                                                      |
 | device_class            | string  | `None`  | Extra classification of what the device is. Each domain specifies their own. Device classes can come with extra requirements for unit of measurement and supported features.                                                                                 |
-| device_state_attributes | dict    | `None`  | Extra information to store in the state machine. It needs to be information that further explains the state, it should not be static information like firmware version. See [below](core/entity.md#standard-attributes) for details of standard attributes. |
+| device_state_attributes | dict    | `None`  | Extra information to store in the state machine. It needs to be information that further explains the state, it should not be static information like firmware version. |
 | entity_picture          | URL     | `None`  | Url of a picture to show for the entity.                                                                                                                                                                                                                     |
 | name                    | string  | `None`  | Name of the entity                                                                                                                                                                                                                                           |
 | should_poll             | boolean | `True`  | Should Home Assistant check with the entity for an updated state. If set to `False`, entity will need to notify Home Assistant of new updates by calling one of the [schedule update methods](#methods).                                                     |
@@ -127,15 +127,6 @@ The following properties are used and controlled by Home Assistant, and should n
 | Name    | Type    | Default | Description                                                                                                                                                                              |
 | ------- | ------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | enabled | boolean | `True`  | Indicate if entity is enabled in the entity registry. It also returns `True` if the platform doesn't support the entity registry. Disabled entities will not be added to Home Assistant. |
-
-## Standard attributes
-
-The following `device_state_attributes` are considered standard and should follow the convention below. The constant should be imported from `homeassistant/const.py`.
-
-| Name             | Type    | Unit | Constant                | Description                                                                                                                                           |
-| ---------------- | ------- | ---- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| battery_charging | boolean | N/A  | `ATTR_BATTERY_CHARGING` | Battery charging status of the entity, shown as a boolean `true` or `false`. If charging is not supported, then this attribute should not be created. |
-| battery_level    | integer | %    | `ATTR_BATTERY_LEVEL`    | Battery level of the entity, shown as an integer percentage between 0-100.                                                                            |
 
 ## Lifecycle hooks
 


### PR DESCRIPTION
The battery must be now a sensor, not an attribute.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Following [this](https://github.com/home-assistant/core/pull/43895/files#r543557187) comment, battery state must be now a sensor entity. So related attributes description must be removed. 


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [x] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
