### PR TITLE
Add "context" to result of websocket calls where applicable

### DIFF
--- a/docs/api/websocket.md
+++ b/docs/api/websocket.md
@@ -93,15 +93,20 @@ If the data is incorrect, the server will reply with `auth_invalid` message and 
 
 ## Command phase
 
-During this phase the client can give commands to the server. The server will respond to each command with a `result` message indicating when the command is done and if it was successful.
+During this phase the client can give commands to the server. The server will respond to each command with a `result` message indicating when the command is done and if it was successful along with the context of the command.
 
 ```json
 {
   "id": 6,
   "type": "result",
   "success": true,
-  // Can contain extra result info
-  "result": null
+  "result": {
+    "context": {
+      "id": "326ef27d19415c60c492fe330945f954",
+      "parent_id": null,
+      "user_id": "31ddb597e03147118cf8d2f8fbea5553"
+    }
+  }
 }
 ```
 
@@ -158,7 +163,12 @@ For each event that matches, the server will send a message of type `event`. The
                "white_value":200,
                "friendly_name":"Bed Light"
             },
-            "last_updated":"2016-11-26T01:37:24.265390+00:00"
+            "last_updated":"2016-11-26T01:37:24.265390+00:00",
+            "context": {
+               "id": "326ef27d19415c60c492fe330945f954",
+               "parent_id": null,
+               "user_id": "31ddb597e03147118cf8d2f8fbea5553"
+            }
          },
          "old_state":{
             "entity_id":"light.bed_light",
@@ -168,12 +178,22 @@ For each event that matches, the server will send a message of type `event`. The
                "supported_features":147,
                "friendly_name":"Bed Light"
             },
-            "last_updated":"2016-11-26T01:37:10.466994+00:00"
+            "last_updated":"2016-11-26T01:37:10.466994+00:00",
+            "context": {
+               "id": "e4af5b117137425e97658041a0538441",
+               "parent_id": null,
+               "user_id": "31ddb597e03147118cf8d2f8fbea5553"
+            }
          }
       },
       "event_type":"state_changed",
       "time_fired":"2016-11-26T01:37:24.265429+00:00",
-      "origin":"LOCAL"
+      "origin":"LOCAL",
+      "context": {
+         "id": "326ef27d19415c60c492fe330945f954",
+         "parent_id": null,
+         "user_id": "31ddb597e03147118cf8d2f8fbea5553"
+      }
    }
 }
 ```


### PR DESCRIPTION
Add context to the example outputs.  Brings documentation inline with actual output from these commands.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Adding context to the results of call_service and event websocket results.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/44458