### PR TITLE
Set a default for add-on options and schema config

### DIFF
--- a/docs/add-ons/configuration.md
+++ b/docs/add-ons/configuration.md
@@ -146,8 +146,8 @@ The configuration for an add-on is stored in `config.json`.
 | kernel_modules | bool | no | Map host kernel modules and config into add-on (readonly).
 | stdin | bool | no | Boolean. If enabled, you can use the STDIN with Home Assistant API.
 | legacy | bool | no | Boolean. If the Docker image has no `hass.io` labels, you can enable the legacy mode to use the config data.
-| options | dict | yes | Default options value of the add-on.
-| schema | dict | yes | Schema for options value of the add-on. It can be `false` to disable schema validation and use custom options.
+| options | dict | no | Default options value of the add-on.
+| schema | dict | no | Schema for options value of the add-on. It can be `false` to disable schema validation and use custom options.
 | image | string | no | For use with Docker Hub and other container registries.
 | timeout | integer | no | Default 10 (seconds). The timeout to wait until the Docker daemon is done or will be killed.
 | tmpfs | string | no | Mount a tmpfs filesystem in `/tmpfs`. Valid format for this option is : `size=XXXu,uid=N,rw`. Size is mandatory, valid units (`u`) are `k`, `m`, `g` and `XXX` has to be replaced by a number. `uid=N` (with `N` the uid number) and `rw` are optional.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

It is always nice if an add-on doesn't need any options (and thus might not have a schema).

This PR adds a default empty dictionaries to the `schema` and `options` configuration parameters of an add-on configuration, mainly for cleaner add-on configurations.

For a future improvement, it would be nice if we could expose if the add-on has options (and thus a schema) and hide the config from the UI based on that.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/supervisor/pull/2421
