### PR TITLE
Command to start Supervisor is wrong

### DIFF
--- a/docs/add-ons/testing.md
+++ b/docs/add-ons/testing.md
@@ -7,7 +7,7 @@ The fastest and recommended way to develop add-ons is using a local Visual Studi
 - Follow the instructions to download and install the [Remote Containers][remote-containers] VS Code extension.
 - Copy the `.devcontainer` folder from [Official Add-ons][hassio-addons] repository into the root of your add-ons folders.
 - Open the root folder inside VS Code, and when prompted re-open the window inside the container (or, from the Command Palette, select 'Rebuild and Reopen in Container'). 
-- When VS Code has opened your folder in the container (which can take some time for the first run) you'll need to run the task (Terminal -> Run Task) 'Start Home Assistant', which will bootstrap Supervisor and Home Assistant. 
+- When VS Code has opened your folder in the container (which can take some time for the first run) you'll need to bootstrap Supervisor and Home Assistant by opening a terminal and executing `.devcontainer/supervisor.sh`. 
 - You'll then be able to access the normal onboarding process via the Home Assistant instance at `http://localhost:8123/`.
 - The add-on(s) found in your root folder will automatically be found in the Local Add-ons repository.
 


### PR DESCRIPTION
The commands that are initially specified to run are in tasks.json in the main addon repo. Adding these tasks by copying also `.vscode`  next to `.devcontainer` does not work as the paths are wrong.
Best way is to open a terminal and run the `supervisor.sh` script directly.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Correct procedure to start the supervisor.


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
