### PR TITLE
Replace PyPI tutorial dead link

### DIFF
--- a/docs/creating_platform_code_review.md
+++ b/docs/creating_platform_code_review.md
@@ -88,4 +88,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     status = bridge.status()
     ```
 
-    [Tutorial on publishing your own PyPI package](https://jeffknupp.com/blog/2013/08/16/open-sourcing-a-python-project-the-right-way/)
+    [Tutorial on publishing your own PyPI package](https://towardsdatascience.com/how-to-open-source-your-first-python-package-e717444e1da0)
+
+    Other noteworthy resources for publishing python packages:  
+    [Cookiecutter Project](https://cookiecutter.readthedocs.io/)  
+    [flit](https://flit.readthedocs.io/)  
+    [Poetry](https://python-poetry.org/)  


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
> The documentation contains two references

As mentioned in issue #822, two pages refer to a dead website for a PyPI tutorial. Only one link has been replaced in PR #823. This PR also replaces the link on the other page.
## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #822 
- Link to relevant existing code or pull request: #823 
