### PR TITLE
Add information on turning off OS SSH access

### DIFF
--- a/docs/operating-system/debugging.md
+++ b/docs/operating-system/debugging.md
@@ -37,6 +37,9 @@ You will initially be logged in to Home Assistant CLI for HassOS where you can p
 [Home Assistant OS]: https://github.com/home-assistant/hassos
 [Supervisor Architecture]: /architecture_index.md
 
+### Turning off SSH access to the host
+Use a USB drive formatted with FAT, ext4, or NTFS and name it CONFIG (case sensitive). Remove any existing `authorized_keys` file from the drive and leave the drive empty. When the Home Assistant OS device is rebooted with this drive inserted, any existing keys will be removed and the SSH service will be stopped.
+
 ## Checking the logs
 
 ```shell

--- a/docs/operating-system/debugging.md
+++ b/docs/operating-system/debugging.md
@@ -38,6 +38,7 @@ You will initially be logged in to Home Assistant CLI for HassOS where you can p
 [Supervisor Architecture]: /architecture_index.md
 
 ### Turning off SSH access to the host
+
 Use a USB drive formatted with FAT, ext4, or NTFS and name it CONFIG (case sensitive). Remove any existing `authorized_keys` file from the drive and leave the drive empty. When the Home Assistant OS device is rebooted with this drive inserted, any existing keys will be removed and the SSH service will be stopped.
 
 ## Checking the logs


### PR DESCRIPTION
The current documentation does not describe how to stop the SSH access to the host if it is no longer needed. The service will be stopped and the keys removed if the Home Assistant device is booted with an empty CONFIG drive inserted.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Documentation update for clarity

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/operating-system/blob/59b9d82a55a8141adb86d8d95d3f602428da7c22/buildroot-external/rootfs-overlay/usr/sbin/hassos-config#L80
