### PR TITLE
Remove pylint unused-import

### DIFF
--- a/docs/data_entry_flow_index.md
+++ b/docs/data_entry_flow_index.md
@@ -301,7 +301,7 @@ Example configuration flow that includes two show progress tasks.
 ```python
 from homeassistant import config_entries
 
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DOMAIN
 
 
 class TestFlow(config_entries.ConfigFlow, domain=DOMAIN):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Remove comment: `pylint: disable=unused-import`
With pylint `2.7.3`, this isn't necessary anymore.

PR to update pylint: https://github.com/home-assistant/core/pull/48488


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [x] Removed stale or deprecated documentation

