### PR TITLE
Change py.test -> pytest

### DIFF
--- a/docs/development_testing.md
+++ b/docs/development_testing.md
@@ -38,7 +38,7 @@ If you are working on tests for an integration and you need the dependencies ava
 
 ### Running single tests using `tox`
 
-You can pass arguments via `tox` to `py.test` to be able to run single test suites or test files. Replace `py38` with the Python version that you use.
+You can pass arguments via `tox` to `pytest` to be able to run single test suites or test files. Replace `py38` with the Python version that you use.
 
 ```shell
 # Stop after the first test fails
@@ -65,7 +65,7 @@ Now that you have all test dependencies installed, you can run tests on individu
 flake8 homeassistant/core.py
 pylint homeassistant/core.py
 pydocstyle homeassistant/core.py
-py.test tests/test_core.py
+pytest tests/test_core.py
 ```
 
 You can also run linting tests against all changed files, as reported by `git diff upstream/dev... --diff-filter=d --name-only`, using the `lint` script:


### PR DESCRIPTION
## Proposed change
The command I use in the dev container is `pytest`, however the documentation says the command is `py.test`. Removing the `.` would simplify the documentation as it will match the pytest documentaiton https://docs.pytest.org/en/stable/usage.html

## Type of change

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [X] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
