### PR TITLE
Add "strictly_typed" field to manifest.json

### DIFF
--- a/docs/creating_integration_manifest.md
+++ b/docs/creating_integration_manifest.md
@@ -16,7 +16,8 @@ Every integration has a manifest file to specify basic information about an inte
   "codeowners": ["@balloob"],
   "requirements": ["aiohue==1.9.1"],
   "quality_scale": "platinum",
-  "iot_class": "local_polling"
+  "iot_class": "local_polling",
+  "strictly_typed": true
 }
 ```
 
@@ -262,3 +263,16 @@ The following IoT classes are accepted in the manifest:
 - `calculated`: The integration does not handle communication on it's own, but provides a calculated result.
 
 [iot_class]: https://www.home-assistant.io/blog/2016/02/12/classifying-the-internet-of-things/#classifiers
+
+## Strict type checks
+
+If your integration is fully covered with type hints, we recommend you to enable strict mypy checks.
+Mypy will check if all required type annotations are added and if all types are used correctly.
+This can catch some potential issues in the code.
+
+
+```json
+{
+ "strictly_typed": true
+}
+```

--- a/docs/creating_integration_manifest.md
+++ b/docs/creating_integration_manifest.md
@@ -267,7 +267,7 @@ The following IoT classes are accepted in the manifest:
 ## Strict type checks
 
 If your integration is fully covered with type hints, we recommend you to enable strict mypy checks.
-Mypy will check if all required type annotations are added and if all types are used correctly.
+[Mypy](https://mypy.readthedocs.io/en/stable/) will check if all required type annotations are added and if all types are used correctly.
 This can catch some potential issues in the code.
 
 


### PR DESCRIPTION
For https://github.com/home-assistant/core/pull/49270

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Add new field which will be used by `hassfest` for generating `mypy.ini`.
Hassfest plugin is added in https://github.com/home-assistant/core/pull/49270

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/49270
