### PR TITLE
Make "Creating your first integration" step 1 in Building integrations

### DIFF
--- a/docs/creating_component_index.md
+++ b/docs/creating_component_index.md
@@ -2,7 +2,7 @@
 title: "Creating your first integration"
 ---
 
-Alright, you learned about the [manifest](creating_integration_manifest.md), so it's time to write your first code for your integration. AWESOME. Don't worry, we've tried hard to keep it as easy as possible. From a Home Assistant development environment, type the following and follow the instructions:
+Alright, so it's time to write your first code for your integration. AWESOME. Don't worry, we've tried hard to keep it as easy as possible. From a Home Assistant development environment, type the following and follow the instructions:
 
 ```shell
 python3 -m script.scaffold integration

--- a/sidebars.js
+++ b/sidebars.js
@@ -117,9 +117,9 @@ module.exports = {
       "development_catching_up",
     ],
     "Building Integrations": [
+      "creating_component_index",
       "creating_integration_file_structure",
       "creating_integration_manifest",
-      "creating_component_index",
       "config_entries_config_flow_handler",
       "config_entries_options_flow_handler",
       "configuration_yaml_index",


### PR DESCRIPTION
## Proposed change
New developers can easily become overwhelmed by all the details in a project as complex as Home Assistant. When a new developer wishes to create an integration, the first thing they should be directed to do is create a scaffold for their proposed integration.

By describing the file structure and how a `manifest.json` file are formatted implies that the developer needs to create them before running the `script.scaffold` python script. However, that is not the case.

I propose we move "Creating your first integration" to become the first thing a potential developer would read when reading the "Building Integrations" documentation.

## Type of change

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [X] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation