### PR TITLE
Added second example of calling a sync function

### DIFF
--- a/docs/asyncio_working_with_async.md
+++ b/docs/asyncio_working_with_async.md
@@ -101,6 +101,13 @@ If you are running inside an async context, it might sometimes be necessary to c
 result = await hass.async_add_executor_job(hub.update)
 ```
 
+Or, for a function with parameters:
+
+```python
+# do_work(config) is a sync function with one parameter
+result = await hass.async_add_executor_job(do_work, config)
+```
+
 ## Starting independent task from async
 
 If you want to spawn a task that will not block the current async context, you can choose to create it as a task on the event loop. It will then be executed in parallel.


### PR DESCRIPTION
It's not clear with the existing example what to do if the sync function has parameters. This gives a second explicit example.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
To give an explicit example of how to call a sync function that takes parameters. My own attempt was to use `hass.async_add_executor_job(do_work(config))` which threw a confusing error asking me to use async_add_executor_job.


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
