### PR TITLE
Deprecate Switch entity properties

### DIFF
--- a/docs/core/entity/switch.md
+++ b/docs/core/entity/switch.md
@@ -16,6 +16,13 @@ Properties should always only return information from memory and not do I/O (lik
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
 | is_on | boolean | **Required** | If the switch is currently on or off.
+
+## Deprecated Properties
+
+The following properties are deprecated and should not be used by new integrations it is recommended to migrate them to sensors, the deprecated properties will remain until at least the end of 2021.
+
+Name | Type | Default | Description
+| ---- | ---- | ------- | -----------
 | current_power_w | float | `None` | The current power usage in W.
 | today_energy_kwh | float | `None` | Total energy usage in kWh.
 

--- a/docs/core/entity/switch.md
+++ b/docs/core/entity/switch.md
@@ -19,7 +19,7 @@ Properties should always only return information from memory and not do I/O (lik
 
 ## Deprecated Properties
 
-The following properties are deprecated and should not be used by new integrations it is recommended to migrate them to sensors, the deprecated properties will remain until at least the end of 2021.
+The following properties are deprecated and should not be used by new integrations. Provide them as sensors instead.
 
 Name | Type | Default | Description
 | ---- | ---- | ------- | -----------


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
As discussed [architecture#579](https://github.com/home-assistant/architecture/discussions/579,) I suggest to update the documentations that the following properties of the Switch entity are deprecated and should not be used by new integrations:
- `current_power_w`
- `today_energy_kwh`

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
