### PR TITLE
Update debugging.md

### DIFF
--- a/docs/operating-system/debugging.md
+++ b/docs/operating-system/debugging.md
@@ -31,7 +31,7 @@ ssh root@homeassistant.local -p 22222
 
 If you have an older installation or have changed your hostname, you may need to use a different hostname in the command above. You can check the correct hostname to use in the System page of the Supervisor interface in Home Assistant.
 
-Starting in Core version core-2021.6.6 you will be logged as root in the ```/root``` folder, if you have an older instalation you will initially be able to perform normal CLI tasks. If you need access to the host system use the ```login``` command. In case your SSH connection is closed after the 'login' command, this means you are alredy logged in the host OS.
+Starting in Core version core-2021.6.6 you will be logged in as root in the ```/root``` folder, if you have an older installation you will initially be able to perform normal CLI tasks. If you need access to the host system use the ```login``` command. In case your SSH connection is closed after the 'login' command, this means you are already logged in to the host OS.
 
 [Home Assistant OS] is a hypervisor for Docker. See the [Supervisor Architecture] documentation for information regarding the Supervisor. The Supervisor offers an API to manage the host and running the Docker containers. Home Assistant itself and all installed addons run in separate Docker containers.
 

--- a/docs/operating-system/debugging.md
+++ b/docs/operating-system/debugging.md
@@ -31,9 +31,7 @@ ssh root@homeassistant.local -p 22222
 
 If you have an older installation or have changed your hostname, you may need to use a different hostname in the command above. You can check the correct hostname to use in the System page of the Supervisor interface in Home Assistant.
 
-Starting in Core version core-2021.6.6 you will be logged in as root in the ```/root``` folder, if you have an older installation you will initially be able to perform normal CLI tasks. If you need access to the host system use the ```login``` command. In case your SSH connection is closed after the 'login' command, this means you are already logged in to the host OS.
-
-[Home Assistant OS] is a hypervisor for Docker. See the [Supervisor Architecture] documentation for information regarding the Supervisor. The Supervisor offers an API to manage the host and running the Docker containers. Home Assistant itself and all installed addons run in separate Docker containers.
+You will be logged in as root in the ```/root``` folder. [Home Assistant OS] is a hypervisor for Docker. See the [Supervisor Architecture] documentation for information regarding the Supervisor. The Supervisor offers an API to manage the host and running the Docker containers. Home Assistant itself and all installed addons run in separate Docker containers.
 
 [CLI tasks]: https://www.home-assistant.io/hassio/commandline/
 [Home Assistant OS]: https://github.com/home-assistant/operating-system

--- a/docs/operating-system/debugging.md
+++ b/docs/operating-system/debugging.md
@@ -31,7 +31,9 @@ ssh root@homeassistant.local -p 22222
 
 If you have an older installation or have changed your hostname, you may need to use a different hostname in the command above. You can check the correct hostname to use in the System page of the Supervisor interface in Home Assistant.
 
-You will initially be able to perform normal [CLI tasks]. If you need access to the host system use the 'login' command. [Home Assistant OS] is a hypervisor for Docker. See the [Supervisor Architecture] documentation for information regarding the Supervisor. The Supervisor offers an API to manage the host and running the Docker containers. Home Assistant itself and all installed addons run in separate Docker containers.
+Starting in Core version core-2021.6.6 you will be logged as root in the ```/root``` folder, if you have an older instalation you will initially be able to perform normal CLI tasks. If you need access to the host system use the ```login``` command. In case your SSH connection is closed after the 'login' command, this means you are alredy logged in the host OS.
+
+[Home Assistant OS] is a hypervisor for Docker. See the [Supervisor Architecture] documentation for information regarding the Supervisor. The Supervisor offers an API to manage the host and running the Docker containers. Home Assistant itself and all installed addons run in separate Docker containers.
 
 [CLI tasks]: https://www.home-assistant.io/hassio/commandline/
 [Home Assistant OS]: https://github.com/home-assistant/operating-system


### PR DESCRIPTION
Updated the debugging.md to clarified the change in behavior when you ssh into the host OS. As starting on core-2021.6.6 you are already logged as root and not in CLI, so the 'loggin' command is not required and will actually close your ssh connection if entered.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This is a small update to the debugging.md page that clarifies that you don't need to 'login' to use commands other than CLI, when accessing the host OS.

## Type of change
- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
This pull request is relegated with this forum question: [https://community.home-assistant.io/t/cant-log-in-after-ssh-to-the-the-host/317656](https://community.home-assistant.io/t/cant-log-in-after-ssh-to-the-the-host/317656)
I can't say this is a widespread issue but you got 2 users (me included) that spent some time trying to figure out why the login command closed the SSH connection.

- This PR fixes or closes issue: Closes home-assistant/developers.home-assistant#1433
- Link to relevant existing code or pull request: 
