### PR TITLE
Add `STATE_VACATION` to Water Heaters

### DIFF
--- a/docs/core/entity/water-heater.md
+++ b/docs/core/entity/water-heater.md
@@ -38,6 +38,7 @@ Properties have to follow the units defined in the `temperature_unit`.
 | `STATE_HEAT_PUMP` | Slowest to heat, but uses less energy.
 | `STATE_GAS` | Gas only mode, uses the most energy.
 | `STATE_OFF` | The water heater is off.
+| `STATE_VACATION` | Vacation mode, provides energy savings by not reheating water.
 
 ## Supported Features
 


### PR DESCRIPTION
Add Developer Documentation for new Water Heater State Added in Core PR #52494

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Update Docs to include new `VACATION` state that is added in https://github.com/home-assistant/core/pull/52494.


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [X] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
  * https://github.com/home-assistant/core/pull/52494
