### PR TITLE
Document new dict format for siren.available_tones

### DIFF
--- a/docs/core/entity/siren.md
+++ b/docs/core/entity/siren.md
@@ -13,8 +13,8 @@ Properties should always only return information from memory and not do I/O (lik
 
 | Name                    | Type   | Default                               | Description                                                                             |
 | ----------------------- | ------ | ------------------------------------- | --------------------------------------------------------------------------------------- |
-| is_on                   | bool   | `NotImplementedError()`               | Whether the device is on or off.                                                        |
-| available_tones         | list   | `NotImplementedError()`               | The list of available tones on the device to pass into the `turn_on` service. Requires `SUPPORT_TONES` feature.                  |
+| is_on                   | bool           | `NotImplementedError()`               | Whether the device is on or off.                                                        |
+| available_tones         | list or dict   | `NotImplementedError()`               | The list or dictionary of available tones on the device to pass into the `turn_on` service. If a dictionary is provided, when a user uses the dict value of a tone, it will get converted to the corresponding dict key before being passed on to the integration platform. Requires `SUPPORT_TONES` feature.           |
 
 ### Tones
 


### PR DESCRIPTION
## Proposed change
Added dictionary as a possible type for `siren.available_tones` in https://github.com/home-assistant/core/pull/54198 . Dependent on https://github.com/home-assistant/developers.home-assistant/pull/1015 getting merged first.


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/54198
