### PR TITLE
Add hint to refresh browser cache

### DIFF
--- a/docs/internationalization/core.md
+++ b/docs/internationalization/core.md
@@ -105,6 +105,8 @@ In order to test changes to translation files, the translation strings must be c
 python3 -m script.translations develop
 ```
 
+You will probably need to update your browser cache for the changes to take effect (e.g. ctrl-F5).
+
 ### Introducing new strings
 
 To introduce new strings, add them to `strings.json` or to a platform strings file. Try to use as many references to common strings as possible. Common strings live in `homeassistant/strings.json`. You can refer to those translations using references. For example:

--- a/docs/internationalization/core.md
+++ b/docs/internationalization/core.md
@@ -105,7 +105,7 @@ In order to test changes to translation files, the translation strings must be c
 python3 -m script.translations develop
 ```
 
-You will probably need to update your browser cache for the changes to take effect (e.g. ctrl-F5).
+If translations do not show, clear the browser cache (cmd + R (for MacOS), ctrl + F5 (Windows and Linux))
 
 ### Introducing new strings
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Update developer documentation to make it easier.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
After running script.translations develop, the local browser still has old information, even if HA core is restarted.  The need to update browser cache is not intuitive. I have been puzzled by this more than once, so this hint will remind people (including me) and avoid wasting time.

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
