### PR TITLE
Fix container name

### DIFF
--- a/docs/operating-system/debugging.md
+++ b/docs/operating-system/debugging.md
@@ -48,7 +48,7 @@ Use a USB drive formatted with FAT, ext4, or NTFS and name it CONFIG (case sensi
 journalctl -f -u hassos-supervisor.service
 
 # Supervisor logs
-docker logs hassos_supervisor
+docker logs hassio_supervisor
 
 # Home Assistant logs
 docker logs homeassistant


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [X] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

It looks like the name of the container has changed, or was always like that.

```
# docker ps
CONTAINER ID   IMAGE                                                      COMMAND                  CREATED          STATUS          PORTS                                   NAMES9fd6cec37393   homeassistant/aarch64-hassio-multicast:2021.04.0           "/init"                  17 minutes ago   Up 17 minutes                                           hassio_multicast
1e9e2e1ceec6   ghcr.io/home-assistant/aarch64-hassio-cli:2021.08.1        "/init /bin/bash -c …"   17 minutes ago   Up 17 minutes                                           hassio_cli
3ce15776c985   ghcr.io/home-assistant/aarch64-hassio-audio:2021.07.0      "/init"                  17 minutes ago   Up 17 minutes                                           hassio_audio
08330e37b015   ghcr.io/home-assistant/aarch64-hassio-dns:2021.06.0        "/init"                  17 minutes ago   Up 17 minutes                                           hassio_dns
f84f4cffc31b   homeassistant/aarch64-hassio-supervisor:latest             "/init"                  13 days ago      Up 17 minutes                                           hassio_supervisor
9f4805af7bf5   ghcr.io/home-assistant/aarch64-hassio-observer:2021.06.0   "/init"                  3 months ago     Up 19 minutes   0.0.0.0:4357->80/tcp, :::4357->80/tcp   hassio_observer
```
