### PR TITLE
Fix non-existent COLOR_MODE's in light.md

### DIFF
--- a/docs/core/entity/light.md
+++ b/docs/core/entity/light.md
@@ -19,13 +19,13 @@ A light entity controls the brightness, hue and saturation color value, white va
 | is_on    | bool | bool  | Returns if the light entity is on or not.  
 | max_mireds | int | int | Return the warmest color_temp that this light supports.
 | min_mireds | int | int | Return the coldest color_temp that this light supports.
-| rgb_color | tuple | None | Return the rgb color value (int, int, int). This property will be copied to the light's state attribute when the light's color mode is set to `COLOR_MODE_COLOR_RGB` and ignored otherwise.
-| rgbw_color | tuple | None | Return the rgbw color value (int, int, int, int). This property will be copied to the light's state attribute when the light's color mode is set to `COLOR_MODE_COLOR_RGBW` and ignored otherwise.
-| rgbww_color | tuple | None | Return the rgbww color value (int, int, int, int, int). This property will be copied to the light's state attribute when the light's color mode is set to `COLOR_MODE_COLOR_RGBWW` and ignored otherwise.
+| rgb_color | tuple | None | Return the rgb color value (int, int, int). This property will be copied to the light's state attribute when the light's color mode is set to `COLOR_MODE_RGB` and ignored otherwise.
+| rgbw_color | tuple | None | Return the rgbw color value (int, int, int, int). This property will be copied to the light's state attribute when the light's color mode is set to `COLOR_MODE_RGBW` and ignored otherwise.
+| rgbww_color | tuple | None | Return the rgbww color value (int, int, int, int, int). This property will be copied to the light's state attribute when the light's color mode is set to `COLOR_MODE_RGBWW` and ignored otherwise.
 | supported_color_modes | set | None | Flag supported color modes.
 | supported_features | int | int | Flag supported features.
 | white_value | int | None | Return the white value of this light between 0..255. This is deprecated and will be removed in Home Assistant 2021.10.
-| xy_color | tuple | None | Return the xy color value (float, float). This property will be copied to the light's state attribute when the light's color mode is set to `COLOR_MODE_COLOR_XY` and ignored otherwise.
+| xy_color | tuple | None | Return the xy color value (float, float). This property will be copied to the light's state attribute when the light's color mode is set to `COLOR_MODE_XY` and ignored otherwise.
 
 ## Color Modes
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
COLOR_MODE_COLOR_RGB, COLOR_MODE_COLOR_RGBW, COLOR_MODE_COLOR_RGBWW, COLOR_MODE_COLOR_XY

Do not exist in the light entity: https://github.com/home-assistant/core/blob/dev/homeassistant/components/light/__init__.py

The information in the light documentation is not consistent and does not work
Should be: COLOR_MODE_RGB, COLOR_MODE_RGBW, COLOR_MODE_RGBWW, COLOR_MODE_XY as mentioned in line 54-64 of light/__init__.py
<!-- 
The information in the documentation is not consistent and does not work
-->


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [x] Removed stale or deprecated documentation

## Additional information

<!--

-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
