### PR TITLE
Add `entity_registry` endpoint

### DIFF
--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -421,6 +421,40 @@ curl -X GET -H "Authorization: Bearer ABCDEFGH" \
 
 </ApiEndpoint>
 
+<ApiEndpoint path="/api/entity_registry/<entity_id>" method="get">
+
+Returns a json encoded representation of an entry from the entity registry for specified entity_id. Returns 404 if not found.
+
+```json
+{
+  "entity_id": "input_boolean.test",
+  "config_entry_id": null,
+  "device_id": null,
+  "area_id": null,
+  "unique_id": "test",
+  "platform": "input_boolean",
+  "name": null,
+  "icon": null,
+  "disabled_by": null,
+  "capabilities": {},
+  "supported_features": 0,
+  "device_class": null,
+  "unit_of_measurement": null,
+  "original_name": "Test",
+  "original_icon": null
+}
+```
+
+Sample `curl` command:
+
+```shell
+curl -X GET -H "Authorization: Bearer ABCDEFGH" \
+  -H "Content-Type: application/json" \
+  http://localhost:8123/api/entity_registry/input_boolean.test
+```
+
+</ApiEndpoint>
+	
 <ApiEndpoint path="/api/error_log" method="get">
 
 Retrieve all errors logged during the current session of Home Assistant as a plaintext response.


### PR DESCRIPTION
## Proposed change
This PR adds a new endpoint to the REST API to retrieve entity information from the registry.
PR with the functionality [#57437](https://github.com/home-assistant/core/pull/57437)
## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
