### PR TITLE
Correct device_class `lock` on/off mapping

### DIFF
--- a/docs/core/entity/binary-sensor.md
+++ b/docs/core/entity/binary-sensor.md
@@ -29,7 +29,7 @@ Properties should always only return information from memory and not do I/O (lik
 | gas | On means gas detected, Off means no gas (clear).
 | heat | On means hot, Off means normal.
 | light | On means light detected, Off means no light.
-| lock | On means open (unlocked), Off means closed (locked).
+| lock | On means closed (locked), Off means open (unlocked).
 | moisture | On means wet, Off means dry.
 | motion | On means motion detected, Off means no motion (clear).
 | moving | On means moving, Off means not moving (stopped).


### PR DESCRIPTION
According to the lock template from https://www.home-assistant.io/integrations/lock.template/, `on` should be `locked` for lock.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Correct the device_class `lock` value mapping in the binary_sensor document.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
