### PR TITLE
`manifest.json` required to load the service

### DIFF
--- a/docs/dev_101_services.md
+++ b/docs/dev_101_services.md
@@ -31,11 +31,25 @@ def setup(hass, config):
     return True
 ```
 
-Load the integration by adding the following to your `configuration.yaml`. When your component is loaded, a new service should be available to call.
+To load the integration in Home Assistant is necessary to create a `manifest.json` and to add an entry in your `configuration.yaml`. When your component is loaded, a new service should be available to call.
 
 ```yaml
 # configuration.yaml entry
 hello_service:
+```
+
+An example of `manifest.json`
+```json
+{
+    "domain": "hello_service",
+    "name": "Hello Service",
+    "documentation": "https://developers.home-assistant.io/docs/dev_101_services",
+    "dependencies": [],
+    "codeowners": [],
+    "requirements": [],
+    "iot_class": "local_polling",
+    "version": "0.1.0"
+}
 ```
 
 Open the frontend and in the sidebar, click the first icon in the developer tool section. This will open the Call Service developer tool. On the right, find your service and click on it. This will automatically fill in the correct values.


### PR DESCRIPTION
From my tests, it is also necessary to add a `manifest.json` to properly load the service in Home Assistant.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->



## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->
I added an example of `manifest.json` in the file.
From my tests, it is also necessary to add a `manifest.json` to properly load the service in Home Assistant.

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->
