### PR TITLE
Add a message about building cryptography on macOS

### DIFF
--- a/docs/development_environment.mdx
+++ b/docs/development_environment.mdx
@@ -93,6 +93,11 @@ brew install python3 autoconf ffmpeg
 
 If you encounter build issues with `cryptography` when running the `script/setup` script below, check the cryptography documentation for [installation instructions](https://cryptography.io/en/latest/installation/#building-cryptography-on-macos).
 
+If you're having issues building `cryptography` try running:
+```shell
+env LDFLAGS="-L$(brew --prefix openssl@1.1)/lib" CFLAGS="-I$(brew --prefix openssl@1.1)/include" script/setup
+```
+
 ## Setup Local Repository
 
 Visit the [Home Assistant Core repository](https://github.com/home-assistant/core) and click **Fork**.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Add small message to users who are struggling with the manual environment, this fixed it for me. I believe the error comes from not having the correct OpenSSL libraries linked.

## Type of change
- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
Debated adding message about installing OpenSSL, this would be up to the mainters to decide if the documentation requires it  
