### PR TITLE
Fix CoverEntity `is_closed` property default value

### DIFF
--- a/docs/core/entity/cover.md
+++ b/docs/core/entity/cover.md
@@ -19,7 +19,7 @@ Properties should always only return information from memory and not do I/O (lik
 | current_cover_tilt_position | int | None | The current tilt position of the cover where 0 means closed/no tilt and 100 means open/maximum tilt.  Required with `SUPPORT_SET_TILT_POSITION`
 | is_opening | bool | None | If the cover is opening or not. Used to determine `state`.
 | is_closing | bool | None | If the cover is closing or not. Used to determine `state`.
-| is_closed | bool | `NotImplementedError()` | If the cover is closed or not.  if the state is unknown, return `None`. Used to determine `state`.
+| is_closed | bool | None | If the cover is closed or not. If the state is unknown, return `None`. Used to determine `state`.
 
 ### Entity Properties (base class properties which may be overridden)
 


### PR DESCRIPTION
## Proposed change

NotImplementedError() -> None

```
class CoverEntity(Entity):
    ...
     _attr_is_closed: bool | None                           # L196
    ...
    @property                                                        # L289-L292
    def is_closed(self) -> bool | None:
        """Return if the cover is closed or not."""
        return self._attr_is_closed
    ...
```

https://github.com/home-assistant/core/blob/1320f27fd706b5767baab5ac29dde1ce7d8042c8/homeassistant/components/cover/__init__.py#L196

https://github.com/home-assistant/core/blob/1320f27fd706b5767baab5ac29dde1ce7d8042c8/homeassistant/components/cover/__init__.py#L289-L292


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
