### PR TITLE
Add missing `await`s under SSDP

### DIFF
--- a/docs/network_discovery.md
+++ b/docs/network_discovery.md
@@ -59,7 +59,7 @@ from homeassistant.components import ssdp
 
 ...
 
-discovery_info = ssdp.async_get_discovery_info_by_udn_st(hass, udn, st)
+discovery_info = await ssdp.async_get_discovery_info_by_udn_st(hass, udn, st)
 ```
 
 ### Looking up devices by `ST`
@@ -74,7 +74,7 @@ from homeassistant.components import ssdp
 
 ...
 
-discovery_infos = ssdp.async_get_discovery_info_by_st(hass, "urn:schemas-upnp-org:device:ZonePlayer:1")
+discovery_infos = await ssdp.async_get_discovery_info_by_st(hass, "urn:schemas-upnp-org:device:ZonePlayer:1")
 for discovery_info in discovery_infos:
   ...
 
@@ -92,7 +92,7 @@ from homeassistant.components import ssdp
 
 ...
 
-discovery_infos = ssdp.async_get_discovery_info_by_udn(hass, udn)
+discovery_infos = await ssdp.async_get_discovery_info_by_udn(hass, udn)
 for discovery_info in discovery_infos:
   ...
 


### PR DESCRIPTION
Didn't know I had to await those functions, so I'm helping out more beginners like me

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
I'm adding some missing `await`s to Networking and Discovery

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation
- [x] Fixing example code

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

Fixing this would stop things like [this](https://discord.com/channels/330944238910963714/554842238073700352/925423705818009640) from happening
