### PR TITLE
Allow binary sensor state to be None

### DIFF
--- a/docs/core/entity/binary-sensor.md
+++ b/docs/core/entity/binary-sensor.md
@@ -13,7 +13,7 @@ Properties should always only return information from memory and not do I/O (lik
 
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
-| is_on| boolean | **Required** | If the binary sensor is currently on or off.
+| is_on| boolean | `None` | **Required** | If the binary sensor is currently on or off.
 | device_class | string | `None` | Type of binary sensor.
 
 ### Available device classes

--- a/docs/core/entity/binary-sensor.md
+++ b/docs/core/entity/binary-sensor.md
@@ -13,7 +13,7 @@ Properties should always only return information from memory and not do I/O (lik
 
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
-| is_on| boolean | `None` | **Required** | If the binary sensor is currently on or off.
+| is_on| boolean | `None` | If the binary sensor is currently on or off.
 | device_class | string | `None` | Type of binary sensor.
 
 ### Available device classes

--- a/docs/core/entity/camera.md
+++ b/docs/core/entity/camera.md
@@ -13,12 +13,12 @@ Properties should always only return information from memory and not do I/O (lik
 
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
-| is_recording | bool | None | Indication of whether the camera is recording. Used to determine `state`.
-| is_streaming | bool | None | Indication of whether the camera is streaming. Used to determine `state`.
+| is_recording | bool | `None` | Indication of whether the camera is recording. Used to determine `state`.
+| is_streaming | bool | `None` | Indication of whether the camera is streaming. Used to determine `state`.
 | motion_detection_enabled | bool | False | Indication of whether the camera has motion detection enabled.
-| is_on | bool | True | Indication camera is on.
-| brand | str | None | The brand (manufacturer) of the camera.
-| model | str | None | The model of the camera.
+| is_on | bool | `None` | Indication camera is on.
+| brand | str | `None` | The brand (manufacturer) of the camera.
+| model | str | `None` | The model of the camera.
 | frame_interval | float | 0.5 | The interval between frames of the stream.
 | frontend_stream_type | str | None | Used with `SUPPORT_STREAM` to tell the frontend which type of stream to use (`STREAM_TYPE_HLS` or `STREAM_TYPE_WEBRTC`)
 

--- a/docs/core/entity/fan.md
+++ b/docs/core/entity/fan.md
@@ -13,14 +13,14 @@ Properties should always only return information from memory and not do I/O (lik
 
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
-| current_direction | str | None | Return the current direction of the fan |
-| is_on | boolean | None |Return true if the entity is on |
+| current_direction | str | `None` | Return the current direction of the fan |
+| is_on | boolean | `None` |Return true if the entity is on |
 | oscillating | boolean | None | Return true if the fan is oscillating |
-| percentage | int | None | Return the current speed percentage. Must be a value between 0 (off) and 100 |
+| percentage | int | `None` | Return the current speed percentage. Must be a value between 0 (off) and 100 |
 | speed_count | int | 100 | The number of speeds the fan supports |
 | supported_features | int | 0 | Flag supported features |
-| preset_mode | str | None | Return the current preset_mode. One of the values in `preset_modes` or `None` if no preset is active. |
-| preset_modes | list | None | Get the list of available preset_modes. This is an arbitrary list of str and should not contain any speeds. |
+| preset_mode | str | `None` | Return the current preset_mode. One of the values in `preset_modes` or `None` if no preset is active. |
+| preset_modes | list | `None` | Get the list of available preset_modes. This is an arbitrary list of str and should not contain any speeds. |
 
 ### Preset Modes
 

--- a/docs/core/entity/humidifier.md
+++ b/docs/core/entity/humidifier.md
@@ -13,14 +13,14 @@ Properties should always only return information from memory and not do I/O (lik
 
 | Name                    | Type   | Default                               | Description                                                                               |
 | ----------------------- | ------ | ------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| target_humidity         | int    | None                                  | The target humidity the device is trying to reach.                                        |
+| target_humidity         | int    | `None`                                | The target humidity the device is trying to reach.                                        |
 | max_humidity            | int    | `DEFAULT_MAX_HUMIDITY` (value == 100) | Returns the maximum humidity.                                                             |
 | min_humidity            | int    | `DEFAULT_MIN_HUMIDITY` (value == 0)   | Returns the minimum humidity.                                                             |
 | mode                    | string | `NotImplementedError()`               | The current active preset. Requires `SUPPORT_MODES`.                                      |
 | available_modes         | list   | `NotImplementedError()`               | The available modes. Requires `SUPPORT_MODES`.                                            |
 | supported_features      | int    | (abstract method)                     | Bitmap of supported features. See below.                                                  |
-| is_on                   | bool   | `NotImplementedError()`               | Whether the device is on or off.                                                          |
-| device_class            | string | None                                  | Either DEVICE_CLASS_HUMIDIFIER or DEVICE_CLASS_DEHUMIDIFIER                               |
+| is_on                   | bool   | `None`                                | Whether the device is on or off.                                                          |
+| device_class            | string | `None`                                | Either DEVICE_CLASS_HUMIDIFIER or DEVICE_CLASS_DEHUMIDIFIER                               |
 
 ### Modes
 

--- a/docs/core/entity/light.md
+++ b/docs/core/entity/light.md
@@ -16,7 +16,7 @@ A light entity controls the brightness, hue and saturation color value, white va
 | effect | String | None | Return the current effect.
 | effect_list | list | None | Return the list of supported effects.
 | hs_color | tuple | None | Return the hue and saturation color value (float, float). This property will be copied to the light's state attribute when the light's color mode is set to `COLOR_MODE_HS` and ignored otherwise.
-| is_on    | bool | bool  | Returns if the light entity is on or not.  
+| is_on    | bool | None  | Returns if the light entity is on or not.  
 | max_mireds | int | int | Return the warmest color_temp that this light supports.
 | min_mireds | int | int | Return the coldest color_temp that this light supports.
 | rgb_color | tuple | None | Return the rgb color value (int, int, int). This property will be copied to the light's state attribute when the light's color mode is set to `COLOR_MODE_RGB` and ignored otherwise.

--- a/docs/core/entity/light.md
+++ b/docs/core/entity/light.md
@@ -16,7 +16,7 @@ A light entity controls the brightness, hue and saturation color value, white va
 | effect | String | None | Return the current effect.
 | effect_list | list | None | Return the list of supported effects.
 | hs_color | tuple | None | Return the hue and saturation color value (float, float). This property will be copied to the light's state attribute when the light's color mode is set to `COLOR_MODE_HS` and ignored otherwise.
-| is_on    | bool | None  | Returns if the light entity is on or not.  
+| is_on    | bool | `None`  | Returns if the light entity is on or not.  
 | max_mireds | int | int | Return the warmest color_temp that this light supports.
 | min_mireds | int | int | Return the coldest color_temp that this light supports.
 | rgb_color | tuple | None | Return the rgb color value (int, int, int). This property will be copied to the light's state attribute when the light's color mode is set to `COLOR_MODE_RGB` and ignored otherwise.

--- a/docs/core/entity/siren.md
+++ b/docs/core/entity/siren.md
@@ -13,7 +13,7 @@ Properties should always only return information from memory and not do I/O (lik
 
 | Name                    | Type   | Default                               | Description                                                                             |
 | ----------------------- | ------ | ------------------------------------- | --------------------------------------------------------------------------------------- |
-| is_on                   | bool           | `NotImplementedError()`               | Whether the device is on or off.                                                        |
+| is_on                   | bool           | `None`                                | Whether the device is on or off.                                                        |
 | available_tones         | list or dict   | `NotImplementedError()`               | The list or dictionary of available tones on the device to pass into the `turn_on` service. If a dictionary is provided, when a user uses the dict value of a tone, it will get converted to the corresponding dict key before being passed on to the integration platform. Requires `SUPPORT_TONES` feature.           |
 
 ### Tones

--- a/docs/core/entity/switch.md
+++ b/docs/core/entity/switch.md
@@ -15,7 +15,7 @@ Properties should always only return information from memory and not do I/O (lik
 
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
-| is_on | boolean | **Required** | If the switch is currently on or off.
+| is_on | boolean | `None` | If the switch is currently on or off.
 
 ## Deprecated Properties
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Adjusts the default state documentation occurrences of `is_on` for ToggleEntity based things to `None`.

Upstream PR: https://github.com/home-assistant/core/pull/64621

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/64621
