### PR TITLE
Add "reprompt" for the intent response

### DIFF
--- a/docs/intent_firing.md
+++ b/docs/intent_firing.md
@@ -33,6 +33,7 @@ The intent response is an instance of `homeassistant.helpers.intent.IntentRespon
 | ---- | ---- | ----------- |
 | `intent` | Intent | Instance of intent that triggered response. |
 | `speech` | Dictionary | Speech responses. Each key is a type. Allowed types are `plain` and `ssml`. |
+| `reprompt` | Dictionary | Reprompt responses. Each key is a type. Allowed types are `plain` and `ssml`.<br />This is used to keep the session open when a response is required from the user. In these cases, `speech` usually is a question. |
 | `card` | Dictionary | Card responses. Each key is a type. |
 
 Speech dictionary values:
@@ -40,6 +41,13 @@ Speech dictionary values:
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | `speech` | String | The text to say
+| `extra_data` | Any | Extra information related to this speech.
+
+Reprompt dictionary values:
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `reprompt` | String | The text to say when user takes too long to respond
 | `extra_data` | Any | Extra information related to this speech.
 
 Card dictionary values:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
- Added "reprompt" for the intent response


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->
https://developer.amazon.com/en-US/docs/alexa/custom-skills/request-and-response-json-reference.html#response-object

"The object containing the outputSpeech to use if a re-prompt is necessary.

Used if your service keeps the session open after sending the response (shouldEndSession is false), but the user doesn't respond with anything that maps to an intent defined in your voice interface while the microphone is open. The user has a few seconds to respond to the reprompt before Alexa closes the session.

If the reprompt doesn't have a value, Alexa doesn't reprompt the user."

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/65256
