### PR TITLE
Replace Climate HVAC_MODE_* constants with HVACMode enum

### DIFF
--- a/docs/core/entity/climate.md
+++ b/docs/core/entity/climate.md
@@ -26,7 +26,7 @@ Properties should always only return information from memory and not do I/O (lik
 | min_temp                | int    | `DEFAULT_MIN_TEMP` (value == 7)      | Returns the minimum temperature.                                                                             |
 | max_humidity            | int    | `DEFAULT_MAX_HUMIDITY` (value == 99) | Returns the maximum humidity. Requires `SUPPORT_TARGET_HUMIDITY`.                                            |
 | min_humidity            | int    | `DEFAULT_MIN_HUMIDITY` (value == 30) | Returns the minimum humidity. Requires `SUPPORT_TARGET_HUMIDITY`.                                            |
-| hvac_mode               | string | `NotImplementedError()`              | The current operation (e.g. heat, cool, idle). Used to determine `state`.                                    |
+| hvac_mode               | HVACMode | `NotImplementedError()`              | The current operation (e.g. heat, cool, idle). Used to determine `state`.                                    |
 | hvac_action             | string | None                                 | The current HVAC action (heating, cooling)                                                                   |
 | hvac_modes              | list   | `NotImplementedError()`              | List of available operation modes. See below.                                                                |
 | preset_mode             | string | `NotImplementedError()`              | The current active preset. Requires `SUPPORT_PRESET_MODE`.                                                   |
@@ -40,17 +40,19 @@ Properties should always only return information from memory and not do I/O (lik
 
 ### HVAC modes
 
-You are only allowed to use the built-in HVAC modes. If you want another mode, add a preset instead.
+You are only allowed to use the built-in HVAC modes, provided by the `HVACMode`
+enum. If you want another mode, add a preset instead.
 
-| Name                  | Description                                                         |
-| --------------------- | ------------------------------------------------------------------- |
-| `HVAC_MODE_OFF`       | The device is turned off.                                           |
-| `HVAC_MODE_HEAT`      | The device is set to heat to a target temperature.                  |
-| `HVAC_MODE_COOL`      | The device is set to cool to a target temperature.                  |
-| `HVAC_MODE_HEAT_COOL` | The device supports heating/cooling to a range                      |
-| `HVAC_MODE_AUTO`      | The device is set to a schedule, learned behavior, AI.              |
-| `HVAC_MODE_DRY`       | The device is set to dry/humidity mode.                             |
-| `HVAC_MODE_FAN_ONLY`  | The device only has the fan on. No heating or cooling taking place. |
+
+| Name                 | Description                                                         |
+| -------------------- | ------------------------------------------------------------------- |
+| `HVACMode.OFF`       | The device is turned off.                                           |
+| `HVACMode.HEAT`      | The device is set to heat to a target temperature.                  |
+| `HVACMode.COOL`      | The device is set to cool to a target temperature.                  |
+| `HVACMode.HEAT_COOL` | The device supports heating/cooling to a range                      |
+| `HVACMode.AUTO`      | The device is set to a schedule, learned behavior, AI.              |
+| `HVACMode.DRY`       | The device is set to dry/humidity mode.                             |
+| `HVACMode.FAN_ONLY`  | The device only has the fan on. No heating or cooling taking place. |
 
 ### HVAC Action
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Documents the `HVACMode` enum, replacing the `HVAC_MODE_*` constants.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [x] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/70286
