### PR TITLE
Clarify when an encrypted request has no data

### DIFF
--- a/docs/api/native-app-integration/sending-data.md
+++ b/docs/api/native-app-integration/sending-data.md
@@ -110,7 +110,7 @@ For other languages, please see the list of [Bindings for other languages](https
 
 ### Configuration
 
-We use the [secret-key cryptography](https://download.libsodium.org/doc/secret-key_cryptography) features of Sodium to encrypt and decrypt payloads. All payloads are JSON encoded in Base64. For Base64 type, use `sodium_base64_VARIANT_ORIGINAL` (that is, "original", no padding, not URL safe).
+We use the [secret-key cryptography](https://download.libsodium.org/doc/secret-key_cryptography) features of Sodium to encrypt and decrypt payloads. All payloads are JSON encoded in Base64. For Base64 type, use `sodium_base64_VARIANT_ORIGINAL` (that is, "original", no padding, not URL safe). If the payload does not contain a `data` key when unencrypted (such as with the [get_config](https://developers.home-assistant.io/docs/api/native-app-integration/sending-data#get-config) request), an empty JSON object (`{}`) must be encrypted instead.
 
 ### Signaling encryption support
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
I've added some documentation for when issuing an encrypted webhook request for a `type` that normally has no `data` key. Most actions *do* contain data, however there are [a couple](https://developers.home-assistant.io/docs/api/native-app-integration/sending-data#get-zones), like `get_zones` and `get_config` that are sent with no data when unencrypted. This documentation does not explicitly state what to do in this scenario, though it does hint at it.

The raised exception when no payload is sent also interferes with upgrading encryption from legacy (the `ATTR_NO_LEGACY_ENCRYPTION` flag).

Things I tried:
* Send no `encrypted` key nor `encrypted_data`: Home Assistant refuses to accept unencrypted webhook.
* Send `encrypted=True`, but no `encrypted_data`: Home Assistant schema requires `encrypted_data` with `encrypted` payload, even for `get_config` action.
* Send empty string "encrypted" with secret key in `encrypted_data` field: [mobile app code](https://github.com/home-assistant/core/blob/c8e06e2456b1d39cc638424fbb54ef1a17a4e0bc/homeassistant/components/mobile_app/helpers.py#L88) tries and fails to parse empty string as JSON, throwing exception.
* Send empty JSON object encrypted in `encrypted_data`: Success with no errors.


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
