### PR TITLE
Correct /api/intent/handle endpoint route, add `intent:` hint

### DIFF
--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -647,9 +647,11 @@ If the check fails, the errors attribute in the object will list what caused the
 
 </ApiEndpoint>
 
-<ApiEndpoint path="/api/intent/handling" method="post">
+<ApiEndpoint path="/api/intent/handle" method="post">
 
 Handle an intent.
+
+You must add `intent:` to your `configuration.yaml` to enable this endpoint.
 
 Sample `curl` command:
 	


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Clarification of /api/intent/handle docs

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->
I figured the endpoint is /api/intent/handle and not /api/intent/handling. Also, I had to add `intent:` to my `configuration.yaml` to enable it, otherwise it returned 404s and documented that.

- This PR fixes or closes issue: --
- Link to relevant existing code or pull request: --
