### PR TITLE
`host_pid` does not work in s6 v3

### DIFF
--- a/blog/2022-05-12-s6-overlay-base-images.md
+++ b/blog/2022-05-12-s6-overlay-base-images.md
@@ -54,6 +54,4 @@ This is a problem because S6 expects to be PID 1 (it's literally in the [tagline
 
 In V2, S6 didn't actually check that it was running as PID 1. This is why it "worked" when in this mode in the past (although it required some [workarounds](https://github.com/hassio-addons/addon-glances/blob/8575d7903ef4c0a7c49e9ab32e0536bd2eb12dd6/glances/rootfs/bin/s6-nuke) to keep s6 from breaking systems when running this way). In V3 S6 checks that it is actually PID 1 and refuses to start otherwise.
 
-There's no easy solution to this, the option simply won't work in S6 V3. As a temporary fix you can switch to using the corresponding [community add-ons base image](https://github.com/hassio-addons?q=base&type=all&language=&sort=). I must stress that this is temporary though, eventually those will update too.
-
-Long-term you should not use s6 overlay in your addon as it's not designed for this use case. You can continue to use the addon base images by overriding `/init` with a no-op script and then using the normal docker init system. Or you can switch to a different base image like [alpine](https://hub.docker.com/search?q=alpine&type=image) or [debian](https://hub.docker.com/_/debian) and add what you need.
+To fix this, don't use s6 overlay in your addon as it's not designed for this use case. You can continue to use the addon base images by overriding `/init` with a no-op script and then use the normal docker init system. Or you can switch to a different base image like stock alpine or debian and add what you need.

--- a/blog/2022-05-12-s6-overlay-base-images.md
+++ b/blog/2022-05-12-s6-overlay-base-images.md
@@ -43,3 +43,17 @@ You have to tweak your [AppArmor profile](/docs/add-ons/presentation#apparmor) t
   /run/{,**} rwk,
   /dev/tty rw,
 ```
+
+## `host_pid` option
+
+Addons running without protection mode enabled can set `host_pid: true` in their configuration. As described in the [documentation](https://developers.home-assistant.io/docs/add-ons/configuration#optional-configuration-options):
+
+> Allow to run container on host PID namespace. Works only for not protected add-ons.
+
+This is a problem because S6 expects to be PID 1 (it's literally in the [tagline](https://github.com/just-containers/s6-overlay#s6-overlay-)) and that's impossible when using the host PID namespace.
+
+In V2, S6 didn't actually check that it was running as PID 1. This is why it "worked" when in this mode in the past (although it required some [workarounds](https://github.com/hassio-addons/addon-glances/blob/8575d7903ef4c0a7c49e9ab32e0536bd2eb12dd6/glances/rootfs/bin/s6-nuke) to keep s6 from breaking systems when running this way). In V3 S6 checks that it is actually PID 1 and refuses to start otherwise.
+
+There's no easy solution to this, the option simply won't work in S6 V3. As a temporary fix you can switch to using the corresponding [community add-ons base image](https://github.com/hassio-addons?q=base&type=all&language=&sort=). I must stress that this is temporary though, eventually those will update too.
+
+Long-term you should not use s6 overlay in your addon as its not designed for this. You should use stock [alpine](https://hub.docker.com/search?q=alpine&type=image), [debian](https://hub.docker.com/_/debian) or [ubuntu](https://hub.docker.com/_/ubuntu) as your base image instead and add what you need to the image to make your addon work.

--- a/blog/2022-05-12-s6-overlay-base-images.md
+++ b/blog/2022-05-12-s6-overlay-base-images.md
@@ -56,4 +56,4 @@ In V2, S6 didn't actually check that it was running as PID 1. This is why it "wo
 
 There's no easy solution to this, the option simply won't work in S6 V3. As a temporary fix you can switch to using the corresponding [community add-ons base image](https://github.com/hassio-addons?q=base&type=all&language=&sort=). I must stress that this is temporary though, eventually those will update too.
 
-Long-term you should not use s6 overlay in your addon as its not designed for this. You should use stock [alpine](https://hub.docker.com/search?q=alpine&type=image), [debian](https://hub.docker.com/_/debian) or [ubuntu](https://hub.docker.com/_/ubuntu) as your base image instead and add what you need to the image to make your addon work.
+Long-term you should not use s6 overlay in your addon as it's not designed for this use case. You can continue to use the addon base images by overriding `/init` with a no-op script and then using the normal docker init system. Or you can switch to a different base image like [alpine](https://hub.docker.com/search?q=alpine&type=image) or [debian](https://hub.docker.com/_/debian) and add what you need.

--- a/docs/add-ons/configuration.md
+++ b/docs/add-ons/configuration.md
@@ -141,7 +141,7 @@ Note:  Avoid the use of this filename for anything other than add-on configurati
 | `host_network` | bool | `false` | If `true`, the add-on runs on host network.
 | `host_ipc` | bool | `false` | Allow to share the IPC namespace with others.
 | `host_dbus` | bool | `false` | Map the host D-Bus service into the add-on.
-| `host_pid` | bool | `false` | Allow to run container on host PID namespace. Works only for not protected add-ons. **Warning:** Does not work with S6 Overlay. If need this to be `true` you should not use the normal add-on base images. Use a stock alpine, debian or ubuntu one instead.
+| `host_pid` | bool | `false` | Allow to run container on host PID namespace. Works only for not protected add-ons. **Warning:** Does not work with S6 Overlay. If need this to be `true` and you use the normal add-on base image you disable S6 by overriding `/init`. Or use an alternate base image.
 | `devices` | list | | Device list to map into the add-on. Format is: `<path_on_host>`. E.g., `/dev/ttyAMA0`
 | `homeassistant` | string | | Pin a minimum required Home Assistant Core version for the add-on. Value is a version string like `0.91.2`.
 | `hassio_role` | str | `default` |Role-based access to Supervisor API. Available: `default`, `homeassistant`, `backup`, `manager` or `admin`

--- a/docs/add-ons/configuration.md
+++ b/docs/add-ons/configuration.md
@@ -141,7 +141,7 @@ Note:  Avoid the use of this filename for anything other than add-on configurati
 | `host_network` | bool | `false` | If `true`, the add-on runs on host network.
 | `host_ipc` | bool | `false` | Allow to share the IPC namespace with others.
 | `host_dbus` | bool | `false` | Map the host D-Bus service into the add-on.
-| `host_pid` | bool | `false` | Allow to run container on host PID namespace. Works only for not protected add-ons.
+| `host_pid` | bool | `false` | Allow to run container on host PID namespace. Works only for not protected add-ons. **Warning:** Does not work with S6 Overlay. If need this to be `true` you should not use the normal add-on base images. Use a stock alpine, debian or ubuntu one instead.
 | `devices` | list | | Device list to map into the add-on. Format is: `<path_on_host>`. E.g., `/dev/ttyAMA0`
 | `homeassistant` | string | | Pin a minimum required Home Assistant Core version for the add-on. Value is a version string like `0.91.2`.
 | `hassio_role` | str | `default` |Role-based access to Supervisor API. Available: `default`, `homeassistant`, `backup`, `manager` or `admin`


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

`host_pid` option does not work in s6 v3. Mention this in blog post.


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
