### PR TITLE
Add blog post about waiting for config entry platforms

### DIFF
--- a/blog/2022-07-08-config_entry_forwards.md
+++ b/blog/2022-07-08-config_entry_forwards.md
@@ -1,0 +1,11 @@
+---
+author: J. Nick Koston
+authorURL: https://github.com/bdraco
+title: "Waiting for config entry platforms"
+---
+
+Before 2022.8, it was impossible to `await` config entry platforms forwards without a deadlock if one of the platforms loaded by the config entry was not already loaded.
+
+Integrations need to be refactored to replace calls to `hass.config_entries.async_setup_platforms` with `hass.config_entries.async_forward_entry_setups` and/or await all `hass.config_entries.async_forward_entry_setup` to ensure that Home Assistant does not inadventantly reload the integration while entities and platforms are still being set up.
+
+`hass.config_entries.async_setup_platforms` is scheduled to be removed in 2022.12.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Wait for config entry platform forwards to ensure entries are never reloaded before they are finished setting up platforms and entities.

The following integrations have not been updated as they require more complex refactoring and/or test updates and may still suffer from reload races after this PR (each one will probably need its own PR).  They need to be refactored to replace calls to `hass.config_entries.async_setup_platforms` with `hass.config_entries.async_forward_entry_setups` and/or await all `hass.config_entries.async_forward_entry_setup`

- ambient_station
- axis
- deconz
- cast
- deconz
- esphome (race still present since it loads late)
- fjaraskupan
- heos
- homekit_controller
- homematicip_cloud
- islamic_prayer_times
- knx
- konnected
- mikrotik
- nest (legacy)
- openthrem_gw (https://github.com/home-assistant/core/pull/73806/#discussion_r907774078)
- plex (https://github.com/home-assistant/core/pull/73806/#discussion_r907776540)
- point
- samsungtv
- shelly
- steam_online
- tellduslive
- tomorrowio
- totalconnect
- unifi
- wemo
- vesync
- zha
- zwave_js
- zwave_me


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/73806
