### PR TITLE
change doc links master -> dev

### DIFF
--- a/docs/asyncio_working_with_async.md
+++ b/docs/asyncio_working_with_async.md
@@ -109,5 +109,5 @@ If you want to spawn a task that will not block the current async context, you c
 hass.async_create_task(async_say_hello(hass, target))
 ```
 
-[dev-docs]: https://dev-docs.home-assistant.io/en/master/api/core.html
+[dev-docs]: https://dev-docs.home-assistant.io/en/dev/api/core.html
 [dev-docs-async]: https://dev-docs.home-assistant.io/en/dev/api/util.html#module-homeassistant.util.async

--- a/docs/dev_101_config.md
+++ b/docs/dev_101_config.md
@@ -6,7 +6,7 @@ Based on where you are in the code, `config` can mean various things.
 
 ### On the hass object
 
-On the hass object it is an instance of the Config class. The Config class contains the users preferred units, the path to the config directory and which components are loaded. [See available methods.](https://dev-docs.home-assistant.io/en/master/api/core.html#homeassistant.core.Config)
+On the hass object it is an instance of the Config class. The Config class contains the users preferred units, the path to the config directory and which components are loaded. [See available methods.](https://dev-docs.home-assistant.io/en/dev/api/core.html#homeassistant.core.Config)
 
 ### Config passed into component setup
 

--- a/docs/dev_101_events.md
+++ b/docs/dev_101_events.md
@@ -57,5 +57,5 @@ def setup(hass, config):
 
 Home Assistant comes with a lot of bundled helpers to listen to specific types of event. There are helpers to track a point in time, to track a time interval, a state change or the sun set. [See available methods.][helpers]
 
-[helpers]: https://dev-docs.home-assistant.io/en/master/api/helpers.html#module-homeassistant.helpers.event
+[helpers]: https://dev-docs.home-assistant.io/en/dev/api/helpers.html#module-homeassistant.helpers.event
 [object]: https://www.home-assistant.io/docs/configuration/events/

--- a/docs/dev_101_hass.md
+++ b/docs/dev_101_hass.md
@@ -11,11 +11,11 @@ The Home Assistant instance contains four objects to help you interact with the 
 
 | Object | Description |
 | ------ | ----------- |
-| `hass` | This is the instance of Home Assistant. Allows starting, stopping and enqueuing new jobs. [See available methods.](https://dev-docs.home-assistant.io/en/master/api/core.html#homeassistant.core.HomeAssistant)
-| `hass.config` | This is the core configuration of Home Assistant exposing location, temperature preferences and config directory path. [See available methods.](https://dev-docs.home-assistant.io/en/master/api/core.html#homeassistant.core.Config)
-| `hass.states` | This is the StateMachine. It allows you to set states and track when they are changed. [See available methods.](https://dev-docs.home-assistant.io/en/master/api/core.html#homeassistant.core.StateMachine) |
-| `hass.bus` | This is the EventBus. It allows you to trigger and listen for events. [See available methods.](https://dev-docs.home-assistant.io/en/master/api/core.html#homeassistant.core.EventBus) |
-| `hass.services` | This is the ServiceRegistry. It allows you to register services. [See available methods.](https://dev-docs.home-assistant.io/en/master/api/core.html#homeassistant.core.ServiceRegistry) |
+| `hass` | This is the instance of Home Assistant. Allows starting, stopping and enqueuing new jobs. [See available methods.](https://dev-docs.home-assistant.io/en/dev/api/core.html#homeassistant.core.HomeAssistant)
+| `hass.config` | This is the core configuration of Home Assistant exposing location, temperature preferences and config directory path. [See available methods.](https://dev-docs.home-assistant.io/en/dev/api/core.html#homeassistant.core.Config)
+| `hass.states` | This is the StateMachine. It allows you to set states and track when they are changed. [See available methods.](https://dev-docs.home-assistant.io/en/dev/api/core.html#homeassistant.core.StateMachine) |
+| `hass.bus` | This is the EventBus. It allows you to trigger and listen for events. [See available methods.](https://dev-docs.home-assistant.io/en/dev/api/core.html#homeassistant.core.EventBus) |
+| `hass.services` | This is the ServiceRegistry. It allows you to register services. [See available methods.](https://dev-docs.home-assistant.io/en/dev/api/core.html#homeassistant.core.ServiceRegistry) |
 
 <img class='invertDark'
   alt='Overview of the Home Assistant core architecture'


### PR DESCRIPTION
change links in developer documentation from pointing to the master
branch to point to the dev branch. The master branch online docs are
missing much information.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Changes all references to documentation hosted on the master branch to instead point to the dev branch.



## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->
The online docs at https://developers.home-assistant.io/docs/development_index/ have links pointing to API documentation hosted on the master branch, which shows an API reference with either no information or limited information.  

This can be verified by visiting [accessing the core introduction](https://developers.home-assistant.io/docs/dev_101_hass) and then clicking on the API reference documentation for any of the "see available methods" links in the `hass` object table near the top of the page.  

All existing links were verified to not contain the expected information. All new links were verified to contain the expected information.  

- This PR fixes or closes issue: fixes # 
- Link to relevant existing code or pull request: 
