### PR TITLE
Blog post for AutomationActionType deprecation

### DIFF
--- a/blog/2022-08-15-automation-action-type-deprecation.md
+++ b/blog/2022-08-15-automation-action-type-deprecation.md
@@ -1,0 +1,19 @@
+---
+author: Marc Mueller
+authorURL: https://github.com/cdce8p
+title: "AutomationActionType deprecation for 2022.9"
+---
+
+For Home Assistant Core 2022.9, we have deprecated `AutomationActionType`, `AutomationTriggerInfo`,
+and `AutomationTriggerData` from `homeassistant/components/automation/__init__.py`.
+They are being replaced by `TriggerActionType`, `TriggerInfo`, and `TriggerData`
+from `homeassistant/helpers/trigger.py`.
+
+| Old | New |
+| --- | --- |
+| `AutomationActionType` | `TriggerActionType` |
+| `AutomationTriggerInfo` | `TriggerInfo` |
+| `AutomationTriggerData` | `TriggerData` |
+
+Furthermore, we recommend updating the `automation_info` parameter name for the
+`async_attach_trigger` function to `trigger_info`.

--- a/docs/device_automation_trigger.md
+++ b/docs/device_automation_trigger.md
@@ -92,7 +92,7 @@ To wire it up: Given a `TRIGGER_SCHEMA` config, make sure the `action` is called
 For example, you might attach the trigger and action to [Events fired](integration_events.md) on the event bus by your integration.
 
 ```python
-async def async_attach_trigger(hass, config, action, automation_info):
+async def async_attach_trigger(hass, config, action, trigger_info):
     """Attach a trigger."""
     event_config = event_trigger.TRIGGER_SCHEMA({
         event_trigger.CONF_PLATFORM: "event",
@@ -103,7 +103,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
         },
     }
     return await event_trigger.async_attach_trigger(
-        hass, event_config, action, automation_info, platform_type="device"
+        hass, event_config, action, trigger_info, platform_type="device"
     )
 ```
 


### PR DESCRIPTION
## Proposed change
Blog post for changes to `AutomationActionType`, `AutomationTriggerInfo`, and `AutomationTriggerData`.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/76790
