### PR TITLE
Fix the pytest command on testing page

### DIFF
--- a/docs/development_testing.md
+++ b/docs/development_testing.md
@@ -77,7 +77,7 @@ script/lint
 In case you want to check the code coverage for your new component, run the following from the root of the repository:
 
 ```shell
-pytest ./tests/components/<your_component>/ --asyncio-mode=strict --cov=homeassistant.components.<your_component> --cov-report term-missing -vv
+pytest ./tests/components/<your_component>/ --cov=homeassistant.components.<your_component> --cov-report term-missing -vv
 ```
 
 ### Preventing linter errors


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
As I understand correctly the pytest command does not support anymore the option --asyncio-mode=strict.
So I suggest to remove it in the documentation.

Also if I run the command with the option I get an error:
```
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: --asyncio-mode=strict
  inifile: /workspaces/core/pyproject.toml
  rootdir: /workspaces/core
```


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [X] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
