### PR TITLE
Fix incorrect match examples for bluetooth

### DIFF
--- a/docs/creating_integration_manifest.md
+++ b/docs/creating_integration_manifest.md
@@ -182,7 +182,7 @@ The following example will match service data with a 128 bit uuid used for Switc
 {
   "bluetooth": [
     {
-      "service_uuid": ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
+      "service_uuid": "cba20d00-224d-11e6-9fb8-0002a5d5c51b"
     }
   ]
 }
@@ -194,7 +194,7 @@ If you want to match service data with a 16 bit uuid, you will have to convert i
 {
   "bluetooth": [
     {
-      "service_data_uuid": ["0000fd3d-0000-1000-8000-00805f9b34fb"]
+      "service_data_uuid": "0000fd3d-0000-1000-8000-00805f9b34fb"
     }
   ]
 }

--- a/docs/network_discovery.md
+++ b/docs/network_discovery.md
@@ -47,7 +47,7 @@ def _async_discovered_device(service_info: bluetooth.BluetoothServiceInfoBleak, 
 
 entry.async_on_unload(
     bluetooth.async_register_callback(
-        hass, _async_discovered_device, {"service_uuids": {"cba20d00-224d-11e6-9fb8-0002a5d5c51b"}, "connectable": False}, bluetooth.BluetoothScanningMode.ACTIVE
+        hass, _async_discovered_device, {"service_uuid": "cba20d00-224d-11e6-9fb8-0002a5d5c51b", "connectable": False}, bluetooth.BluetoothScanningMode.ACTIVE
     )
 )
 ```


### PR DESCRIPTION

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Fix incorrect match examples for bluetooth.

These matchers do not take lists, they take a single value

https://github.com/home-assistant/core/blob/0881ff2d1fe4034b33821775fa236589d8836912/homeassistant/loader.py#L90

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
