### PR TITLE
Set device_tracker latitude/longitude Type as float

### DIFF
--- a/docs/core/entity/device-tracker.md
+++ b/docs/core/entity/device-tracker.md
@@ -55,8 +55,8 @@ TrackerEntity does not support attribute shorthand for [property implementation]
 | Name              | Type    | Default      | Description                                       |
 | ----------------- | ------- | ------------ | ------------------------------------------------- |
 | source_type       | SourceType | **Required** | The source type, eg `gps` or `router`, of the device. |
-| latitude          | string  | **Required** | The latitude coordinate of the device.            |
-| longitude         | string  | **Required** | The longitude coordinate of the device.           |
+| latitude          | float  | **Required** | The latitude coordinate of the device.            |
+| longitude         | float  | **Required** | The longitude coordinate of the device.           |
 | battery_level     | integer | `None`       | The battery level of the device.                  |
 | location_accuracy | integer | `None`       | The location accuracy (m) of the device.          |
 | location_name     | string  | `None`       | The location name of the device.                  |


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

The current device_tracker entity documentation lists longitude and latitude Type as `string`. However, these properties are of `float` type. Returning these properties as strings results in a TypeError when developers don't define the location_name property.


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [x] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: [Relevant code](https://github.com/home-assistant/core/blob/be34fdc3447c75dc637a0aa5678122a80ae2e674/homeassistant/components/device_tracker/config_entry.py#L232-L240)
