### PR TITLE
Fix folded keep operator in yaml-style-guide.md

### DIFF
--- a/docs/documenting/yaml-style-guide.md
+++ b/docs/documenting/yaml-style-guide.md
@@ -202,7 +202,7 @@ In the examples above the no chomping operators are used (`|`, `>`). This is
 preferred, unless the example requires a different handling of the ending new
 line. In those cases the use of the strip operator (`|-`, `>-`: no trailing new
 line, any additional new lines are removed from the end) or keep operator
-(`|+`, `|-`: trailing new line, and keep all additional new lines from the end)
+(`|+`, `>+`: trailing new line, and keep all additional new lines from the end)
 is allowed.
 
 ### Additional string guidance


### PR DESCRIPTION
Where the keep operator is mentioned, it wrongly shows the folded strip operator instead of the folded keep operator.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Correct the folded keep operator.


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
