### PR TITLE
Update timezone requirements for calendar events

### DIFF
--- a/docs/core/entity/calendar.md
+++ b/docs/core/entity/calendar.md
@@ -48,6 +48,9 @@ A calendar entity can return events that occur during a particular time range. S
 - The `end_date` is the upper bound and applied to the event's `start` (exclusive).
 - Recurring events should be flattened and returned as individual `CalendarEvent`.
 
+The start and end datetime will always have a timezone, which the implementation should be use for
+determing the order of events e.g. the start of an all day event for comparison with other events.
+
 ```python
 class MyCalendar(CalendarEntity):
 
@@ -122,8 +125,8 @@ A `CalendarEvent` represents an individual event on a calendar.
 
 | Name        | Type             | Default      | Description                                                                                                                                     |
 | ----------- | ---------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| start       | datetime or date | **Required** | The start (inclusive) of the event. Must be before `end`. Both `start` and `end` must be the same type. As a datetime, must be in UTC timezone. |
-| end         | datetime or date | **Required** | The end (exclusive) of the event. Must be after `start`. As a datetime, must be in UTC timezone.                                                |
+| start       | datetime or date | **Required** | The start (inclusive) of the event. Must be before `end`. Both `start` and `end` must be the same type. As a datetime, may have a timezone or be floating (which is interpreted as local timezone) |
+| end         | datetime or date | **Required** | The end (exclusive) of the event. Must be after `start`.                                                                                        |
 | summary     | string           | **Required** | A title or summary of the event.                                                                                                                |
 | location    | string           | `None`       | A geographic location of the event.                                                                                                             |
 | description | string           | `None`       | A detailed description of the event.                                                                                                            |


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Update timezone requirements for calendar events to be more flexible with respect to timezones. Previously the wording said it required UTC, which actually isn't true nor ideal.

A calendar event start datetime may be represented as UTC, in a particular timezone, or without a timezone and interpreted as floating -- and all of these are valid and useful.

Examples scenarios of where floating vs non-floating is useful:
- With local calendar, you can specify floating dates without a timezone. If you have a home routine schedule (e.g. dim lights at 9pm) then you move to another timezone, you don't need to adjust anything beside the system timezone.
- With cloud calendars, you may care about the specific timezone of the event if its somewhere else.

When putting events on a timeline (e.g. rendering in UI, triggers, etc) Home Assistant does need to assign a timezone for which to evaluate events e.g. determining the start time of an all day event must happen in some timezone. This should not just be UTC, but instead by the timezone of the system so we have consistent ordering for the local time.

Alternative: We could have different rules for event creation vs event return, but i think it would be unnecessary work for integrations.

Aside: I may move some call sites away from always using UTC to see if it helps address https://github.com/home-assistant/core/issues/80022

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue:
- Link to relevant existing code or pull request: 
