### PR TITLE
version number is now mandatory

### DIFF
--- a/docs/creating_integration_manifest.md
+++ b/docs/creating_integration_manifest.md
@@ -17,8 +17,9 @@ Every integration has a manifest file to specify basic information about an inte
   "codeowners": ["@balloob"],
   "requirements": ["aiohue==1.9.1"],
   "quality_scale": "platinum",
-  "iot_class": "local_polling"
-  "loggers": ["aiohue"]
+  "iot_class": "local_polling",
+  "loggers": ["aiohue"],
+  "version": "0.1.0"
 }
 ```
 
@@ -33,7 +34,8 @@ Or a minimal example that you can copy into your project:
   "dependencies": [],
   "codeowners": [],
   "requirements": [],
-  "iot_class": "cloud_polling"
+  "iot_class": "cloud_polling",
+  "version": "0.1.0"
 }
 ```
 


### PR DESCRIPTION
There were a few commas missing in the JSON objects. 

Also, the version number seems to be mandatory now. Could not find the corresponding changelog, but Integrations dont start up without it.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Reflect the mandatory version number in the minimal manifest configuration
-->


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information


- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
