### PR TITLE
Deprecated callback removed for MQTT subscribe

### DIFF
--- a/blog/2023-02-21-deprecated-callback-removed.md
+++ b/blog/2023-02-21-deprecated-callback-removed.md
@@ -1,0 +1,33 @@
+---
+author: Jan Bouwhuis
+authorURL: https://twitter.com/jbouwh
+title: Deprecated callback signatures for MQTT subscribe removed
+---
+
+Home Assistant's MQTT integration [no longer supports](https://github.com/home-assistant/core/pull/88543)
+deprecated callback signatures for MQTT subscribe.
+
+Integrations that still used a deprecated callback signature for the callback function on MQTT subscribe will break. An exception will be raised if a not supported callback type is detected.
+
+Examples of deprecated callback functions that will no longer work:
+
+```python
+async def async_deprecated_callback1(topic: str, payload: ReceivePayloadType, qos: int) -> None:
+    """Deprecated async callback example 1."""
+    ...
+
+
+@callback
+def async_deprecated_callback2(topic: str, payload: ReceivePayloadType, qos: int) -> None:
+    """Deprecated async callback example 2."""
+    ...
+```
+
+Example of a correct callback signature:
+
+```python
+@callback
+def async_correct_callback(msg: msg: ReceiveMessage) -> None:
+    """Callback example 1."""
+    ...
+```

--- a/blog/2023-02-21-deprecated-callback-removed.md
+++ b/blog/2023-02-21-deprecated-callback-removed.md
@@ -7,7 +7,7 @@ title: Deprecated callback signatures for MQTT subscribe removed
 Home Assistant's MQTT integration [no longer supports](https://github.com/home-assistant/core/pull/88543)
 deprecated callback signatures for MQTT subscribe.
 
-Integrations that still used a deprecated callback signature for the callback function on MQTT subscribe will break. An exception will be raised if a not supported callback type is detected.
+Custome integrations that still used the deprecated callback signature for the callback function on MQTT subscribe will break unless updated. An exception will be raised if a not supported callback type is detected.
 
 Examples of deprecated callback functions that will no longer work:
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
https://github.com/home-assistant/core/pull/88543 removes some deprecated callback signatures, The blog article explains this.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
