### PR TITLE
Fix typo in blog post on intent whitespace

### DIFF
--- a/blog/2023-02-03-responses.md
+++ b/blog/2023-02-03-responses.md
@@ -34,4 +34,4 @@ Response templates are in the [Jinja2 format](https://www.home-assistant.io/docs
 
 The second change comes from [hassil](https://github.com/home-assistant/hassil), the parser for our [intent template syntax](/docs/voice/intent-recognition/template-sentence-syntax/). In addition to an 8-10x speed-up in parsing, whitespace inside templates is taken literally.
 
-Previously, a template like `light(s | ing)` would match both "light" and "lighting". Now, "light" and "light ing" would be matched instead due to the extra space around `|`. The correct template would be `light(s|ing)`
+Previously, a template like `light(s | ing)` would match both "lights" and "lighting". Now, "light s" and "light ing" would be matched instead due to the extra space around `|`. The correct template would be `light(s|ing)`


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
There was a small typo in the blogpost describing whitespace changes for intent templates.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information

The example shows the before and after matching "light" and "light" when I believe it should be "lights" and "light s"
