### PR TITLE
Find ui after running dev environment

### DIFF
--- a/docs/development_environment.mdx
+++ b/docs/development_environment.mdx
@@ -46,7 +46,7 @@ When a task is currently running (like `Preview` for the docs), it can be restar
 
 ### Debugging with Visual Studio Code
 
-If the Dev Container was set up correctly - it supports debugging by default, out-of-the-box. It provides the necessary debug configurations, so hitting F5 should launch Home Assistant. Any breakpoints put in the code should be triggered, and the debugger should stop. 
+If the Dev Container was set up correctly - it supports debugging by default, out-of-the-box. It provides the necessary debug configurations, so hitting F5 should launch Home Assistant. Any breakpoints put in the code should be triggered, and the debugger should stop. If your dev instance started without issues, you should find the browser ui to the dev instance running on "localhost:8123".
 
 It is also possible to debug a remote Home Assistance instance (e.g., productive instance) by following the procedure described [here](https://www.home-assistant.io/integrations/debugpy/).
 


### PR DESCRIPTION
Added line to explain where dev instance ui is hosted after running dev environment.

