### PR TITLE
Update a deprecated value for "startup" option for Add-On

### DIFF
--- a/docs/add-ons/tutorial.md
+++ b/docs/add-ons/tutorial.md
@@ -150,7 +150,7 @@ arch:
   - armhf
   - armv7
   - i386
-startup: before
+startup: services
 ports:
   8000/tcp: 8000
 ```


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Fix an old value for `startup` option that is deprecated in one example of the Add-On tutorial.

The example is deprecated and gives this supervisor warning:
`Add-on config 'startup' with 'before' is deprecated. Please report this to the maintainer of Hello world`


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation
