### PR TITLE
Clarify the default behavior of  the signficant_changes_only parameter of REST history API

### DIFF
--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -207,7 +207,7 @@ You can pass the following optional GET parameters:
 - `end_time=<timestamp>` to choose the end of the period in URL encoded format (defaults to 1 day).
 - `minimal_response` to only return `last_changed` and `state` for states other than the first and last state (much faster).
 - `no_attributes` to skip returning attributes from the database (much faster).
-- `significant_changes_only` to only return significant state changes.
+- `significant_changes_only=0` to return all state changes (defaults to only returning significant states changes).
 
 Example without `minimal_response`
 


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
By default the REST history API only returns significant states changes.  This  actual behavior is the inverse of what the API documentation suggests, that it will only occur if  `significant_changes_only` is defined.  This appears to have been the default behavior ever since the feature was introduced in https://github.com/home-assistant/core/pull/33356/ . 

```
        significant_changes_only = (
            request.query.get("significant_changes_only", "1") != "0"
        )
```

Since this filter is enabled by default and nobody seems to have noticed for the past 3 years, it should be documented that `significant_changes_only=0` is what will disable it.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
