### PR TITLE
Document default_backup_mount in the /mount endpoint

### DIFF
--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -1748,14 +1748,16 @@ Returns information about mounts configured in Supervisor
 
 **Returned data:**
 
-| key              | type       | description                                        |
-| ---------------- | ---------- | -------------------------------------------------- |
-| mounts           | list       | A list of [Mounts](api/supervisor/models.md#mount) |
+| key                  | type           | description                                        |
+| -------------------- | -------------- | -------------------------------------------------- |
+| mounts               | list           | A list of [Mounts](api/supervisor/models.md#mount) |
+| default_backup_mount | string or null | Name of a backup mount or `null` for /backup       |
 
 **Example response:**
 
 ```json
 {
+  "default_backup_mount": "my_share",
   "mounts": [
     {
       "name": "my_share",


### PR DESCRIPTION
Updates the supervisor add-on API documentation to include the "default_backup_mount" key returned by the /mount endpoint.
I found that the endpoint returns this additional key which AFAICT isn't provided anywhere else.  I'm assuming its just an oversight and not intended to be undocumented.
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Document what values to expect from the /mount endpoint.


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->
