### PR TITLE
Add a developer blog post for upcoming service API changes

### DIFF
--- a/blog/2023-06-14-service-calls.md
+++ b/blog/2023-06-14-service-calls.md
@@ -6,6 +6,9 @@ title: "Service Call API changes"
 
 This change affects Service Call APIs: `hass.services.async_call` and `hass.services.call`.
 
-For Home Assistant Core 2023.7 the return values for service calls have been changed to better
-support [Service return values](https://github.com/home-assistant/architecture/discussions/777#discussioncomment-6127898). The behavior has been updated to raise raise an
-`asyncio.TimeoutError` on timeout and the return value is no longer a boolean.
+For Home Assistant Core 2023.7 some input arguments and the return values for service calls have
+been changed to prepare to better support [Service return values](https://github.com/home-assistant/architecture/discussions/777#discussioncomment-6127898). 
+
+Previously, the return value of `True` on success and `False` if a timeout occurred. The `limit`
+argument that sets a timeout has been removed, and the boolean return value has been removed.
+Callers that would like a timeout should now set their own using asyncio.

--- a/blog/2023-06-14-service-calls.md
+++ b/blog/2023-06-14-service-calls.md
@@ -1,0 +1,11 @@
+---
+author: Allen Porter
+authorURL: https://github.com/allenporter
+title: "Service Call API changes"
+---
+
+This change affects Service Call APIs: `hass.services.async_call` and `hass.services.call`.
+
+For Home Assistant Core 2023.7 the return values for service calls have been changed to better
+support [Service return values](https://github.com/home-assistant/architecture/discussions/777#discussioncomment-6127898). The behavior has been updated to raise raise an
+`asyncio.TimeoutError` on timeout and the return value is no longer a boolean.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Add a developer blog post for upcoming service API changes that remove the limit from service calls and change the return value.

We can either merge this incrementally, or add more as we change the API more (including service response data).

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [X] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/94657
