### PR TITLE
Remove unimplemented error property from vacuum documentation

### DIFF
--- a/docs/core/entity/vacuum.md
+++ b/docs/core/entity/vacuum.md
@@ -19,7 +19,6 @@ Properties should always only return information from memory and not do I/O (lik
 | ---- | ---- | ------- | -----------
 | battery_icon | string | function | Battery icon to show in UI.
 | battery_level | int | `none` | Current battery level.
-| error | string | **Required** with `STATE_ERROR` | An error message if the vacuum is in `STATE_ERROR`.
 | fan_speed | string | `none` | The current fan speed.
 | fan_speed_list | list | `NotImplementedError()`| List of available fan speeds.
 | name | string | **Required** | Name of the entity.
@@ -34,7 +33,7 @@ Properties should always only return information from memory and not do I/O (lik
 | `STATE_IDLE` | The vacuum is not paused, not docked and does not have any errors.
 | `STATE_PAUSED` | The vacuum was cleaning but was paused without returning to the dock.
 | `STATE_RETURNING` | The vacuum is done cleaning and is currently returning to the dock, but not yet docked.
-| `STATE_ERROR` | The vacuum encountered an error while cleaning, the error can be specified as a property on the entity.
+| `STATE_ERROR` | The vacuum encountered an error while cleaning.
 
 ## Supported Features
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Remove unimplemented `error` property from `vacuum` documentation

According to the documentation, there's an `error` property which must be set when the vacuum is in state `error. It's however not implemented by the `vacuum` entity integration and there's no special support for it in frontend.

Out of the 6 core integrations which support the `error` state, 3 integrations (`ecovacs`, `sharkiq`, `xiaomi_mioo`) set an `error` state attribute themselves by implementing an `extra_state_attributes` method.

An alternative to this PR would be to add the `error` property to the `vacuum` base class.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
