### PR TITLE
Update creating_integration_manifest.md

### DIFF
--- a/docs/creating_integration_manifest.md
+++ b/docs/creating_integration_manifest.md
@@ -163,7 +163,7 @@ If your integration supports discovery via bluetooth, you can add a matcher to y
 
 Matches for `local_name` must be at least three (3) characters long and may not contain any patterns in the first three (3) characters.
 
-If the device only needs advertisement data, setting `connectable` to `false` will opt-in to receive discovery from Bluetooth controllers that do not have support for making connections such as remote ESPHome devices.
+If the device only needs advertisement data, setting `connectable` to `false` will opt-in to receive discovery from Bluetooth controllers that do not have support for making connections.
 
 The following example will match Nespresso Prodigio machines:
 


### PR DESCRIPTION
## Proposed change
Remote ESPHome devices using Bluetooth Proxy now support up to 3 active connections: https://esphome.io/components/bluetooth_proxy.html

I'm not sure if this documentation was referring to vanilla ESPHome devices or ESPHome devices running Bluetooth Proxy given Bluetooth Proxy used to not support active connections. Regardless, it might be confusing to have that reference removed.

## Type of change
- [] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
none

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
