### PR TITLE
Fix spelling mistake in development_environment.mdx

### DIFF
--- a/docs/development_environment.mdx
+++ b/docs/development_environment.mdx
@@ -48,7 +48,7 @@ When a task is currently running (like `Preview` for the docs), it can be restar
 
 If the Dev Container was set up correctly - it supports debugging by default, out-of-the-box. It provides the necessary debug configurations, so hitting F5 should launch Home Assistant. Any breakpoints put in the code should be triggered, and the debugger should stop. 
 
-It is also possible to debug a remote Home Assistance instance (e.g., productive instance) by following the procedure described [here](https://www.home-assistant.io/integrations/debugpy/).
+It is also possible to debug a remote Home Assistance instance (e.g., production instance) by following the procedure described [here](https://www.home-assistant.io/integrations/debugpy/).
 
 ## Manual Environment
 


### PR DESCRIPTION
## Proposed change
Assuming this was meant to reference "production" and not "productive"

## Type of change
- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
none

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
