### PR TITLE
Ensure tasks are done before progressing a progress config flow

### DIFF
--- a/docs/data_entry_flow_index.md
+++ b/docs/data_entry_flow_index.md
@@ -425,15 +425,20 @@ class TestFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_user(self, user_input=None):
-        if not self.task_one or not self.task_two:
-            if not self.task_one:
-                task = asyncio.sleep(10)
-                self.task_one = self.hass.async_create_task(self._async_do_task(task))
-                progress_action = "task_one"
-            else:
-                task = asyncio.sleep(10)
-                self.task_two = self.hass.async_create_task(self._async_do_task(task))
-                progress_action = "task_two"
+        if not self.task_one:
+            task = asyncio.sleep(10)
+            self.task_one = self.hass.async_create_task(self._async_do_task(task))
+            progress_action = "task_one"
+        elif not self.task_one.done():
+            progress_action = "task_one"
+        elif not self.task_two:
+            task = asyncio.sleep(10)
+            self.task_two = self.hass.async_create_task(self._async_do_task(task))
+            progress_action = "task_two"
+        elif not self.task_two.done():
+            progress_action = "task_two"
+
+        if not self.task_two or not self.task_two.done():
             return self.async_show_progress(
                 step_id="user",
                 progress_action=progress_action,


### PR DESCRIPTION
## Proposed change
The documentation states "The frontend will update each time we call show progress or show progress done.". This means that the frontend will refresh the config flow. When you don't guard against a task being done, it progresses to the next task(s) before the task is done. 

Some more in depth analysis can be found in https://github.com/home-assistant/core/issues/95749

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/issues/95749
