### PR TITLE
Add blog post about use of cached_property in Entity

### DIFF
--- a/blog/2023-09-14-entity_cached_property.md
+++ b/blog/2023-09-14-entity_cached_property.md
@@ -8,4 +8,4 @@ The `Entity` base class now caches `device_class` and `attribution` using the py
 
 If your custom integration defines `device_class` or `attribution` using a `@property`, it should switch to using `@cached_property` instead unless these values can change at run time. Integrations should avoid changing `device_class` at run time since anything that consumes the state may be unable to handle the `device_class` unexpectedly changing.
 
-The `@cached_property` decorator should be imported from `homeassistant.backports.functools` since the built-in `@cached_property` contains undocumented locking functionality that is not desirable and has been removed in cpython 3.12 and later. For more information, see [cached_property](https://docs.python.org/3.12/library/functools.html#functools.cached_property)
+The `@cached_property` decorator should be imported from `homeassistant.backports.functools` since the built-in `@cached_property` contains undocumented locking functionality that is not desirable and has been removed in cpython 3.12. For more information, see [cached_property](https://docs.python.org/3.12/library/functools.html#functools.cached_property)

--- a/blog/2023-09-14-entity_cached_property.md
+++ b/blog/2023-09-14-entity_cached_property.md
@@ -4,7 +4,7 @@ authorURL: https://github.com/bdraco
 title: Entities with dynamic `device_class` or `attribution`
 ---
 
-The `Entity` base class now caches `device_class` and `attribution` using the python `@cached_property` decorator. The cache allows Home Assistant to avoid recalculating the device class and attribution each time the state for the entity is written to the state machine since these values are rarely if ever, expected to change.
+The `Entity` base class now caches `device_class` and `attribution` using the python `@cached_property` decorator. The cache allows Home Assistant to avoid recalculating the device class and attribution each time the state for the entity is written to the state machine since these values are not normally expected to change.
 
 If your custom integration defines `device_class` or `attribution` using a `@property`, it should switch to using `@cached_property` instead unless these values can change at run time. Integrations should avoid changing `device_class` at run time since anything that consumes the state may be unable to handle the `device_class` unexpectedly changing.
 

--- a/blog/2023-09-14-entity_cached_property.md
+++ b/blog/2023-09-14-entity_cached_property.md
@@ -4,7 +4,7 @@ authorURL: https://github.com/bdraco
 title: Entities with dynamic `device_class` or `attribution`
 ---
 
-The `Entity` base class now caches `device_class` and `attribution` using the python `@cached_property` decorator. The cache allows Home Assistant to avoid recalculating the device class and attribution each time the state for the entity is written to the state machine since these values are not normally expected to change.
+The `Entity` base class now caches `device_class` and `attribution` using the `@cached_property` decorator. The cache allows Home Assistant to avoid recalculating the device class and attribution each time the state for the entity is written to the state machine since these values are not normally expected to change.
 
 If your custom integration defines `device_class` or `attribution` using a `@property`, it should switch to using `@cached_property` instead unless these values can change at run time. Integrations should avoid changing `device_class` at run time since anything that consumes the state may be unable to handle the `device_class` unexpectedly changing.
 

--- a/blog/2023-09-14-entity_cached_property.md
+++ b/blog/2023-09-14-entity_cached_property.md
@@ -1,0 +1,11 @@
+---
+author: J. Nick Koston
+authorURL: https://github.com/bdraco
+title: Entities with dynamic `device_class` or `attribution``
+---
+
+The `Entity` base class now caches `device_class` and `attribution` using the python `@cached_property` decorator. The cache allows Home Assistant to avoid recalculating the device class and attribution each time the state for the entity is written to the state machine since these values are rarely if ever, expected to change.
+
+If your custom integration defines `device_class` or `attribution` using a `@property`, it should switch to using `@cached_property` instead unless these values can change at run time. Integrations should avoid changing `device_class` at run time since anything that consumes the state may be unable to handle the `device_class` unexpectedly changing.
+
+The `@cached_property` decorator should be imported from `homeassistant.backports.functools` since the built-in `@cached_property` contains undocumented locking functionality that is not desirable and has been removed in cpython 3.12 and later. For more information, see [cached_property](https://docs.python.org/3.12/library/functools.html#functools.cached_property)

--- a/blog/2023-09-14-entity_cached_property.md
+++ b/blog/2023-09-14-entity_cached_property.md
@@ -1,7 +1,7 @@
 ---
 author: J. Nick Koston
 authorURL: https://github.com/bdraco
-title: Entities with dynamic `device_class` or `attribution``
+title: Entities with dynamic `device_class` or `attribution`
 ---
 
 The `Entity` base class now caches `device_class` and `attribution` using the python `@cached_property` decorator. The cache allows Home Assistant to avoid recalculating the device class and attribution each time the state for the entity is written to the state machine since these values are rarely if ever, expected to change.


### PR DESCRIPTION

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Add blog post about use of cached_property in Entity

Note `translation_key` is not documented since there was no core usage outside of `entity.py` and it would likely be noise given how new it is.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/95315
