### PR TITLE
Add library testing doc

### DIFF
--- a/docs/api_lib_testing.md
+++ b/docs/api_lib_testing.md
@@ -1,0 +1,70 @@
+---
+title: "Python library: Testing in Home Assistant"
+sidebar_label: Testing in Home Assistant
+---
+
+This guide explains how to run Home Assistant using an unsupported version of an external library. This is primarily intended for testing how the new version behaves in Home Assistant without having a full Home Assistant development environment.
+
+This guide is not intended for integration developers. If you are doing integration development, you should follow the integration development workflow and [specify the library in the integration manifest](creating_integration_manifest#custom-requirements-during-development--testing).
+
+## Where to test
+
+It is recommended to create a new, disposable Home Assistant installation by following the [installation guide](https://www.home-assistant.io/installation/). The quickest and easiest method is to install Home Assistant Container.
+
+However, in some cases, you may need to or want to test using an existing Home Assistant installation. When using an existing Home Assistant installation:
+
+- You don't need to make another installation of Home Assistant.
+- Everything is already configured.
+- You will need to restart this Home Assistant instance when making changes, which may cause downtimes for automations, gaps in logs, etc.
+- Testing with different libraries is unsupported and can lead to Home Assistant instability that the Home Assistant developers will not be able to help you with.
+- If you don't clean up after you're done, you will continue running the same version of the library even if Home Assistant includes an updated version of the library, which may cause the integration to break.
+
+## Obtaining access
+
+### Home Assistant Operating System
+
+If you have a monitor and keyboard or a serial console that can be connected to the device or virtual machine, you can log in there using the username "root" and no password. If not, you can use either the [developer SSH](operating-system/debugging) or the community [Advanced SSH & Web Terminal](https://my.home-assistant.io/redirect/supervisor_addon/?addon=a0d7b954_ssh) add-on with "Protection mode" turned off. The standard [SSH](https://my.home-assistant.io/redirect/supervisor_addon/?addon=core_ssh) add-on does not provide access to the Home Assistant Container environment.
+
+Once you have shell access, type `docker exec -it homeassistant /bin/bash` to get into the Home Assistant Container environment.
+
+You may want to turn this level of remote access back off later.
+
+:::note
+It is usually possible to create the expected file structure and copy it into the configuration directory using the [Samba](https://my.home-assistant.io/redirect/supervisor_addon/?addon=core_samba) add-on. However, this is more difficult to explain and can be difficult to troubleshoot.
+:::
+
+### Home Assistant Supervised
+
+Type `docker exec -it homeassistant /bin/bash` to get into the Home Assistant Container environment.
+
+### Home Assistant Container
+
+If you are running the container in Docker, type `docker exec -it homeassistant /bin/bash` to get into the Home Assistant Container environment. If you're using a different container runtime or gave the container a different name, you will need to alter the command accordingly.
+
+### Home Assistant Core
+
+If Home Assistant Core was installed following the official installation instructions, run the following commands to set up your environment:
+
+```shell
+sudo -u homeassistant -H -s
+source /srv/homeassistant/bin/activate
+cd ~/.homeassistant
+```
+
+## Installing libraries
+
+After following the above steps, you should now have a command prompt inside your Home Assistant configuration directory.
+
+If you just want to install a different version of a library, you can use `pip3 install -I --prefix deps <your-library>==<version>` to install the library into the appropriate location in your config folder. It's possible to install unreleased versions by using Git commits: `pip3 install -I --prefix deps git+https://github.com/<user>/<repo>.git@<commit|branch|tag>`. Restart Home Assistant for the changes to take effect.
+
+:::note
+If the library contains unmanaged code and compatible wheels are not available, installation will likely fail because Home Assistant does not come with compilers and development packages. Cross-compiling a compatible wheel is outside the scope of this document.
+:::
+
+Home Assistant will look for libraries in this directory first, before it looks for libraries in the usual places, and this directory is not reset when restarting or upgrading Home Assistant.
+
+You can uninstall the library and its dependencies by deleting them from your config directory. It will be somewhere like `deps/lib/python<version>/site-packages`.
+
+:::caution
+Remember to uninstall the library and its later. If you do not uninstall the library, eventually the version in your config directory will be older than the version in Home Assistant. The older version will continue to be used, and this will likely cause unexpected problems.
+:::

--- a/sidebars.js
+++ b/sidebars.js
@@ -272,7 +272,12 @@ module.exports = {
     {
       type: "category",
       label: "Building a Python library",
-      items: ["api_lib_index", "api_lib_auth", "api_lib_data_models"],
+      items: [
+        "api_lib_index",
+        "api_lib_auth",
+        "api_lib_data_models",
+        "api_lib_testing",
+      ],
     },
     {
       type: "category",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This PR adds documentation about how to replace an included library with a different one. This is useful for external library developers who are not Home Assistant developers. For example, if somebody wants to add a new device type to a library, they can fork the library, add the new device, and then use these instructions to cause Home Assistant to load the forked version to verify that the new device is functioning as expected.

Because of a problem with the way the Lutron Caséta library and integration work, if somebody buys a device that isn't supported, often all they need to do is add the appropriate string into the appropriate dictionary and make sure the device works as expected. Usually they are Home Assistant users and don't have a way to verify their changes without loading their modified library into Home Assistant. It's probably similar for other libraries.

I tried not to make it sound like a recommended thing to do for daily driving new libraries because that's something I've done before and run into problems later because I forgot to undo it.

The alternate method that doesn't require running Python commands in the Home Assistant environment, and therefore doesn't require special access on Home Assistant Operating System, is fairly straightforward for pure Python libraries. However, you need to know what version of Python Home Assistant is using so you can create the correct library path, and if the library has native code then it starts getting complicated, especially for Home Assistant OS users, to collect the correct files. If somebody gets it wrong and puts x86_64 glibc libraries from their PC into their Home Assistant Container or Home Assistant OS config directory, the errors probably aren't going to be very helpful. If it's a user making a simple change like adding a string to a list, they may not know whether the library contains native code or not. Installing from the shell seems like it has the highest chance of success or at least knowing why it doesn't work.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/blob/6d1876394ef9eceee38c2cf9082f45d37218be07/homeassistant/bootstrap.py#L456-L464
