### PR TITLE
Add fedora dependency install command (Dnf)

### DIFF
--- a/docs/development_environment.mdx
+++ b/docs/development_environment.mdx
@@ -69,9 +69,14 @@ It is also possible to set up a more traditional development environment. See th
 
 Install the core dependencies.
 
+Ubuntu:
 ```shell
 sudo apt-get update
 sudo apt-get install python3-pip python3-dev python3-venv autoconf libssl-dev libxml2-dev libxslt1-dev libjpeg-dev libffi-dev libudev-dev zlib1g-dev pkg-config libavformat-dev libavcodec-dev libavdevice-dev libavutil-dev libswscale-dev libavresample-dev libavfilter-dev ffmpeg
+```
+Fedora:
+```shell
+sudo dnf install python3-pip python3-devel autoconf libssl-devel libxml2-devel libjpeg-devel libffi-devel pkg-config libavresample-free-devel libavformat-free-devel libavdevice-free-devel ffmpeg-free cmake make
 ```
 
 ### Developing on Windows


### PR DESCRIPTION
## Proposed change
Add command to install dependencies in fedora (using dnf)
(relevant since testing page already contains this command for fedora: https://developers.home-assistant.io/docs/development_testing/ )


## Type of change

- [X] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information


- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
