### PR TITLE
Update development_environment.mdx to fix broken dependency #1353

### DIFF
--- a/docs/development_environment.mdx
+++ b/docs/development_environment.mdx
@@ -93,7 +93,7 @@ Install the core dependencies.
 
 ```shell
 sudo apt-get update
-sudo apt-get install python3-pip python3-dev python3-venv autoconf libssl-dev libxml2-dev libxslt1-dev libjpeg-dev libffi-dev libudev-dev zlib1g-dev pkg-config libavformat-dev libavcodec-dev libavdevice-dev libavutil-dev libswscale-dev libavresample-dev libavfilter-dev ffmpeg
+sudo apt-get install python3-pip python3-dev python3-venv autoconf libssl-dev libxml2-dev libxslt1-dev libjpeg-dev libffi-dev libudev-dev zlib1g-dev pkg-config libavformat-dev libavcodec-dev libavdevice-dev libavutil-dev libswscale-dev libswresample-dev libavfilter-dev ffmpeg
 ```
 
 ### Developing on Windows


### PR DESCRIPTION
Updating libavresample-dev to libswresample-dev as per

https://github.com/home-assistant/developers.home-assistant/issues/1353

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Replace broken dependency when setting up development environment


## Type of change
- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
- This PR fixes or closes issue: fixes #1353
- Link to relevant existing code or pull request: 
