### PR TITLE
Make device tracker latitude and longitude optional

### DIFF
--- a/docs/core/entity/device-tracker.md
+++ b/docs/core/entity/device-tracker.md
@@ -38,7 +38,7 @@ DHCP discover packets to find existing devices.
 
 ## TrackerEntity
 
-A TrackerEntity tracks the location of a device and reports it either as a location name, a zone name or `home` or `not_home` states. A TrackerEntity normally receives GPS coordinates to determine its state.
+A TrackerEntity tracks the location of a device and reports it either as a location name, a zone name or `home` or `not_home` states. A TrackerEntity normally receives GPS coordinates to determine its state. Either `location_name` or `latitude` and `longitude` should be set to report state.
 
 Derive a platform entity from [`homeassistant.components.device_tracker.config_entry.TrackerEntity`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/device_tracker/config_entry.py)
 
@@ -55,8 +55,8 @@ TrackerEntity does not support attribute shorthand for [property implementation]
 | Name              | Type                           | Default      | Description                                           |
 | ----------------- | ------------------------------ | ------------ | ----------------------------------------------------- |
 | battery_level     | <code>int &#124; None</code>   | `None`       | The battery level of the device.                      |
-| latitude          | <code>float &#124; None</code> | **Required** | The latitude coordinate of the device.                |
+| latitude          | <code>float &#124; None</code> | `None`       | The latitude coordinate of the device.                |
 | location_accuracy | `int`                          | `0`          | The location accuracy (m) of the device.              |
 | location_name     | <code>str &#124; None</code>   | `None`       | The location name of the device.                      |
-| longitude         | <code>float &#124; None</code> | **Required** | The longitude coordinate of the device.               |
+| longitude         | <code>float &#124; None</code> | `None`       | The longitude coordinate of the device.               |
 | source_type       | SourceType                     | **Required** | The source type, eg `gps` or `router`, of the device. |


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
- The device tracker latitude and longitude have been made optional.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/108838
