### PR TITLE
Document read_only option for mounts

### DIFF
--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -1851,7 +1851,8 @@ Returns information about mounts configured in Supervisor
       "type": "cifs",
       "server": "server.local",
       "share": "media",
-      "state": "active"
+      "state": "active",
+      "read_only": false
     }
   ]
 }
@@ -1892,7 +1893,8 @@ Value in `name` must be unique and can only consist of letters, numbers and unde
   "server": "server.local",
   "share": "media",
   "username": "admin",
-  "password": "password"
+  "password": "password",
+  "read_only": false
 }
 ```
 
@@ -1915,7 +1917,8 @@ name, it cannot be changed. Delete and re-add the mount to change the name.
   "usage": "media",
   "type": "nfs",
   "server": "server.local",
-  "path": "/media/camera"
+  "path": "/media/camera",
+  "read_only": true
 }
 ```
 

--- a/docs/api/supervisor/models.md
+++ b/docs/api/supervisor/models.md
@@ -275,9 +275,10 @@ The `content` key of a backup object contains the following keys:
 | ---------- | -------------- | ---------------------------------------------------------------------- | ---------------- |
 | name       | string         | Name of the mount                                                      | both             |
 | type       | string         | Type of the mount (cifs or nfs)                                        | both             |
-| usage      | string         | Usage of the mount (backup, media, or share)                            | both             |
+| usage      | string         | Usage of the mount (backup, media, or share)                           | both             |
 | server     | string         | IP address or hostname of the network share server                     | both             |
 | port       | int            | Port to use (if not using the standard one for the mount type)         | both             |
+| read_only  | bool           | Mount is read-only (not available for backup mounts)                   | both             |
 | path       | string         | (nfs mounts only) Path to mount from the network share                 | both             |
 | share      | string         | (cifs mounts only) Share to mount from the network share               | both             |
 | username   | string         | (cifs mounts only) Username to use for authentication                  | request only     |


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Document option to make a read only mount for share or media usage added in https://github.com/home-assistant/supervisor/pull/4872


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/supervisor/pull/4872
