### PR TITLE
Add new `single_config_entry` manifest option

### DIFF
--- a/blog/2024-02-11-single-instance-only-manifest-option.md
+++ b/blog/2024-02-11-single-instance-only-manifest-option.md
@@ -5,7 +5,7 @@ authorImageURL: https://avatars.githubusercontent.com/u/3989428?s=96&v=4
 title: "New single instance only manifest option"
 ---
 
-In Home Assistant 2024.2, we introduced a new `single_instance_only` option for the integration manifest file.
+In Home Assistant 2024.3, we introduced a new `single_instance_only` option for the integration manifest file.
 This option allows you to say that your integration supports only one config entry.
 
 Home Assistant will take care and prevent the initialization of a config flow if there is already a config entry for the integration.

--- a/blog/2024-02-11-single-instance-only-manifest-option.md
+++ b/blog/2024-02-11-single-instance-only-manifest-option.md
@@ -5,7 +5,7 @@ authorImageURL: https://avatars.githubusercontent.com/u/3989428?s=96&v=4
 title: "New single instance only manifest option"
 ---
 
-In Home Assistant 2024.3, we introduced a new `single_instance_only` option for the integration manifest file.
+In Home Assistant 2024.3, we introduced a new `single_config_entry` option for the integration manifest file.
 This option allows you to say that your integration supports only one config entry.
 
 Home Assistant will take care and prevent the initialization of a config flow if there is already a config entry for the integration.

--- a/blog/2024-02-11-single-instance-only-manifest-option.md
+++ b/blog/2024-02-11-single-instance-only-manifest-option.md
@@ -1,0 +1,14 @@
+---
+author: Jan-Philipp Benecke
+authorURL: https://github.com/jpbede
+authorImageURL: https://avatars.githubusercontent.com/u/3989428?s=96&v=4
+title: "New single instance only manifest option"
+---
+
+In Home Assistant 2024.2, we introduced a new `single_instance_only` option for the integration manifest file.
+This option allows you to say that your integration supports only one config entry.
+
+Home Assistant will take care and prevent the initialization of a config flow if there is already a config entry for the integration.
+This way you won't have to implement the check in the config flow.
+
+Integrations that have this option not set and do the check in the config flow should replace it with the new option.

--- a/blog/2024-02-26-single-instance-only-manifest-option.md
+++ b/blog/2024-02-26-single-instance-only-manifest-option.md
@@ -6,9 +6,9 @@ title: "New single instance only manifest option"
 ---
 
 In Home Assistant 2024.3, we introduced a new `single_config_entry` option for the integration manifest file.
-This option allows you to say that your integration supports only one config entry.
+This option allows you to set that your integration supports only one config entry.
 
 Home Assistant will take care and prevent the initialization of a config flow if there is already a config entry for the integration.
-This way you won't have to implement the check in the config flow.
+This way you won't have to implement any check in the config flow.
 
-Integrations that have this option not set and do the check in the config flow should replace it with the new option.
+Integrations that have this option not set in their manifest and do the check in the config flow should replace it with the new option.

--- a/docs/creating_integration_manifest.md
+++ b/docs/creating_integration_manifest.md
@@ -118,7 +118,7 @@ Specify the `config_flow` key if your integration has a config flow to create a 
 
 ### Single config entry only
 
-Specify the `single_config_entry` key if your integration supports only one config entry. When specified, the frontend will not allow the user to add more than one config entry for this integration.
+Specify the `single_config_entry` key if your integration supports only one config entry. When specified, it will not allow the user to add more than one config entry for this integration.
 
 ```json
 {

--- a/docs/creating_integration_manifest.md
+++ b/docs/creating_integration_manifest.md
@@ -116,13 +116,13 @@ Specify the `config_flow` key if your integration has a config flow to create a 
 }
 ```
 
-### Single instance only
+### Single config entry only
 
-Specify the `single_instance_only` key if your integration supports only one config entry. When specified, the frontend will not allow the user to add more than one config entry for this integration.
+Specify the `single_config_entry` key if your integration supports only one config entry. When specified, the frontend will not allow the user to add more than one config entry for this integration.
 
 ```json
 {
-  "single_instance_only": true
+  "single_config_entry": true
 }
 ```
 

--- a/docs/creating_integration_manifest.md
+++ b/docs/creating_integration_manifest.md
@@ -116,6 +116,16 @@ Specify the `config_flow` key if your integration has a config flow to create a 
 }
 ```
 
+### Single instance only
+
+Specify the `single_instance_only` key if your integration supports only one config entry. When specified, the frontend will not allow the user to add more than one config entry for this integration.
+
+```json
+{
+  "single_instance_only": true
+}
+```
+
 ## Requirements
 
 Requirements are Python libraries or modules that you would normally install using `pip` for your component. Home Assistant will try to install the requirements into the `deps` subdirectory of the Home Assistant [configuration directory](https://www.home-assistant.io/docs/configuration/) if you are not using a `venv` or in something like `path/to/venv/lib/python3.6/site-packages` if you are running in a virtual environment. This will make sure that all requirements are present at startup. If steps fail, like missing packages for the compilation of a module or other install errors, the component will fail to load.


### PR DESCRIPTION
## Proposed change
Add the `single_config_entry` manifest option, so signal that only one config entry is supported (https://github.com/home-assistant/core/pull/109505)

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/109505
