### PR TITLE
Add dev blog about deprecating `@bind_hass` and `hass.components`

### DIFF
--- a/blog/2024-02-27-deprecate-bind-hass-and-hass-components.md
+++ b/blog/2024-02-27-deprecate-bind-hass-and-hass-components.md
@@ -6,7 +6,7 @@ title: "Deprecate use of @bind_hass and hass.components"
 ---
 
 As of Home Assistant 2024.3, we deprecate the use of the `@bind_hass` decorator 
-and thus also the use of `hass.components`.
+and thus also the use of `hass.components`. A warning will be logged if used.
 
 Starting from Home Assistant 2024.9, the `@bind_hass` decorator and 
 `hass.components` will be removed and will no longer work.

--- a/blog/2024-02-27-deprecate-bind-hass-and-hass-components.md
+++ b/blog/2024-02-27-deprecate-bind-hass-and-hass-components.md
@@ -1,0 +1,88 @@
+---
+author: Jan-Philipp Benecke
+authorURL: https://github.com/jpbede
+authorImageURL: https://avatars.githubusercontent.com/u/3989428?s=96&v=4
+title: "Deprecate use of @bind_hass and hass.components"
+---
+
+As of Home Assistant 2024.3, we deprecate the use of the `@bind_hass` decorator 
+and thus also the use of `hass.components`.
+
+Starting from Home Assistant 2024.9, the `@bind_hass` decorator and 
+`hass.components` will be removed and will no longer work.
+
+## Use of `@bind_hass` decorator
+
+Integrations that use the `@bind_hass` decorator should be updated to remove them and pass the `hass` object as first parameter to the function instead:
+
+### New example
+
+```python
+from homeassistant.core import HomeAssistant
+from homeassistant.components.persistent_notification import async_create
+
+def create_notification(hass: HomeAssistant, message: str):
+    """Create a notification."""
+    async_create(
+        hass,
+        message, 
+        title='Important notification'
+    )
+
+async def async_setup(hass: HomeAssistant, config):
+    """Set up the component."""
+    create_notification(hass, "You're already using the latest version!")
+```
+
+### Old example
+
+```python
+from homeassistant.core import HomeAssistant
+from homeassistant.loader import bind_hass
+from homeassistant.components.persistent_notification import async_create
+
+@bind_hass
+def create_notification(hass: HomeAssistant, message: str):
+    """Create a notification."""
+    async_create(
+        hass,
+        message, 
+        title='Important notification'
+    )
+
+async def async_setup(hass: HomeAssistant, config):
+    """Set up the component."""
+    create_notification("You're already using the latest version!")
+```
+
+## Use of `hass.components` 
+
+Integrations that use `hass.components` should be updated to import the functions and classes directly from the integration package and pass the `hass` object as first parameter:
+
+### New example
+
+```python
+from homeassistant.core import HomeAssistant
+from homeassistant.components.persistent_notification import async_create
+
+async def async_setup(hass: HomeAssistant, config):
+    """Set up the component."""
+    async_create(
+        hass, 
+        "You're already using the latest version!", 
+        title='Important notification'
+    )
+```
+
+### Old example
+
+```python
+from homeassistant.core import HomeAssistant
+
+async def async_setup(hass: HomeAssistant, config):
+    """Set up the component."""
+    hass.components.persistent_notification.async_create(
+        "You're already using the latest version!", 
+        title='Important notification'
+    )
+```

--- a/blog/2024-02-27-deprecate-bind-hass-and-hass-components.md
+++ b/blog/2024-02-27-deprecate-bind-hass-and-hass-components.md
@@ -10,7 +10,7 @@ and thus also the use of `hass.components`.
 With the release of Home Assistant 2024.3, we are starting to adjust and remove usage in Home Assistant Core.
 Authors of custom integrations will need to adjust their code to avoid breakage.
 
-Starting from Home Assistant 2024.9, the `@bind_hass` decorator and 
+Starting from Home Assistant 2024.6, the `@bind_hass` decorator and 
 `hass.components` will be removed and will no longer work.
 
 ## Use of `@bind_hass` decorator

--- a/blog/2024-02-27-deprecate-bind-hass-and-hass-components.md
+++ b/blog/2024-02-27-deprecate-bind-hass-and-hass-components.md
@@ -9,7 +9,7 @@ As of Home Assistant 2024.3, we deprecate the use of the `@bind_hass` decorator
 and thus also the use of `hass.components`.
 Using `hass.components` will issue a warning in the logs.
 Authors of custom integrations are encouraged to update their code 
-by now to prevent any issues with Home Assistant 2024.9.
+to prevent any issues before Home Assistant 2024.9.
 
 Starting from Home Assistant 2024.9, the `@bind_hass` decorator and 
 `hass.components` will be removed and will no longer work.

--- a/blog/2024-02-27-deprecate-bind-hass-and-hass-components.md
+++ b/blog/2024-02-27-deprecate-bind-hass-and-hass-components.md
@@ -59,7 +59,9 @@ async def async_setup(hass: HomeAssistant, config):
 
 ## Use of `hass.components` 
 
-Integrations that use `hass.components` should be updated to import the functions and classes directly from the integration package and pass the `hass` object as first parameter:
+Integrations that use `hass.components` should be updated to import the functions and classes directly
+from the integration package and pass the `hass` object as first parameter.
+Remember to include the imported components under `dependencies` in your `manifest.json`.
 
 ### New example
 

--- a/blog/2024-02-27-deprecate-bind-hass-and-hass-components.md
+++ b/blog/2024-02-27-deprecate-bind-hass-and-hass-components.md
@@ -7,8 +7,9 @@ title: "Deprecate use of @bind_hass and hass.components"
 
 As of Home Assistant 2024.3, we deprecate the use of the `@bind_hass` decorator 
 and thus also the use of `hass.components`.
-With the release of Home Assistant 2024.3, we are starting to adjust and remove usage in Home Assistant Core.
-Authors of custom integrations will need to adjust their code to avoid breakage.
+Using `hass.components` will issue a warning in the logs.
+Authors of custom integrations are encouraged to update their code 
+by now to prevent any issues with Home Assistant 2024.9.
 
 Starting from Home Assistant 2024.9, the `@bind_hass` decorator and 
 `hass.components` will be removed and will no longer work.

--- a/blog/2024-02-27-deprecate-bind-hass-and-hass-components.md
+++ b/blog/2024-02-27-deprecate-bind-hass-and-hass-components.md
@@ -10,7 +10,7 @@ and thus also the use of `hass.components`.
 With the release of Home Assistant 2024.3, we are starting to adjust and remove usage in Home Assistant Core.
 Authors of custom integrations will need to adjust their code to avoid breakage.
 
-Starting from Home Assistant 2024.6, the `@bind_hass` decorator and 
+Starting from Home Assistant 2024.9, the `@bind_hass` decorator and 
 `hass.components` will be removed and will no longer work.
 
 ## Use of `@bind_hass` decorator

--- a/blog/2024-02-27-deprecate-bind-hass-and-hass-components.md
+++ b/blog/2024-02-27-deprecate-bind-hass-and-hass-components.md
@@ -6,7 +6,9 @@ title: "Deprecate use of @bind_hass and hass.components"
 ---
 
 As of Home Assistant 2024.3, we deprecate the use of the `@bind_hass` decorator 
-and thus also the use of `hass.components`. A warning will be logged if used.
+and thus also the use of `hass.components`.
+With the release of Home Assistant 2024.3, we are starting to adjust and remove usage in Home Assistant Core.
+Authors of custom integrations will need to adjust their code to avoid breakage.
 
 Starting from Home Assistant 2024.9, the `@bind_hass` decorator and 
 `hass.components` will be removed and will no longer work.

--- a/docs/auth_permissions.md
+++ b/docs/auth_permissions.md
@@ -262,7 +262,7 @@ from homeassistant.components import websocket_api
 
 
 async def async_setup(hass, config):
-    hass.components.websocket_api.async_register_command(websocket_create)
+    websocket_api.async_register_command(hass, websocket_create)
     return True
 
 

--- a/docs/frontend/extending/websocket-api.md
+++ b/docs/frontend/extending/websocket-api.md
@@ -81,10 +81,12 @@ async def ws_handle_thumbnail(
 With all pieces defined, it's time to register the command. This is done inside your setup method.
 
 ```python
+from homeassistant.components import websocket_api
+
 async def async_setup(hass, config):
     """Setup of your component."""
-    hass.components.websocket_api.async_register_command(ws_get_panels)
-    hass.components.websocket_api.async_register_command(ws_handle_thumbnail)
+    websocket_api.async_register_command(hass, ws_get_panels)
+    websocket_api.async_register_command(hass, ws_handle_thumbnail)
 ```
 
 ## Calling the command from the frontend (JavaScript)


### PR DESCRIPTION
## Proposed change
Add a dev blog about deprecating the `@bind_hass` decorator and the use of `hass.components`.
Also fix some code examples that use `hass.components`.

Logging PR in core: https://github.com/home-assistant/core/pull/111508

Related https://github.com/home-assistant/core/pull/111522 https://github.com/home-assistant/core/pull/111494

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
