### PR TITLE
Deprecate aux heater in Climate Entity

### DIFF
--- a/blog/2024-03-10-climate-aux-heater-deprecated.md
+++ b/blog/2024-03-10-climate-aux-heater-deprecated.md
@@ -1,0 +1,11 @@
+---
+author: G Johansson
+authorURL: https://github.com/gjohansson-ST
+title: "Climate entity auxiliary heater is deprecated"
+---
+
+As of Home Assistant Core 2024.4 we have deprecated the auxiliary heater functionality in `ClimateEntity`.
+
+Integrations that are currently implementing the `is_aux_heat` property and the `turn_aux_heat_on`/`turn_aux_heat_off` methods needs to remove these and alternatively implement other entities to accommodate the necessary functionality such as a `SwitchEntity` or in the case of a read-only property a `BinarySensorEntity`.
+
+You can read more about this decision [here](https://github.com/home-assistant/architecture/discussions/932).

--- a/blog/2024-03-10-climate-aux-heater-deprecated.md
+++ b/blog/2024-03-10-climate-aux-heater-deprecated.md
@@ -6,6 +6,6 @@ title: "Climate entity auxiliary heater is deprecated"
 
 As of Home Assistant Core 2024.4 we have deprecated the auxiliary heater functionality in `ClimateEntity`.
 
-Integrations that are currently implementing the `is_aux_heat` property and the `turn_aux_heat_on`/`turn_aux_heat_off` methods needs to remove these and alternatively implement other entities to accommodate the necessary functionality such as a `SwitchEntity` or in the case of a read-only property a `BinarySensorEntity`.
+Integrations that are currently implementing the `is_aux_heat` property and the `turn_aux_heat_on`/`turn_aux_heat_off` methods need to remove these and alternatively implement other entities to accommodate the necessary functionality such as a `SwitchEntity` or in the case of a read-only property a `BinarySensorEntity`.
 
 You can read more about this decision [here](https://github.com/home-assistant/architecture/discussions/932).

--- a/docs/core/entity/climate.md
+++ b/docs/core/entity/climate.md
@@ -20,7 +20,6 @@ Properties should always only return information from memory and not do I/O (lik
 | hvac_action             | <code>HVACAction &#124; None</code> | `None`                               | The current HVAC action (heating, cooling)                                 |
 | hvac_mode               | <code>HVACMode &#124; None</code>   | **Required**                         | The current operation (e.g. heat, cool, idle). Used to determine `state`.  |
 | hvac_modes              | <code>list[HVACMode]</code>         | **Required**                         | List of available operation modes. See below.                              |
-| is_aux_heat             | <code>int &#124; None</code>        | **Required by SUPPORT_AUX_HEAT**     | True if an auxiliary heater is on.                                         |
 | max_humidity            | `int`                               | `DEFAULT_MAX_HUMIDITY` (value == 99) | The maximum humidity.                                                      |
 | max_temp                | `float`                             | `DEFAULT_MAX_TEMP` (value == 35 °C)  | The maximum temperature in `temperature_unit`.                             |
 | min_humidity            | `int`                               | `DEFAULT_MIN_HUMIDITY` (value == 30) | The minimum humidity.                                                      |
@@ -123,7 +122,6 @@ and are combined using the bitwise or (`|`) operator.
 | `FAN_MODE`                 | The device supports fan modes.                                                              |
 | `PRESET_MODE`              | The device supports presets.                                                                |
 | `SWING_MODE`               | The device supports swing modes.                                                            |
-| `AUX_HEAT`                 | The device supports auxiliary heaters.                                                      |
 | `TURN_ON`                 | The device supports turn on.                                                      |
 | `TURN_OFF`                 | The device supports turn off.                                                      |
 
@@ -253,25 +251,4 @@ class MyClimateEntity(ClimateEntity):
 
     async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""
-```
-
-### Control auxiliary heater
-
-```python
-class MyClimateEntity(ClimateEntity):
-    # Implement one of these methods.
-
-    def turn_aux_heat_on(self):
-        """Turn auxiliary heater on."""
-
-    async def async_turn_aux_heat_on(self):
-        """Turn auxiliary heater on."""
-
-    # Implement one of these methods.
-
-    def turn_aux_heat_off(self):
-        """Turn auxiliary heater off."""
-
-    async def async_turn_aux_heat_off(self):
-        """Turn auxiliary heater off."""
 ```


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Start deprecation of `ClimateEntity` aux heater property and methods as outlined in https://github.com/home-assistant/architecture/discussions/932

Core PR: https://github.com/home-assistant/core/pull/112532

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
