### PR TITLE
Update humidity property types to float

### DIFF
--- a/docs/core/entity/climate.md
+++ b/docs/core/entity/climate.md
@@ -13,23 +13,23 @@ Properties should always only return information from memory and not do I/O (lik
 
 | Name                    | Type                                | Default                              | Description                                                                |
 | ----------------------- | ----------------------------------- | ------------------------------------ | -------------------------------------------------------------------------- |
-| current_humidity        | <code>int &#124; None</code>        | `None`                               | The current humidity.                                                      |
+| current_humidity        | <code>float &#124; None</code>        | `None`                               | The current humidity.                                                      |
 | current_temperature     | <code>float &#124; None</code>      | `None`                               | The current temperature.                                                   |
 | fan_mode                | <code>str &#124; None</code>        | **Required by SUPPORT_FAN_MODE**     | The current fan mode.                                                      |
 | fan_modes               | <code>list[str] &#124; None</code>  | **Required by SUPPORT_FAN_MODE**     | The list of available fan modes.                                           |
 | hvac_action             | <code>HVACAction &#124; None</code> | `None`                               | The current HVAC action (heating, cooling)                                 |
 | hvac_mode               | <code>HVACMode &#124; None</code>   | **Required**                         | The current operation (e.g. heat, cool, idle). Used to determine `state`.  |
 | hvac_modes              | <code>list[HVACMode]</code>         | **Required**                         | List of available operation modes. See below.                              |
-| max_humidity            | `int`                               | `DEFAULT_MAX_HUMIDITY` (value == 99) | The maximum humidity.                                                      |
+| max_humidity            | `float`                               | `DEFAULT_MAX_HUMIDITY` (value == 99) | The maximum humidity.                                                      |
 | max_temp                | `float`                             | `DEFAULT_MAX_TEMP` (value == 35 °C)  | The maximum temperature in `temperature_unit`.                             |
-| min_humidity            | `int`                               | `DEFAULT_MIN_HUMIDITY` (value == 30) | The minimum humidity.                                                      |
+| min_humidity            | `float`                               | `DEFAULT_MIN_HUMIDITY` (value == 30) | The minimum humidity.                                                      |
 | min_temp                | `float`                             | `DEFAULT_MIN_TEMP` (value == 7 °C)   | The minimum temperature in `temperature_unit`.                             |
 | precision               | `float`                             | According to `temperature_unit`      | The precision of the temperature in the system. Defaults to tenths for TEMP_CELSIUS, whole number otherwise. |
 | preset_mode             | <code>str &#124; None</code>        | **Required by SUPPORT_PRESET_MODE**  | The current active preset.                                                 |
 | preset_modes            | <code>list[str] &#124; None</code>  | **Required by SUPPORT_PRESET_MODE**  | The available presets.                                                     |
 | swing_mode              | <code>str &#124; None</code>        | **Required by SUPPORT_SWING_MODE**   | The swing setting.                                                         |
 | swing_modes             | <code>list[str] &#124; None</code>  | **Required by SUPPORT_SWING_MODE**   | Returns the list of available swing modes.                                 |
-| target_humidity         | <code>int &#124; None</code>        | `None`                               | The target humidity the device is trying to reach.                         |
+| target_humidity         | <code>float &#124; None</code>        | `None`                               | The target humidity the device is trying to reach.                         |
 | target_temperature      | <code>float &#124; None</code>      | `None`                               | The temperature currently set to be reached.                               |
 | target_temperature_high | <code>float &#124; None</code>      | **Required by TARGET_TEMPERATURE_RANGE** | The upper bound target temperature                                     |
 | target_temperature_low  | <code>float &#124; None</code>      | **Required by TARGET_TEMPERATURE_RANGE** | The lower bound target temperature                                     |

--- a/docs/core/entity/humidifier.md
+++ b/docs/core/entity/humidifier.md
@@ -15,13 +15,13 @@ Properties should always only return information from memory and not do I/O (lik
 | ----------------------- | ---------------------------------------------- | ------------------------------------- | -------------------------------------------------- |
 | action                  | <code>HumidifierAction &#124; None</code>      | `None`                                | Returns the current status of the device.          |
 | available_modes         | <code>list[str] &#124; None</code>             | **Required by MODES**                 | The available modes. Requires `SUPPORT_MODES`.     |
-| current_humidity        | <code>int &#124; None</code>                   | `None`                                | The current humidity measured by the device.       |
+| current_humidity        | <code>float &#124; None</code>                   | `None`                                | The current humidity measured by the device.       |
 | device_class            | <code>HumidifierDeviceClass &#124; None</code> | `None`                                | Type of hygrostat                                  |
 | is_on                   | <code>bool &#124; None</code>                  | `None`                                | Whether the device is on or off.                   |
-| max_humidity            | `int`                                          | `DEFAULT_MAX_HUMIDITY` (value == 100) | The maximum humidity.                              |
-| min_humidity            | `int`                                          | `DEFAULT_MIN_HUMIDITY` (value == 0)   | The minimum humidity.                              |
+| max_humidity            | `float`                                          | `DEFAULT_MAX_HUMIDITY` (value == 100) | The maximum humidity.                              |
+| min_humidity            | `float`                                          | `DEFAULT_MIN_HUMIDITY` (value == 0)   | The minimum humidity.                              |
 | mode                    | <code>str &#124; None</code>                   | **Required**                          | The current active mode. Requires `SUPPORT_MODES`. |
-| target_humidity         | <code>int &#124; None</code>                   | `None`                                | The target humidity the device is trying to reach. |
+| target_humidity         | <code>float &#124; None</code>                   | `None`                                | The target humidity the device is trying to reach. |
 
 ### Available device classes
 


### PR DESCRIPTION
## Proposed change
Change `humidity` property types for `climate` and `humidifier` from `int` to `float`.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/111297
