### PR TITLE
Add blog post about deprecating async_track_state_change

### DIFF
--- a/blog/2024-04-13-deprecate_async_track_state_change.md
+++ b/blog/2024-04-13-deprecate_async_track_state_change.md
@@ -6,7 +6,7 @@ title: "Replacing `async_track_state_change` with `async_track_state_change_even
 
 `async_track_state_change` is deprecated and will be removed in Home Assistant 2025.5. `async_track_state_change_event` should be used instead.
 
-`async_track_state_change` always creates a top-level listener for `EVENT_STATE_CHANGED`, which would have to reject all state changes that did not match the desired entities. This design presented a performance problem when there were many integrations using `async_track_state_change`. `async_track_state_change` has been phased out in `core` since the introduction of `async_track_state_change`, with the last instance being removed in 2024.5.
+`async_track_state_change` always creates a top-level listener for `EVENT_STATE_CHANGED`, which would have to reject all state changes that did not match the desired entities. This design presented a performance problem when there were many integrations using `async_track_state_change`. `async_track_state_change` has been phased out in `core` since the introduction of `async_track_state_change_event`, with the last instance being removed in 2024.5.
 
 Example with `async_track_state_change`:
 

--- a/blog/2024-04-13-deprecate_async_track_state_change.md
+++ b/blog/2024-04-13-deprecate_async_track_state_change.md
@@ -1,0 +1,40 @@
+---
+author: J. Nick Koston
+authorURL: https://github.com/bdraco
+title: "Replacing `async_track_state_change` with `async_track_state_change_event`"
+---
+
+`async_track_state_change` is deprecated and will be removed in Home Assistant 2025.5. `async_track_state_change_event` should be used instead.
+
+`async_track_state_change` always creates a top-level listener for `EVENT_STATE_CHANGED`, which would have to reject all state changes that did not match the desired entities. This design presented a performance problem when there were many integrations using `async_track_state_change`. `async_track_state_change` has been phased out in `core` since the introduction of `async_track_state_change`, with the last instance being removed in 2024.5.
+
+Example with `async_track_state_change`:
+
+```python
+from homeassistant.core import State, callback
+from homeassistant.helper.event import async_track_state_change
+
+@callback
+def _async_on_change(entity_id: str, old_state: State | None, new_state: State | None) -> None:
+    ...
+
+unsub = async_track_state_change(hass, "sensor.one", _async_on_change)
+unsub()
+```
+
+Example replacement with `async_track_state_change_event`:
+
+```python
+from homeassistant.core import Event, EventStateChangedData, callback
+from homeassistant.helper.event import async_track_state_change_event
+
+@callback
+def _async_on_change(event: Event[EventStateChangedData]) -> None:
+    entity_id = event.data["entity_id"]
+    old_state = event.data["old_state"]
+    new_state = event.data["new_state"]
+    ...
+
+unsub = async_track_state_change_event(hass, "sensor.one", _async_on_change)
+unsub()
+```


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Add blog post about deprecating async_track_state_change

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/115558
