### PR TITLE
Use PEP 695 type alias for ConfigEntry

### DIFF
--- a/blog/2024-04-30-store-runtime-data-inside-config-entry.md
+++ b/blog/2024-04-30-store-runtime-data-inside-config-entry.md
@@ -15,7 +15,7 @@ An example could look like this:
 # <integration>/__init__.py
 
 # The type alias needs to be suffixed with 'ConfigEntry'
-MyConfigEntry = ConfigEntry["MyData"]
+type MyConfigEntry = ConfigEntry[MyData]
 
 @dataclass
 class MyData:


### PR DESCRIPTION
## Proposed change
Update old blog post to use PEP 695 type alias for `ConfigEntry`. This also avoids the confusion around the quotes inside the annotation.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/117632
