### PR TITLE
AlarmControlPanel code validation

### DIFF
--- a/blog/2024-05-22-alarm_control_panel_validation.md
+++ b/blog/2024-05-22-alarm_control_panel_validation.md
@@ -4,8 +4,8 @@ authorURL: https://github.com/gjohansson-ST
 title: Alarm Control Panel Entity code validation
 ---
 
-The `AlarmControlPanelEntity` is now enforcing validation of code for alarm control panel entities which set `code_arm_required` to `True` (default behavior). Service calls fail if no code is provided when a code is required.
+The `AlarmControlPanelEntity` is now enforcing validation of code for alarm control panel entities, which set `code_arm_required` to `True` (default behavior). Service calls fail if no code is provided, when a code is required.
 
-Previously this was entirely optional and a user could skip code entry regardless of it was needed by the integration or not (and as such each integration needed to implement it's own check).
+Previously this was entirely optional, and a user could skip code entry regardless of it was needed by the integration or not (and as such each integration needed to implement its own check).
 
 As the default behavior is that code is required, custom integrations that don't require a code input need to set `code_arm_required` to `False` or the user will always have to input a code regardless of if it's needed by the service calls.

--- a/blog/2024-05-22-alarm_control_panel_validation.md
+++ b/blog/2024-05-22-alarm_control_panel_validation.md
@@ -4,8 +4,8 @@ authorURL: https://github.com/gjohansson-ST
 title: Alarm Control Panel Entity code validation
 ---
 
-The `AlarmControlPanelEntity` is now enforcing validation of code so for integrations that are creating such entities and are setting `code_arm_required` to `True` (default behavior). The validation will fail unless the user is actually providing a code.
+The `AlarmControlPanelEntity` is now enforcing validation of code for alarm control panel entities which set `code_arm_required` to `True` (default behavior). Service calls fail if no code is provided when a code is required.
 
-Previously this was entirely optional and a user could skip code entry regardless if it was needed by the integration or not (and as such each integration needed to implement it's own check).
+Previously this was entirely optional and a user could skip code entry regardless of it was needed by the integration or not (and as such each integration needed to implement it's own check).
 
-As the default behavior is that code is required, custom integrations that don't require a code input needs to set `code_arm_required` to `False` or the user will always have to input a code regardless if needed by the service calls.
+As the default behavior is that code is required, custom integrations that don't require a code input need to set `code_arm_required` to `False` or the user will always have to input a code regardless of if it's needed by the service calls.

--- a/blog/2024-05-22-alarm_control_panel_validation.md
+++ b/blog/2024-05-22-alarm_control_panel_validation.md
@@ -1,0 +1,11 @@
+---
+author: G Johansson
+authorURL: https://github.com/gjohansson-ST
+title: Alarm Control Panel Entity default code and validation
+---
+
+The `AlarmControlPanelEntity` is now enforcing validation of code so for integrations that are creating such entities and are setting `code_arm_required` to `True` (default behavior). The validation will fail unless the user is actually providing a code.
+
+Previously this was entirely optional and a user could skip code entry regardless if it was needed by the integration or not (and as such each integration needed to implement it's own check).
+
+As the default behavior is that code is required, custom integrations that don't require a code input needs to set `code_arm_required` to `False` or the user will always have to input a code regardless if needed by the service calls.

--- a/blog/2024-05-22-alarm_control_panel_validation.md
+++ b/blog/2024-05-22-alarm_control_panel_validation.md
@@ -1,7 +1,7 @@
 ---
 author: G Johansson
 authorURL: https://github.com/gjohansson-ST
-title: Alarm Control Panel Entity default code and validation
+title: Alarm Control Panel Entity code validation
 ---
 
 The `AlarmControlPanelEntity` is now enforcing validation of code so for integrations that are creating such entities and are setting `code_arm_required` to `True` (default behavior). The validation will fail unless the user is actually providing a code.

--- a/blog/2024-05-22-alarm_control_panel_validation.md
+++ b/blog/2024-05-22-alarm_control_panel_validation.md
@@ -4,7 +4,7 @@ authorURL: https://github.com/gjohansson-ST
 title: Alarm Control Panel Entity code validation
 ---
 
-The `AlarmControlPanelEntity` is now enforcing validation of code for alarm control panel entities, which set `code_arm_required` to `True` (default behavior). Service calls fail if no code is provided, when a code is required.
+The `AlarmControlPanelEntity` is now enforcing validation of code for alarm control panel entities, which set `code_arm_required` to `True` (default behavior). Service calls fail if no code is provided when a code is required.
 
 Previously this was entirely optional, and a user could skip code entry regardless of it was needed by the integration or not (and as such each integration needed to implement its own check).
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Add blogpost about code validation for AlarmControlPanelEntity

Core PR: https://github.com/home-assistant/core/pull/112540

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced validation for alarm control panels, requiring a code entry when `code_arm_required` is set to `True`.
  - Added the option to disable the code requirement by setting `code_arm_required` to `False`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->