### PR TITLE
Add cover exception to response style guide.

### DIFF
--- a/docs/voice/intent-recognition/style-guide.md
+++ b/docs/voice/intent-recognition/style-guide.md
@@ -38,5 +38,5 @@ Responses should be in the present tense. For example, "The light is on" instead
 
 ## Use the correct voice
 
-Responses should be in the active voice. For example, "The light is on" instead of "The light is being turned on".
+Responses should be in the active voice. For example, "The light is on" instead of "The light is being turned on". Exception here is for the `cover` domain, as the actions take considerable time to complete.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Update the response style guide to mention the cover exception.

Related: https://github.com/home-assistant/core/pull/119756

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated guidelines to emphasize active voice in responses, with an exception for the `cover` domain, where passive voice is allowed due to the time-intensive nature of actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->