### PR TITLE
Document system managed field for addons

### DIFF
--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -286,16 +286,16 @@ To reset customized network/audio/options, set it `null`.
 
 **Payload:**
 
-| key                         | type          | description                             |
-| --------------------------- | ------------- | --------------------------------------- |
-| boot                        | string        | (auto, manual)                          |
-| auto_update                 | boolean       | `true` if the add-on should auto update |
-| network                     | dictionary    | A map of network configuration.         |
-| options                     | dictionary    | The add-on configuration                |
-| audio_output                | float or null | The index of the audio output device    |
-| audio_input                 | float or null | The index of the audio input device     |
-| ingress_panel               | boolean       | `true` if ingress_panel is enabled      |
-| watchdog                    | boolean       | `true` if watchdog is enabled           |
+| key           | type          | description                             |
+| ------------- | ------------- | --------------------------------------- |
+| boot          | string        | (auto, manual)                          |
+| auto_update   | boolean       | `true` if the add-on should auto update |
+| network       | dictionary    | A map of network configuration.         |
+| options       | dictionary    | The add-on configuration                |
+| audio_output  | float or null | The index of the audio output device    |
+| audio_input   | float or null | The index of the audio input device     |
+| ingress_panel | boolean       | `true` if ingress_panel is enabled      |
+| watchdog      | boolean       | `true` if watchdog is enabled           |
 
 **You need to supply at least one key in the payload.**
 

--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -278,9 +278,7 @@ Get the add-on logo
 </ApiEndpoint>
 
 <ApiEndpoint path="/addons/<addon>/options" method="post">
-Set the protection mode on an add-on.
-
-This function is not callable by itself and you can not use `self` as the slug here.
+Set the options for an add-on.
 
 :::tip
 To reset customized network/audio/options, set it `null`.
@@ -298,8 +296,6 @@ To reset customized network/audio/options, set it `null`.
 | audio_input                 | float or null | The index of the audio input device     |
 | ingress_panel               | boolean       | `true` if ingress_panel is enabled      |
 | watchdog                    | boolean       | `true` if watchdog is enabled           |
-| system_managed              | boolean       | `true` if managed by Home Assistant     |
-| system_managed_config_entry | boolean       | ID of config entry managing addon       |
 
 **You need to supply at least one key in the payload.**
 
@@ -316,6 +312,31 @@ To reset customized network/audio/options, set it `null`.
     "awesome": true
   },
   "watchdog": true
+}
+```
+
+</ApiEndpoint>
+
+<ApiEndpoint path="/addons/<addon>/sys_options" method="post">
+Change options specific to system managed addons.
+
+This endpoint is only callable by Home Assistant and not by any other client.
+
+**Payload**
+
+| key                         | type          | description                             |
+| --------------------------- | ------------- | --------------------------------------- |
+| system_managed              | boolean       | `true` if managed by Home Assistant     |
+| system_managed_config_entry | boolean       | ID of config entry managing addon       |
+
+**You need to supply at least one key in the payload.**
+
+**Example payload:**
+
+```json
+{
+  "system_managed": true,
+  "system_managed_config_entry": "abc123"
 }
 ```
 

--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -42,7 +42,8 @@ Return overview information about installed add-ons.
       "build": false,
       "url": null,
       "icon": false,
-      "logo": false
+      "logo": false,
+      "system_managed": false
     }
   ]
 }
@@ -164,6 +165,8 @@ Get details about an add-on
 | startup             | string             | The stage when the add-on is started (initialize, system, services, application, once) |
 | state               | string or null     | The state of the add-on (started, stopped)                                             |
 | stdin               | boolean            | `true` if the add-on accepts stdin commands                                            |
+| system_managed      | boolean            | `true` if Home Assistant is managing the add-on                                        |
+| system_managed_config_entry | string     | ID of the config entry managing the add-on within Home Assistant                       |
 | translations        | dictionary         | A dictionary containing content of translation files for the add-on |
 | udev                | boolean            | `true` if udev access is granted is enabled                                            |
 | update_available    | boolean            | `true` if an update is available                                                       |
@@ -239,6 +242,8 @@ Get details about an add-on
   "startup": "application",
   "state": "started",
   "stdin": false,
+  "system_managed": true,
+  "system_managed_config_entry": "abc123",
   "translations": {
     "en": {
       "configuration": {
@@ -283,16 +288,18 @@ To reset customized network/audio/options, set it `null`.
 
 **Payload:**
 
-| key           | type          | description                             |
-| ------------- | ------------- | --------------------------------------- |
-| boot          | string        | (auto, manual)                          |
-| auto_update   | boolean       | `true` if the add-on should auto update |
-| network       | dictionary    | A map of network configuration.         |
-| options       | dictionary    | The add-on configuration                |
-| audio_output  | float or null | The index of the audio output device    |
-| audio_input   | float or null | The index of the audio input device     |
-| ingress_panel | boolean       | `true` if ingress_panel is enabled      |
-| watchdog      | boolean       | `true` if watchdog is enabled           |
+| key                         | type          | description                             |
+| --------------------------- | ------------- | --------------------------------------- |
+| boot                        | string        | (auto, manual)                          |
+| auto_update                 | boolean       | `true` if the add-on should auto update |
+| network                     | dictionary    | A map of network configuration.         |
+| options                     | dictionary    | The add-on configuration                |
+| audio_output                | float or null | The index of the audio output device    |
+| audio_input                 | float or null | The index of the audio input device     |
+| ingress_panel               | boolean       | `true` if ingress_panel is enabled      |
+| watchdog                    | boolean       | `true` if watchdog is enabled           |
+| system_managed              | boolean       | `true` if managed by Home Assistant     |
+| system_managed_config_entry | boolean       | ID of config entry managing addon       |
 
 **You need to supply at least one key in the payload.**
 

--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -165,9 +165,9 @@ Get details about an add-on
 | startup             | string             | The stage when the add-on is started (initialize, system, services, application, once) |
 | state               | string or null     | The state of the add-on (started, stopped)                                             |
 | stdin               | boolean            | `true` if the add-on accepts stdin commands                                            |
-| system_managed      | boolean            | `true` if Home Assistant is managing the add-on                                        |
-| system_managed_config_entry | string     | ID of the config entry managing the add-on within Home Assistant                       |
-| translations        | dictionary         | A dictionary containing content of translation files for the add-on |
+| system_managed      | boolean            | Indicates whether the add-on is managed by Home Assistant                              |
+| system_managed_config_entry | string     | Provides the configuration entry ID if the add-on is managed by Home Assistant         |
+| translations        | dictionary         | A dictionary containing content of translation files for the add-on                    |
 | udev                | boolean            | `true` if udev access is granted is enabled                                            |
 | update_available    | boolean            | `true` if an update is available                                                       |
 | url                 | string or null     | URL to more information about the add-on                                               |

--- a/docs/api/supervisor/models.md
+++ b/docs/api/supervisor/models.md
@@ -21,6 +21,7 @@ These models are describing objects that are getting returned from the superviso
 | icon             | bool           | The add-on has an icon file                            |
 | logo             | bool           | The add-on has a logo file                            |
 | state            | string         | The state of the add-on (started, stopped)            |
+| system_managed   | bool           | `true` if Home Assistant is managing the addon        |
 
 ## Application
 

--- a/docs/api/supervisor/models.md
+++ b/docs/api/supervisor/models.md
@@ -21,7 +21,7 @@ These models are describing objects that are getting returned from the superviso
 | icon             | bool           | The add-on has an icon file                            |
 | logo             | bool           | The add-on has a logo file                            |
 | state            | string         | The state of the add-on (started, stopped)            |
-| system_managed   | bool           | `true` if Home Assistant is managing the addon        |
+| system_managed   | bool           | Indicates whether the add-on is managed by Home Assistant |
 
 ## Application
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Document new system managed options added for addons in https://github.com/home-assistant/supervisor/pull/5145


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/supervisor/pull/5145


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated Supervisor API documentation to include `system_managed` and `system_managed_config_entry` fields for add-on details.
	- Introduced a new API endpoint for managing add-on system options.
	- Added descriptions for `system_managed` attribute in the add-on models documentation, indicating Home Assistant management status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->