### PR TITLE
Use MATCH_ALL constant for recorder state attributes exclusion

### DIFF
--- a/blog/2024-06-22-excluding-state-attributes-from-recording-match-all.md
+++ b/blog/2024-06-22-excluding-state-attributes-from-recording-match-all.md
@@ -1,0 +1,25 @@
+---
+author: G Johansson
+authorURL: https://github.com/gjohansson-ST
+title: "Excluding all state attributes from recording using MATCH_ALL"
+---
+
+The way how state attributes is excluded from recording was previously changed in September, 2023.
+
+The previous implementation was limited as there was no way to handle dynamic attributes or any easy way to simply exclude all attributes instead of listing them individually.
+
+It is now possible within an integration to tell recording to not record any attribute by using the `MATCH_ALL` constant which will automatically remove all attributes from recording except `device_class`, `state_class`, `unit_of_measurement` and `friendly_name`.
+
+```python
+from homeassistant.const import MATCH_ALL
+
+class ExampleEntity(Entity):
+    """Implementation of an entity."""
+
+    _unrecorded_attributes = frozenset({MATCH_ALL})
+
+```
+
+More details can be found in the [entity documentation](/docs/core/entity#excluding-state-attributes-from-recorder-history).
+
+Background for the original change is in [architecture discussion #964](https://github.com/home-assistant/architecture/discussions/964).

--- a/blog/2024-06-22-excluding-state-attributes-from-recording-match-all.md
+++ b/blog/2024-06-22-excluding-state-attributes-from-recording-match-all.md
@@ -4,11 +4,11 @@ authorURL: https://github.com/gjohansson-ST
 title: "Excluding all state attributes from recording using MATCH_ALL"
 ---
 
-The way how state attributes is excluded from recording was previously changed in September, 2023.
+The way how state attributes are excluded from the recording was previously changed in September 2023.
 
 The previous implementation was limited as there was no way to handle dynamic attributes or any easy way to simply exclude all attributes instead of listing them individually.
 
-It is now possible within an integration to tell recording to not record any attribute by using the `MATCH_ALL` constant which will automatically remove all attributes from recording except `device_class`, `state_class`, `unit_of_measurement` and `friendly_name`.
+It is now possible within an integration to tell recording to not record any attribute by using the `MATCH_ALL` constant, which will automatically remove all attributes from recording except `device_class`, `state_class`, `unit_of_measurement`, and `friendly_name.`
 
 ```python
 from homeassistant.const import MATCH_ALL

--- a/docs/core/entity.md
+++ b/docs/core/entity.md
@@ -461,9 +461,9 @@ State attributes which are not suitable for state history recording should be ex
 - `_entity_component_unrecorded_attributes: frozenset[str]` may be set in a base component class, e.g. in `light.LightEntity`
 - `_unrecorded_attributes: frozenset[str]` may be set in an integration's platform e.g. in an entity class defined in platform `hue.light`.
 
-The use of the `MATCH_ALL` constant can be used to exclude all attributes instead of typing them separately. This can be useful for integrations providing attributes which is not known or when you simply want to exclude all without typing them separately.
+The `MATCH_ALL` constant can be used to exclude all attributes instead of typing them separately. This can be useful for integrations providing unknown attributes or when you simply want to exclude all without typing them separately.
 
-Using the `MATCH_ALL` constant does not stop recording for `device_class`, `state_class`, `unit_of_measurement` and `friendly_name` as they might also serve other purposes and therefore should not be excluded from recording.
+Using the `MATCH_ALL` constant does not stop recording for `device_class`, `state_class`, `unit_of_measurement`, and `friendly_name` as they might also serve other purposes and, therefore, should not be excluded from recording.
 
 Examples of platform state attributes which are exluded from recording include the `entity_picture` attribute of `image` entities which will not be valid after some time, the `preset_modes` attribute of `fan` entities which is not likely to change.
 Examples of integration specific state attributes which are excluded from recording include `description` and `location` state attributes in platform `trafikverket.camera` which do not change.

--- a/docs/core/entity.md
+++ b/docs/core/entity.md
@@ -461,6 +461,10 @@ State attributes which are not suitable for state history recording should be ex
 - `_entity_component_unrecorded_attributes: frozenset[str]` may be set in a base component class, e.g. in `light.LightEntity`
 - `_unrecorded_attributes: frozenset[str]` may be set in an integration's platform e.g. in an entity class defined in platform `hue.light`.
 
+The use of the `MATCH_ALL` constant can be used to exclude all attributes instead of typing them separately. This can be useful for integrations providing attributes which is not known or when you simply want to exclude all without typing them separately.
+
+Using the `MATCH_ALL` constant does not stop recording for `device_class`, `state_class`, `unit_of_measurement` and `friendly_name` as they might also serve other purposes and therefore should not be excluded from recording.
+
 Examples of platform state attributes which are exluded from recording include the `entity_picture` attribute of `image` entities which will not be valid after some time, the `preset_modes` attribute of `fan` entities which is not likely to change.
 Examples of integration specific state attributes which are excluded from recording include `description` and `location` state attributes in platform `trafikverket.camera` which do not change.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Update docs + blog post on `MATCH_ALL` constant use for recorder state attribute exclusion.

Related core PR: https://github.com/home-assistant/core/pull/119725

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a method to exclude all state attributes from recording using `MATCH_ALL`.
  - Added the `MATCH_ALL` constant for collectively excluding attributes while preserving key attributes (`device_class`, `state_class`, `unit_of_measurement`, `friendly_name`).

- **Documentation**
  - Updated documentation to reflect the use of the `MATCH_ALL` constant and provided examples of excluded attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->