### PR TITLE
Refer to GRUB instead of Barebox in HAOS docs

### DIFF
--- a/docs/operating-system.md
+++ b/docs/operating-system.md
@@ -10,7 +10,7 @@ Home Assistant Operating System (HAOS) is using the [Buildroot](https://buildroo
 ### Components
 
 - **Bootloader:**
-  - [Barebox](https://barebox.org/) for devices that support EFI
+  - [GRUB](https://www.gnu.org/software/grub/) for devices that support UEFI
   - [U-Boot](https://www.denx.de/wiki/U-Boot) for devices that don't support EFI
 - **Operating System:**
   - [Buildroot](https://buildroot.org/) build system to generate Linux distributions

--- a/docs/operating-system/board-metadata.md
+++ b/docs/operating-system/board-metadata.md
@@ -40,10 +40,10 @@ Enable SPL (secondary program loader) handling. Some U-Boot targets generate a s
 
 `BOOTLOADER`:
 
+- grub
 - uboot
-- barebox
 
-HAOS uses mainly [U-Boot](https://www.denx.de/wiki/U-Boot). For UEFI systems [barebox](https://barebox.org/) is used.
+HAOS uses mainly [U-Boot](https://www.denx.de/wiki/U-Boot). For UEFI systems [GRUB](https://www.gnu.org/software/grub/) is used.
 
 `DISK_SIZE`:
 

--- a/docs/operating-system/partition.md
+++ b/docs/operating-system/partition.md
@@ -40,7 +40,7 @@ HAOS prefers GPT (GUID Partition Table) whenever possible. Boot ROMs of some SoC
 
 ### System partitions
 
-The boot partition is typically a FAT partition and contains system specific content to enable booting. On x86-64 systems this is the EFI system partition containing Barebox.
+The boot partition is typically a FAT partition and contains system specific content to enable booting. On UEFI systems this is the EFI system partition containing GRUB binaries, configuration and its environment file.
 
 Next two versions of the Linux kernel and the main operating systems are stored (Kernel A/B and System A/B, a total of 4 partitions). This allows the system to fall back to the previous release in case booting on the new release fails (A/B update method). The system partitions are only written to during an update and are read-only under regular operation.
 

--- a/docs/operating-system/partition.md
+++ b/docs/operating-system/partition.md
@@ -40,7 +40,7 @@ HAOS prefers GPT (GUID Partition Table) whenever possible. Boot ROMs of some SoC
 
 ### System partitions
 
-The boot partition is typically a FAT partition and contains system specific content to enable booting. On UEFI systems this is the EFI system partition containing GRUB binaries, configuration and its environment file.
+The boot partition is typically a FAT partition and contains system-specific content to enable booting. On UEFI systems this is the EFI system partition containing GRUB binaries, configuration and its environment file.
 
 Next two versions of the Linux kernel and the main operating systems are stored (Kernel A/B and System A/B, a total of 4 partitions). This allows the system to fall back to the previous release in case booting on the new release fails (A/B update method). The system partitions are only written to during an update and are read-only under regular operation.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

We don't use Barebox for over two years since home-assistant/operating-system@d1cc7394, remove the forgotten mentions of it across OS docs.


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [x] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated references from Barebox to GRUB for UEFI systems in Home Assistant Operating System (HAOS).
  - Changed the bootloader from uboot to GRUB in board metadata documentation for UEFI systems.
  - Clarified the content of the boot partition on UEFI systems to include GRUB binaries, configuration, and environment file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->