### PR TITLE
Clarify the meaning and usage of the "id" field in a websocket message

### DIFF
--- a/docs/api/websocket.md
+++ b/docs/api/websocket.md
@@ -23,7 +23,7 @@ During the command phase, the client attaches a unique identifier to each messag
 
 ## Message format
 
-Each API message is a JSON serialized object containing a `type` key. After the authentication phase messages also must contain an `id`, an integer that contains the number of interactions.
+Each API message is a JSON serialized object containing a `type` key. After the authentication phase messages also must contain an `id`, an integer that the caller can use to correlate messages to responses.
 
 Example of an auth message:
 


### PR DESCRIPTION
Based on a discussion in Discord involving confusion over the requirements, if any, for the "id" field in a websocket call, I suggest clarifying that HA has no requirements or interest in the value and it's strictly provided by the caller for the caller's use (for instance, but not limited to, correlating responses to calls).

Discord discussion is here:  https://discord.com/channels/330944238910963714/744321107250774079/1260242623340482682

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

I'm proposing changing the wording around the "id" parameter in the HA websocket call in the documentation to eliminate mention of "number of interactions", which isn't actually a requirement.  As far as I understand it, it's just an integration that the caller provides and will be returned in a response for the caller's use, if desired.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated API documentation to specify that post-authentication messages must contain an `id` used for correlating messages to responses, rather than just being an interaction count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->