### PR TITLE
Document OS boot slot persistence when using GRUB

### DIFF
--- a/docs/operating-system/update-system.md
+++ b/docs/operating-system/update-system.md
@@ -58,7 +58,7 @@ o [kernel.1] (/dev/disk/by-partlabel/hassos-kernel1, raw, inactive)
 
 After an update, RAUC instructs the bootloader to boot into the other slot (e.g. with U-Boot by writing U-Boot environment variables). If the boot succeeds, the slot is marked good and the system will continue to boot into this boot slot. Typically, three attempts are made with each boot slot before reverting to the other boot slot, but the exact logic is dependent on the bootloader integration.
 
-The boot slot can be changed using the `ha os boot-slot` command. On systems using the GRUB bootloader, the boot menu can be also used. In that case, the selected boot slot will be used for future boots, until it’s changed again manually or by an OS update.
+The boot slot can be changed using the `ha os boot-slot` command. On systems using the GRUB bootloader, the boot menu can also be used. In that case, the selected boot slot will be used for future boots, until it’s changed again manually or by an OS update.
 
 ## Security
 

--- a/docs/operating-system/update-system.md
+++ b/docs/operating-system/update-system.md
@@ -58,6 +58,8 @@ o [kernel.1] (/dev/disk/by-partlabel/hassos-kernel1, raw, inactive)
 
 After an update, RAUC instructs the bootloader to boot into the other slot (e.g. with U-Boot by writing U-Boot environment variables). If the boot succeeds, the slot is marked good and the system will continue to boot into this boot slot. Typically, three attempts are made with each boot slot before reverting to the other boot slot, but the exact logic is dependent on the bootloader integration.
 
+The boot slot can be changed using the `ha os boot-slot` command. On systems using the GRUB bootloader, the boot menu can be also used. In that case, the selected boot slot will be used for future boots, until it’s changed again manually or by an OS update.
+
 ## Security
 
 The HAOS RAUC update bundles are signed. HAOS has its own PKI with development and release CAs. Currently, all public builds are signed with the release CA. The certificates are pre-installed on the OS in `/etc/rauc/keyring.pem`.


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Since home-assistant/supervisor#5276 boot slot will be persisted when user selects it in the GRUB menu. Document this behavior.



## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command for managing boot slots in the Home Assistant Operating System.
  
- **Documentation**
	- Enhanced documentation on boot slot management and local builds, improving user understanding of system updates and boot options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->