### PR TITLE
Change lock state is enum

### DIFF
--- a/blog/2024-09-23-state-constants-lock-deprecation.md
+++ b/blog/2024-09-23-state-constants-lock-deprecation.md
@@ -1,0 +1,13 @@
+---
+author: G Johansson
+authorURL: https://github.com/gjohansson-ST
+authorImageURL: https://avatars.githubusercontent.com/u/62932417?v=4
+authorTwitter: GJohansson
+title: "Deprecating state constants for lock"
+---
+
+As of Home Assistant Core 2024.10, the constants used as returning state in `LockEntity` is deprecated and replaced by the `LockState` enum.
+
+There is a one-year deprecation period, and the the constants will stop to work from 2025.10 to ensure all custom integration authors have time to adjust.
+
+As the `state` property is not meant to be overwritten, in most cases this is only related for use in other properties or in tests rather in a `state` property.

--- a/blog/2024-09-23-state-constants-lock-deprecation.md
+++ b/blog/2024-09-23-state-constants-lock-deprecation.md
@@ -6,8 +6,8 @@ authorTwitter: GJohansson
 title: "Deprecating state constants for lock"
 ---
 
-As of Home Assistant Core 2024.10, the constants used as returning state in `LockEntity` is deprecated and replaced by the `LockState` enum.
+As of Home Assistant Core 2024.10, the constants used to return state in `LockEntity` are deprecated and replaced by the `LockState` enum.
 
 There is a one-year deprecation period, and the constants will stop working from 2025.10 to ensure all custom integration authors have time to adjust.
 
-As the `state` property is not meant to be overwritten, in most cases this is only related for use in other properties or in tests rather in a `state` property.
+As the `state` property is not meant to be overwritten, in most cases this change will only affect other Entity properties or tests rather than the `state` property.

--- a/blog/2024-09-23-state-constants-lock-deprecation.md
+++ b/blog/2024-09-23-state-constants-lock-deprecation.md
@@ -8,6 +8,6 @@ title: "Deprecating state constants for lock"
 
 As of Home Assistant Core 2024.10, the constants used as returning state in `LockEntity` is deprecated and replaced by the `LockState` enum.
 
-There is a one-year deprecation period, and the the constants will stop to work from 2025.10 to ensure all custom integration authors have time to adjust.
+There is a one-year deprecation period, and the constants will stop working from 2025.10 to ensure all custom integration authors have time to adjust.
 
 As the `state` property is not meant to be overwritten, in most cases this is only related for use in other properties or in tests rather in a `state` property.

--- a/docs/core/entity/lock.md
+++ b/docs/core/entity/lock.md
@@ -22,6 +22,20 @@ Properties should always only return information from memory and not do I/O (lik
 | is_opening | bool | None | Indication of whether the lock is currently opening. Used to determine `state`.
 | is_open | bool | None | Indication of whether the lock is currently open. Used to determine `state`.
 
+### States
+
+The state is defined by setting it's properties. The resulting state is using the `LockState` enum to return one of the below members.
+
+| Value       | Description                                                        |
+|-------------|--------------------------------------------------------------------|
+| `LOCKED`    | The lock is locked.                                                |
+| `LOCKING`   | The lock is locking.                                               |
+| `UNLOCKING` | The lock is unlocking.                                             |
+| `UNLOCKED`  | The lock is unlocked.                                             |
+| `JAMMED`    | The lock is currently jammed.                                      |
+| `OPENING`   | The lock is opening.                                               |
+| `OPEN`      | The lock is open.                                                  |
+
 ## Supported features
 
 Supported features are defined by using values in the `LockEntityFeature` enum

--- a/docs/core/entity/lock.md
+++ b/docs/core/entity/lock.md
@@ -24,7 +24,7 @@ Properties should always only return information from memory and not do I/O (lik
 
 ### States
 
-The state is defined by setting it's properties. The resulting state is using the `LockState` enum to return one of the below members.
+The state is defined by setting the above properties. The resulting state is using the `LockState` enum to return one of the below members.
 
 | Value       | Description                                                        |
 |-------------|--------------------------------------------------------------------|


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
For`lock` clarify construct the state from it's properties and returns a `LockState` enum
Core PR: https://github.com/home-assistant/core/pull/126379

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `LockState` enum to replace deprecated state constants in the `LockEntity` class.
	- Added a detailed section in the documentation outlining the various states of the lock, enhancing user understanding.

- **Documentation**
	- Updated lock entity documentation to include descriptions of the new `LockState` enum and its members.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->