### PR TITLE
Change camera state to enum

### DIFF
--- a/blog/2024-09-23-state-constants-camera-deprecation.md
+++ b/blog/2024-09-23-state-constants-camera-deprecation.md
@@ -6,8 +6,8 @@ authorTwitter: GJohansson
 title: "Deprecating state constants for camera"
 ---
 
-As of Home Assistant Core 2024.10, the constants used as returning state in `Camera` is deprecated and replaced by the `CameraState` enum.
+As of Home Assistant Core 2024.10, the constants used as returning state in `Camera` are deprecated and replaced by the `CameraState` enum.
 
-There is a one-year deprecation period, and the the constants will stop to work from 2025.10 to ensure all custom integration authors have time to adjust.
+There is a one-year deprecation period, and the constants will stop working from 2025.10 to ensure all custom integration authors have time to adjust.
 
-As the `state` property is not meant to be overwritten, in most cases this is only related for use in other properties or in tests.
+As the `state` property is not meant to be overwritten, in most cases this change will only affect other Entity properties or tests.

--- a/blog/2024-09-23-state-constants-camera-deprecation.md
+++ b/blog/2024-09-23-state-constants-camera-deprecation.md
@@ -1,0 +1,13 @@
+---
+author: G Johansson
+authorURL: https://github.com/gjohansson-ST
+authorImageURL: https://avatars.githubusercontent.com/u/62932417?v=4
+authorTwitter: GJohansson
+title: "Deprecating state constants for camera"
+---
+
+As of Home Assistant Core 2024.10, the constants used as returning state in `Camera` is deprecated and replaced by the `CameraState` enum.
+
+There is a one-year deprecation period, and the the constants will stop to work from 2025.10 to ensure all custom integration authors have time to adjust.
+
+As the `state` property is not meant to be overwritten, in most cases this is only related for use in other properties or in tests.

--- a/blog/2024-09-23-state-constants-camera-deprecation.md
+++ b/blog/2024-09-23-state-constants-camera-deprecation.md
@@ -6,7 +6,7 @@ authorTwitter: GJohansson
 title: "Deprecating state constants for camera"
 ---
 
-As of Home Assistant Core 2024.10, the constants used as returning state in `Camera` are deprecated and replaced by the `CameraState` enum.
+As of Home Assistant Core 2024.10, the constants used to return state in `Camera` are deprecated and replaced by the `CameraState` enum.
 
 There is a one-year deprecation period, and the constants will stop working from 2025.10 to ensure all custom integration authors have time to adjust.
 

--- a/docs/core/entity/camera.md
+++ b/docs/core/entity/camera.md
@@ -27,11 +27,11 @@ Properties should always only return information from memory and not do I/O (lik
 
 The state is defined by setting the properties above. The resulting state uses the `CameraState` enum to return one of the below members.
 
-| Value      | Description                             |
-|------------|-----------------------------------------|
-| `RECORDING`| The camera is currently recording.      |
-| `STREAMING`| The camera is currently streaming.      |
-| `IDLE`     | The camera is currently idle.           |
+| Value       | Description                             |
+|-------------|-----------------------------------------|
+| `RECORDING` | The camera is currently recording.      |
+| `STREAMING` | The camera is currently streaming.      |
+| `IDLE`      | The camera is currently idle.           |
 
 
 ## Supported features

--- a/docs/core/entity/camera.md
+++ b/docs/core/entity/camera.md
@@ -23,6 +23,17 @@ Properties should always only return information from memory and not do I/O (lik
 | motion_detection_enabled | `bool`                              | `False` | Indication of whether the camera has motion detection enabled.                                      |
 | use_stream_for_stills    | `bool`                              | `False` | Determines whether or not to use the `Stream` integration to generate still images                  |
 
+### States
+
+The state is defined by setting it's properties. The resulting state is using the `LockState` enum to return one of the below members.
+
+| Value       | Description                                                        |
+|-------------|--------------------------------------------------------------------|
+| `RECORDING`    | The camera is currently recording.                                 |
+| `STREAMING`   | The camera is currently streaming.                                 |
+| `IDLE` | The camera is currently idle.                                      |
+
+
 ## Supported features
 
 Supported features are defined by using values in the `CameraEntityFeature` enum

--- a/docs/core/entity/camera.md
+++ b/docs/core/entity/camera.md
@@ -25,7 +25,7 @@ Properties should always only return information from memory and not do I/O (lik
 
 ### States
 
-The state is defined by setting its properties. The resulting state uses the `CameraState` enum to return one of the below members.
+The state is defined by setting the properties above. The resulting state uses the `CameraState` enum to return one of the below members.
 
 | Value      | Description                             |
 |------------|-----------------------------------------|

--- a/docs/core/entity/camera.md
+++ b/docs/core/entity/camera.md
@@ -25,7 +25,7 @@ Properties should always only return information from memory and not do I/O (lik
 
 ### States
 
-The state is defined by setting it's properties. The resulting state is using the `LockState` enum to return one of the below members.
+The state is defined by setting it's properties. The resulting state is using the `CameraState` enum to return one of the below members.
 
 | Value       | Description                                                        |
 |-------------|--------------------------------------------------------------------|

--- a/docs/core/entity/camera.md
+++ b/docs/core/entity/camera.md
@@ -25,13 +25,13 @@ Properties should always only return information from memory and not do I/O (lik
 
 ### States
 
-The state is defined by setting it's properties. The resulting state is using the `CameraState` enum to return one of the below members.
+The state is defined by setting its properties. The resulting state uses the `CameraState` enum to return one of the below members.
 
-| Value       | Description                                                        |
-|-------------|--------------------------------------------------------------------|
-| `RECORDING`    | The camera is currently recording.                                 |
-| `STREAMING`   | The camera is currently streaming.                                 |
-| `IDLE` | The camera is currently idle.                                      |
+| Value      | Description                             |
+|------------|-----------------------------------------|
+| `RECORDING`| The camera is currently recording.      |
+| `STREAMING`| The camera is currently streaming.      |
+| `IDLE`     | The camera is currently idle.           |
 
 
 ## Supported features


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
For `camera` clarify we construct the state from it's properties and returns a `CameraState` enum
Core PR: https://github.com/home-assistant/core/pull/126558

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated documentation for the camera entity to include a new section on camera states.
	- Introduced the `CameraState` enum with three states: `RECORDING`, `STREAMING`, and `IDLE`, enhancing user understanding of camera operations.
- **Documentation**
	- Added a new markdown document detailing the deprecation of state constants in the `Camera` component, effective from version 2024.10, with a one-year deprecation period.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->