### PR TITLE
Add blog for deprecation of feature flag constants in vacuum

### DIFF
--- a/blog/2024-09-23-feature-flag-constants-vacuum-deprecation.md
+++ b/blog/2024-09-23-feature-flag-constants-vacuum-deprecation.md
@@ -8,4 +8,4 @@ title: "Deprecating feature flag constants for Vacuum"
 
 As of Home Assistant Core 2022.5, the feature flag constants used in `StateVacuumEntity` were deprecated and replaced by the `VacuumEntityFeature` enum.
 
-However, there was no proper deprecation done and therefore we start the one-year deprecation period in 2024.10, and the the constants will stop to work from 2025.10 to ensure all custom integration authors have time to adjust.
+However, there was no proper deprecation done and therefore now in 2024.10 we start the one-year deprecation period. The constants will stop working from 2025.10, to ensure all custom integration authors have time to adjust.

--- a/blog/2024-09-23-feature-flag-constants-vacuum-deprecation.md
+++ b/blog/2024-09-23-feature-flag-constants-vacuum-deprecation.md
@@ -3,9 +3,9 @@ author: G Johansson
 authorURL: https://github.com/gjohansson-ST
 authorImageURL: https://avatars.githubusercontent.com/u/62932417?v=4
 authorTwitter: GJohansson
-title: "Deprecating state constants for lock"
+title: "Deprecating feature flag constants for Vacuum"
 ---
 
-As of Home Assistant Core 2022.5, the feature flag constants used in `StateVacuumEntity` was deprecated and replaced by the `VacuumEntityFeature` enum.
+As of Home Assistant Core 2022.5, the feature flag constants used in `StateVacuumEntity` were deprecated and replaced by the `VacuumEntityFeature` enum.
 
 However, there was no proper deprecation done and therefore we start the one-year deprecation period in 2024.10, and the the constants will stop to work from 2025.10 to ensure all custom integration authors have time to adjust.

--- a/blog/2024-09-23-feature-flag-constants-vacuum-deprecation.md
+++ b/blog/2024-09-23-feature-flag-constants-vacuum-deprecation.md
@@ -1,0 +1,11 @@
+---
+author: G Johansson
+authorURL: https://github.com/gjohansson-ST
+authorImageURL: https://avatars.githubusercontent.com/u/62932417?v=4
+authorTwitter: GJohansson
+title: "Deprecating state constants for lock"
+---
+
+As of Home Assistant Core 2022.5, the feature flag constants used in `StateVacuumEntity` was deprecated and replaced by the `VacuumEntityFeature` enum.
+
+However, there was no proper deprecation done and therefore we start the one-year deprecation period in 2024.10, and the the constants will stop to work from 2025.10 to ensure all custom integration authors have time to adjust.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Blog for deprecation of the vacuum feature flag constants (which was already by text deprecated already before).
Core PR: https://github.com/home-assistant/core/pull/126354

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a new entry detailing the deprecation of feature flag constants for the `StateVacuumEntity`, effective October 2024, with a transition to the `VacuumEntityFeature` enum.
	- Provided a timeline for the deprecation period and guidance for custom integration authors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->