### PR TITLE
Light state is enum

### DIFF
--- a/blog/2024-09-24-state-constant-light-deprecation.md
+++ b/blog/2024-09-24-state-constant-light-deprecation.md
@@ -1,0 +1,13 @@
+---
+author: G Johansson
+authorURL: https://github.com/gjohansson-ST
+authorImageURL: https://avatars.githubusercontent.com/u/62932417?v=4
+authorTwitter: GJohansson
+title: "Deprecating state constant for light"
+---
+
+As of Home Assistant Core 2024.10, the constant `STATE_ON` used to return state in `LightEntity` are deprecated when imported from `homeassistant.components.light`. It has been replaced by the `LightState` enum.
+
+There is a one-year deprecation period, and the constants will stop working from 2025.10 to ensure all custom integration authors have time to adjust.
+
+As the `state` property is not meant to be overwritten, in most cases this change will only affect other Entity properties, methods or tests rather than the `state` property.

--- a/docs/core/entity/light.md
+++ b/docs/core/entity/light.md
@@ -25,6 +25,15 @@ A light entity controls the brightness, hue and saturation color value, white va
 | supported_color_modes | <code>set[ColorMode] &#124; None</code>                 | `None` | Flag supported color modes.
 | xy_color              | <code>tuple[float, float] &#124; None</code>            | `None` | The xy color value (float, float). This property will be copied to the light's state attribute when the light's color mode is set to `ColorMode.XY` and ignored otherwise.
 
+### States
+
+The state is defined by setting the above `is_on` method. The resulting state is using the `LightState` enum to return one of the below members.
+
+| Value   | Description                                   |
+|---------|-----------------------------------------------|
+| `ON`    | The light is on.                              |
+| `OFF`   | The light is off.                             |
+
 ## Color modes
 
 New integrations must implement both `color_mode` and `supported_color_modes`. If an integration is upgraded to support color mode, both `color_mode` and `supported_color_modes` should be implemented.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Modify `light` as it returns `LightState` enum members.
Blog for deprecated `STATE_ON` constant when imported from `homeassistant.components.light`
Core PR: https://github.com/home-assistant/core/pull/126678

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `LightState` enum with `ON` and `OFF` values for better state representation.
	- Added a new documentation section detailing the states of the light entity.

- **Bug Fixes**
	- Deprecated the `STATE_ON` constant with a one-year grace period before it is removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->