### PR TITLE
Document async_has_matching_flow

### DIFF
--- a/docs/config_entries_config_flow_handler.md
+++ b/docs/config_entries_config_flow_handler.md
@@ -92,7 +92,7 @@ If a unique ID isn't available, alternatively, the `bluetooth`, `dhcp`, `zerocon
 the integration manifest. In that case, the `user` step will be called when the item is discovered.
 
 Alternatively, if an integration can't get a unique ID all the time (e.g., multiple devices, some have one, some don't), a helper is available
-that still allows for discovery, as long as there aren't any instances of the integrations configured yet.
+that still allows for discovery, as long as there aren't any instances of the integration configured yet.
 
 Here's an example of how to handle discovery where a unique ID is not always available:
 

--- a/docs/config_entries_config_flow_handler.md
+++ b/docs/config_entries_config_flow_handler.md
@@ -170,6 +170,8 @@ The Unique ID can be used to update the config entry data when device access det
 When an integration is discovered, their respective discovery step is invoked (ie `async_step_dhcp` or `async_step_zeroconf`) with the discovery information. The step will have to check the following things:
 
 - Make sure there are no other instances of this config flow in progress of setting up the discovered device. This can happen if there are multiple ways of discovering that a device is on the network.
+  - In most cases, it's enough to set the unique ID on the flow and check if there's already a config entry with the same unique ID as explained in the section about [managing unique IDs in config flows](#managing-unique-ids-in-config-flows)
+  - In some cases, a unique ID can't be determined or the unique ID is ambiguous because different discovery sources may have different ways to calculate the unique ID. In this case, implement the method `def is_matching(self, other_flow: Self) -> bool` on the flow and call `hass.config_entries.flow.async_has_matching_flow(self)`. Your flow's `is_matching` method will then be called once for each other ongoing flow.
 - Make sure that the device is not already set up.
 - Invoking a discovery step should never result in a finished flow and a config entry. Always confirm with the user.
 

--- a/docs/config_entries_config_flow_handler.md
+++ b/docs/config_entries_config_flow_handler.md
@@ -171,7 +171,10 @@ When an integration is discovered, their respective discovery step is invoked (i
 
 - Make sure there are no other instances of this config flow in progress of setting up the discovered device. This can happen if there are multiple ways of discovering that a device is on the network.
   - In most cases, it's enough to set the unique ID on the flow and check if there's already a config entry with the same unique ID as explained in the section about [managing unique IDs in config flows](#managing-unique-ids-in-config-flows)
-  - In some cases, a unique ID can't be determined or the unique ID is ambiguous because different discovery sources may have different ways to calculate the unique ID. In this case, implement the method `def is_matching(self, other_flow: Self) -> bool` on the flow and call `hass.config_entries.flow.async_has_matching_flow(self)`. Your flow's `is_matching` method will then be called once for each other ongoing flow.
+  - In some cases, a unique ID can't be determined, or the unique ID is ambiguous because different discovery sources may have different ways to calculate it. In such cases:
+    1. Implement the method `def is_matching(self, other_flow: Self) -> bool` on the flow.
+    2. Call `hass.config_entries.flow.async_has_matching_flow(self)`.
+    3. Your flow's `is_matching` method will then be called once for each other ongoing flow.
 - Make sure that the device is not already set up.
 - Invoking a discovery step should never result in a finished flow and a config entry. Always confirm with the user.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Document async_has_matching_flow

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/126804


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated guidelines on using unique IDs in configuration flows to prevent duplicate device setups.
	- Clarified the handling of unique ID collisions and the implications for various integration methods.
	- Introduced a helper method for scenarios where unique IDs are not consistently available, enhancing user experience during discovery.
	- Emphasized the requirement of unique IDs for Bluetooth, DHCP, HomeKit, Zeroconf/mDNS, USB, or SSDP/uPnP integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->