### PR TITLE
Add mise install docs for frontend

### DIFF
--- a/docs/frontend/development.md
+++ b/docs/frontend/development.md
@@ -3,6 +3,9 @@ title: "Frontend development"
 sidebar_label: "Development"
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 The Home Assistant frontend is built using web components. For more background about our technology choices, [see this blog post](https://developers.home-assistant.io/blog/2019/05/22/internet-of-things-and-the-modern-web.html).
 
 :::caution
@@ -53,19 +56,30 @@ The change to `.devcontainer/devcontainer.json` should be excluded from any PR a
 :::
 
 ### Installing Node.js
+<Tabs groupId="operating-systems">
+  <TabItem value="nvm" label="NVM">
+    Node.js is required to build the frontend. The preferred method of installing node.js is with [nvm](https://github.com/nvm-sh/nvm). Install nvm using the instructions in the [README](https://github.com/nvm-sh/nvm#install--update-script), and install the correct node.js by running the following command inside the home-assistant/frontend repository:
 
-Node.js is required to build the frontend. The preferred method of installing node.js is with [nvm](https://github.com/nvm-sh/nvm). Install nvm using the instructions in the [README](https://github.com/nvm-sh/nvm#install--update-script), and install the correct node.js by running the following command:
+    ```shell
+    nvm install
+    ```
 
-```shell
-nvm install
-```
+    [Yarn](https://yarnpkg.com/en/) is used as the package manager for node modules. [Install yarn using the instructions here.](https://yarnpkg.com/getting-started/install)
+  </TabItem>
+  <TabItem value="mise" label="Mise">
+    Node.js are required to build the frontend and [Yarn](https://yarnpkg.com/en/) is used as the package manager for node modules.
+    
+    You can install both with [mise](https://mise.jdx.dev/). Install mise using the [getting started](https://mise.jdx.dev/getting-started.html) instructions, and install the correct node.js and yarn version by running the following command inside the home-assistant/frontend repository:
 
-[Yarn](https://yarnpkg.com/en/) is used as the package manager for node modules. [Install yarn using the instructions here.](https://yarnpkg.com/getting-started/install)
+    ```shell
+    mise install
+    ```  
+  </TabItem>
+</Tabs>
 
 Next, development dependencies need to be installed to bootstrap the frontend development environment. First activate the right Node version and then download all the dependencies:
 
 ```shell
-nvm use
 script/bootstrap
 script/setup_translations
 ```


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Add instructions on how to install the correct nodejs and yarn version using mise.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
- Link to relevant existing code or pull request: https://github.com/home-assistant/frontend/pull/22119


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a tabbed interface for Node.js installation instructions, allowing users to choose between NVM and Mise methods.
	- Added a link to Mise's getting started guide and commands for installation using Mise.

- **Documentation**
	- Improved clarity and usability of the installation instructions by restructuring them into separate tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->