### PR TITLE
Minor grammar fixes in custom card docs

### DIFF
--- a/docs/frontend/custom-ui/custom-card.md
+++ b/docs/frontend/custom-ui/custom-card.md
@@ -51,7 +51,7 @@ class ContentCardExample extends HTMLElement {
     return 3;
   }
 
-  // The rules for your card for sizing your card if the grid in section view
+  // The rules for sizing your card in the grid in section view
   getLayoutOptions() {
     return {
       grid_rows: 3,
@@ -106,7 +106,7 @@ return customElements
 
 ### Sizing in sections view
 
-You card can define a `getLayoutOptions` method that returns the min, max and default number of cells your card will take in the grid if your card is used if the [sections view](https://www.home-assistant.io/dashboards/sections/)
+You card can define a `getLayoutOptions` method that returns the min, max and default number of cells your card will take in the grid if your card is used in the [sections view](https://www.home-assistant.io/dashboards/sections/).
 If you don't define this method, the card will take 4 columns (full width) and will ignore the rows of the grid.
 
 A cell of the grid is defined with the following dimension:

--- a/docs/frontend/custom-ui/custom-card.md
+++ b/docs/frontend/custom-ui/custom-card.md
@@ -51,7 +51,7 @@ class ContentCardExample extends HTMLElement {
     return 3;
   }
 
-  // The rules for sizing your card in the grid in section view
+  // The rules for sizing your card in the grid in sections view
   getLayoutOptions() {
     return {
       grid_rows: 3,
@@ -106,7 +106,7 @@ return customElements
 
 ### Sizing in sections view
 
-You card can define a `getLayoutOptions` method that returns the min, max and default number of cells your card will take in the grid if your card is used in the [sections view](https://www.home-assistant.io/dashboards/sections/).
+You can define a `getLayoutOptions` method that returns the min, max and default number of cells your card will take in the grid if your card is used in the [sections view](https://www.home-assistant.io/dashboards/sections/).
 If you don't define this method, the card will take 4 columns (full width) and will ignore the rows of the grid.
 
 A cell of the grid is defined with the following dimension:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
SSIA


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Improved clarity and correctness in the `custom-card.md` documentation for better understanding of custom card functionalities.
	- Revised comments and phrasing for the `getLayoutOptions` method to enhance readability and grammatical accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->