### PR TITLE
Add blog post about update entity changes

### DIFF
--- a/blog/2024-10-31-update-entity-changes.md
+++ b/blog/2024-10-31-update-entity-changes.md
@@ -15,4 +15,12 @@ The `update` entity has been adjusted:
 
 Until Home Assistant Core 2025.12, a numerical value in the `in_progress` property will be automatically copied to the `update_percentage` state attribute.
 
+### Documentation and core implementation
+
 See the [update entity developer documentation](https://developers.home-assistant.io/docs/core/entity/update) for details.
+
+PRs:
+- PR adding the [`update_percentage` state attribute](https://github.com/home-assistant/core/pull/128877)
+- PR adding the [`update_percentage` property](https://github.com/home-assistant/core/pull/128908)
+- PR adding the [`display_precision` state attribute and property](https://github.com/home-assistant/core/pull/128930)
+- An example of [updating an integration's update entity](https://github.com/home-assistant/core/pull/129380)

--- a/blog/2024-10-31-update-entity-changes.md
+++ b/blog/2024-10-31-update-entity-changes.md
@@ -9,7 +9,7 @@ title: "Changes to the update entity"
 The `update` entity has been adjusted:
 - The `in_progress` property and the corresponding state attribute should now only be a `bool` indicating if an update is in progress, or `None` if unknown.
 - A new property and a corresponding state attribute `update_percentage` has been added which can either return an `int` or `float` indicating the progress from 0 to 100% or None.
-- A new property and a corresponding state attribute `display_precision` to control the number of decimals to display in frontend when `update_percentage` is a `float`.
+- A new property and a corresponding state attribute `display_precision` to control the number of decimals to display in the frontend when `update_percentage` is a `float`.
 
 ### Backwards compatibility
 

--- a/blog/2024-10-31-update-entity-changes.md
+++ b/blog/2024-10-31-update-entity-changes.md
@@ -9,7 +9,7 @@ title: "Changes to the update entity"
 The `update` entity has been adjusted:
 - The `in_progress` property and the corresponding state attribute should now only be a `bool` indicating if an update is in progress, or `None` if unknown.
 - A new property and a corresponding state attribute `update_percentage` has been added which can either return an `int` or `float` indicating the progress from 0 to 100% or None.
-- A new property and a corresponding state attribute `display_precision` to control the number of decimals to display in the frontend when `update_percentage` is a `float`.
+- A new property and a corresponding state attribute `display_precision` has been added to control the number of decimals to display in the frontend when `update_percentage` is a `float`.
 
 ### Backwards compatibility
 

--- a/blog/2024-10-31-update-entity-changes.md
+++ b/blog/2024-10-31-update-entity-changes.md
@@ -1,0 +1,18 @@
+---
+author: Erik Montnemery
+authorURL: https://github.com/emontnemery
+title: "Changes to the update entity"
+---
+
+### Summary of changes
+
+The `update` entity has been adjusted:
+- The `in_progress` property and the corresponding state attribute should now only be a `bool` indicating if an update is in progress, or `None` if unknown.
+- A new property and a corresponding state attribute `update_percentage` has been added which can either return an `int` or `float` indicating the progress from 0 to 100% or None.
+- A new property and a corresponding state attribute `display_precision` to control the number of decimals to display in frontend when `update_percentage` is a `float`.
+
+### Backwards compatibility
+
+Until Home Assistant Core 2025.12, a numerical value in the `in_progress` property will be automatically copied to the `update_percentage` state attribute.
+
+See the [update entity developer documentation](https://developers.home-assistant.io/docs/core/entity/update) for details.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Add blog post about update entity changes

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `update_percentage` property to track the progress of updates.
	- Added `display_precision` property for controlling decimal display of update progress.
  
- **Improvements**
	- Refined the `in_progress` property to indicate update status as a boolean or `None`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->