### PR TITLE
Deprecate camera frontend_stream_type

### DIFF
--- a/docs/core/entity/camera.md
+++ b/docs/core/entity/camera.md
@@ -111,7 +111,7 @@ class MyCamera(Camera):
 
         Async means that it could take some time to process the offer and responses/message
         will be sent with the send_message callback.
-        This method is used by cameras with CameraEntityFeature.STREAM and StreamType.WEB_RTC.
+        This method is used by cameras with CameraEntityFeature.STREAM
         An integration overriding this method must also implement async_on_webrtc_candidate.
 
         Integrations can override with a native WebRTC implementation.

--- a/docs/core/entity/camera.md
+++ b/docs/core/entity/camera.md
@@ -15,7 +15,6 @@ Properties should always only return information from memory and not do I/O (lik
 | ------------------------ | ------------------------------------| ------- | --------------------------------------------------------------------------------------------------- |
 | brand                    | <code>str &#124; None</code>        | `None`  | The brand (manufacturer) of the camera.                                                             |
 | frame_interval           | `float`                             | 0.5     | The interval between frames of the stream.                                                          |
-| frontend_stream_type     | <code>StreamType &#124; None</code> | `None`  | Used with `CameraEntityFeature.STREAM` to tell the frontend which type of stream to use (`StreamType.HLS` or `StreamType.WEB_RTC`) |
 | is_on                    | `bool`                              | `True`  | Indication of whether the camera is on.                                                             |
 | is_recording             | `bool`                              | `False` | Indication of whether the camera is recording. Used to determine `state`.                           |
 | is_streaming             | `bool`                              | `False` | Indication of whether the camera is streaming. Used to determine `state`.                           |
@@ -93,15 +92,14 @@ A common way for a camera entity to render a camera still image is to pass the s
 
 ### WebRTC streams
 
-WebRTC enabled cameras can be used by facilitating a direct connection with the home assistant frontend. This usage requires `CameraEntityFeature.STREAM` with `frontend_stream_type` set to `StreamType.WEB_RTC`.
-
-The integration must implement the two following methods to support native WebRTC:
+WebRTC enabled cameras can be used by facilitating a direct connection with the home assistant frontend. This usage requires `CameraEntityFeature.STREAM` and the integration must implement the two following methods to support native WebRTC:
 - `async_handle_async_webrtc_offer`: To initialize a WebRTC stream. Any messages/errors coming in async should be forwared to the frontend with the `send_message` callback.
 - `async_on_webrtc_candidate`: The frontend will call it with any candidate coming in after the offer is sent.
 The following method can optionally be implemented:
 - `close_webrtc_session` (Optional): The frontend will call it when the stream is closed. Can be used to clean up things.
 
 WebRTC streams do not use the `stream` component and do not support recording.
+By implementing the WebRTC methods, the frontend assumes that the camera supports only WebRTC and therefore will not fallbac to HLS.
 
 ```python
 class MyCamera(Camera):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Remove deprecated camera frontend_stream_type

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [x] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/130932


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated camera entity documentation to clarify WebRTC support requirements.
	- Removed the `frontend_stream_type` property from WebRTC streams description.
	- Specified necessary methods for WebRTC integration: `async_handle_async_webrtc_offer` and `async_on_webrtc_candidate`.
	- Emphasized that WebRTC streams do not support recording and do not utilize the `stream` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->