### PR TITLE
Clarify DHCP entry matching

### DIFF
--- a/docs/creating_integration_manifest.md
+++ b/docs/creating_integration_manifest.md
@@ -348,7 +348,6 @@ For example:
     {
     "hostname": "[d|p]achio-*",
     "macaddress": "009D6B*"
-    ""
     }
   ]
 }

--- a/docs/creating_integration_manifest.md
+++ b/docs/creating_integration_manifest.md
@@ -346,7 +346,7 @@ For example:
     "macaddress": "009D6B*"
     },
     {
-    "hostname": "[d|p]achio-*",
+    "hostname": "[dp]achio-*",
     "macaddress": "009D6B*"
     }
   ]

--- a/docs/creating_integration_manifest.md
+++ b/docs/creating_integration_manifest.md
@@ -319,7 +319,7 @@ Integrations depending on MQTT should wait using `await mqtt.async_wait_for_mqtt
 
 ## DHCP
 
-If your integration supports discovery via dhcp, you can add the type to your manifest. If the user has the `dhcp` integration loaded, it will load the `dhcp` step of your integration's config flow when it is discovered. We support passively listening for DHCP discovery by the `hostname` and [OUI](https://en.wikipedia.org/wiki/Organizationally_unique_identifier), or matching device registry mac address when `registered_devices` is set to `true`. The manifest value is a list of matcher dictionaries, your integration is discovered if all items of any of the specified matchers are found in the DHCP data. It's up to your config flow to filter out duplicates.
+If your integration supports discovery via DHCP, you can add the type to your manifest. If the user has the `dhcp` integration loaded, it will load the `dhcp` step of your integration's config flow when it is discovered. We support passively listening for DHCP discovery by the `hostname` and [OUI](https://en.wikipedia.org/wiki/Organizationally_unique_identifier), or matching device registry mac address when `registered_devices` is set to `true`. The manifest value is a list of matcher dictionaries, your integration is discovered if all items of any of the specified matchers are found in the DHCP data. [Unix filename pattern matching](https://docs.python.org/3/library/fnmatch.html) is used for matching. It's up to your config flow to filter out duplicates.
 
 If an integration wants to receive discovery flows to update the IP Address of a device when it comes
 online, but a `hostname` or `oui` match would be too broad, and it has registered in the device registry with mac address using the `CONNECTION_NETWORK_MAC`,
@@ -332,9 +332,10 @@ The following example has three matchers consisting of two items. All of the ite
 
 For example:
 
--  If the `hostname` was `Rachio-XYZ` and the `macaddress` was `00:9D:6B:55:12:AA`, the discovery would happen.
--  If the `hostname` was `Rachio-XYZ` and the `macaddress` was `00:00:00:55:12:AA`, the discovery would not happen.
--  If the `hostname` was `NotRachio-XYZ` and the `macaddress` was `00:9D:6B:55:12:AA`, the discovery would not happen.
+-  If the `hostname` was `Rachio-XYZ` and the `macaddress` was `00:9D:6B:55:12:AA`, the discovery would happen (1st matcher).
+-  If the `hostname` was `Dachio-XYZ` or `Pachio-XYZ`, and the `macaddress` was `00:9D:6B:55:12:AA`, the discovery would happen (3rd matcher).
+-  If the `hostname` was `Rachio-XYZ` and the `macaddress` was `00:00:00:55:12:AA`, the discovery would not happen (no matching MAC).
+-  If the `hostname` was `NotRachio-XYZ` and the `macaddress` was `00:9D:6B:55:12:AA`, the discovery would not happen (no matching hostname).
 
 
 ```json
@@ -345,12 +346,9 @@ For example:
     "macaddress": "009D6B*"
     },
     {
-    "hostname": "rachio-*",
-    "macaddress": "F0038C*"
-    },
-    {
-    "hostname": "rachio-*",
-    "macaddress": "74C63B*"
+    "hostname": "[d|p]achio-*",
+    "macaddress": "009D6B*"
+    ""
     }
   ]
 }

--- a/docs/creating_integration_manifest.md
+++ b/docs/creating_integration_manifest.md
@@ -328,7 +328,7 @@ it should add a DHCP entry with `registered_devices` set to `true`.
 If the integration supports `zeroconf` or `ssdp`, these should be preferred over `dhcp` as it generally offers a better
 user experience.
 
-The following example has three matchers consisting of two items. All of the items in any of the three matchers must match for discovery to happen by this config.
+The following example has two matchers consisting of two items. All of the items in any of the matchers must match for discovery to happen by this config.
 
 For example:
 


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Clarify that DHCP entry matching uses fnmatch to check for matches.
Adds an example using `[]` and shortens the example JSON by removing unused matchers.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the integration manifest documentation for improved clarity on setup requirements and examples.
	- Revised DHCP discovery section to specify Unix filename pattern matching for hostname matching.
	- Adjusted examples to reflect hostname variations, including "Dachio-XYZ" and "Pachio-XYZ."
	- Corrected the number of matchers in the DHCP example from three to two.
	- Clarified the explanation of discovery criteria, emphasizing that all specified matchers must match.
	- Minor grammatical corrections and formatting adjustments for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->