### PR TITLE
Allow multiple in sections

### DIFF
--- a/docs/data_entry_flow_index.md
+++ b/docs/data_entry_flow_index.md
@@ -189,6 +189,75 @@ To specify an icon for a section, update `icons.json` according to this example:
 }
 ```
 
+#### Use of repeating sections
+
+Developers can also set `multiple` in sections to allow the user to add/remove sections as needed to provide additional configuration.
+The output of the sections are then a list with dictionaries containing all the users configured sections.
+
+The use of `multiple` in sections also requires to set `default`.
+The use of `default` in sections has priority over defaults for the fields.
+
+|        Key         |        Type        |       Description                                 |
+| :----------------: | :----------------: | :-----------------------------------------: |
+|      `multiple`    |        `bool`      |    Allow user to add/remove sections                                    |
+|      `default`     |     `list[dict]`   |    Provide default values for the section                                     |
+
+```python
+from homeassistant.data_entry_flow import section
+from homeassistant.helpers.selector import selector
+
+class ExampleConfigFlow(data_entry_flow.FlowHandler):
+    async def async_step_user(self, user_input=None):
+        # Specify items in the order they are to be displayed in the UI
+        data_schema = {
+            vol.Required("username"): str,
+            vol.Required("password"): str,
+            # Items can be grouped by collapsible sections
+            "options": section(
+                vol.Schema(
+                    {
+                        vol.Required("stage_1", default=5): int,
+                        vol.Required("stage_2", default=10): int,
+                    }
+                ),
+                # Whether or not the section is initially collapsed (default = False),
+                # user can provide multiple sections (default = None) and 
+                # default values for the section in case of multiple (default = None)
+                {
+                    "collapsed": False,
+                    "multiple": True,
+                    "default": [],
+                },
+            )
+        }
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(data_schema)
+        )
+```
+
+The resulting output from the section is a list with dictionaries containing the values provided by the user.
+
+##### Example output from sections using multiple
+
+```json
+{
+    "username": "some_username",
+    "password": "some_password",
+    "options": [
+        {
+            "stage_1":7,
+            "stage_2":15
+        },
+        {
+            "stage_1":24,
+            "stage_2":4
+        }
+    ]
+}
+```
+
 #### Labels & descriptions
 
 Translations for the form are added to `strings.json` in a key for the `step_id`. That object may contain the folowing keys:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Allow to set and use multiple sections
Core PR: https://github.com/home-assistant/core/pull/131393
Frontend PR: https://github.com/home-assistant/frontend/pull/22965

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for repeating sections in data entry flows, enhancing user input flexibility.
	- Added documentation on the `multiple` and `default` keys, including usage examples and expected output format.

- **Documentation**
	- Updated `data_entry_flow_index.md` to include a new section on dynamic section management in data entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->