### PR TITLE
Add details about typed ConfigEntry in runtime-data and strict-typing IQS rule

### DIFF
--- a/docs/core/integration-quality-scale/rules/runtime-data.md
+++ b/docs/core/integration-quality-scale/rules/runtime-data.md
@@ -37,7 +37,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyIntegrationConfigEntry
 ```
 
 :::info
-If the integration implements `strict-typing`, the type of a `ConfigEntry` <ins>must</ins> be extended with the type of the data put in `runtime_data`.
+If the integration implements `strict-typing`, the use of a custom typed `MyIntegrationConfigEntry` is required and must be used thoughout.
 :::
 
 ## Additional resources

--- a/docs/core/integration-quality-scale/rules/runtime-data.md
+++ b/docs/core/integration-quality-scale/rules/runtime-data.md
@@ -1,6 +1,7 @@
 ---
 title: "Use ConfigEntry.runtime_data to store runtime data"
 related_rules:
+  - strict-typing
   - test-before-setup
 ---
 import RelatedRules from './_includes/related_rules.jsx'
@@ -15,7 +16,7 @@ Because of the added typing, we can use tooling to avoid typing mistakes.
 
 ## Example implementation
 
-The type of a `ConfigEntry` should be extended with the type of the data put in `runtime_data`.
+The type of a `ConfigEntry` can be extended with the type of the data put in `runtime_data`.
 In the following example, we extend the `ConfigEntry` type with `MyClient`, which means that the `runtime_data` attribute will be of type `MyClient`.
 
 `__init__.py`:

--- a/docs/core/integration-quality-scale/rules/runtime-data.md
+++ b/docs/core/integration-quality-scale/rules/runtime-data.md
@@ -15,13 +15,12 @@ Because of the added typing, we can use tooling to avoid typing mistakes.
 
 ## Example implementation
 
-The type of a `ConfigEntry` can be extended with the type of the data put in `runtime_data`.
+The type of a `ConfigEntry` should be extended with the type of the data put in `runtime_data`.
 In the following example, we extend the `ConfigEntry` type with `MyClient`, which means that the `runtime_data` attribute will be of type `MyClient`.
 
 `__init__.py`:
 ```python {1,4,9} showLineNumbers
 type MyIntegrationConfigEntry = ConfigEntry[MyClient]
-
 
 async def async_setup_entry(hass: HomeAssistant, entry: MyIntegrationConfigEntry) -> bool:
     """Set up my integration from a config entry."""

--- a/docs/core/integration-quality-scale/rules/runtime-data.md
+++ b/docs/core/integration-quality-scale/rules/runtime-data.md
@@ -36,6 +36,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyIntegrationConfigEntry
     return True
 ```
 
+:::warning
+If the integration implements `strict-typing`, the type of a `ConfigEntry` <ins>must</ins> be extended with the type of the data put in `runtime_data`.
+:::
+
 ## Additional resources
 
 More information about configuration entries and their lifecycle can be found in the [config entry documentation](../../../config_entries_index).

--- a/docs/core/integration-quality-scale/rules/runtime-data.md
+++ b/docs/core/integration-quality-scale/rules/runtime-data.md
@@ -23,6 +23,7 @@ In the following example, we extend the `ConfigEntry` type with `MyClient`, whic
 ```python {1,4,9} showLineNumbers
 type MyIntegrationConfigEntry = ConfigEntry[MyClient]
 
+
 async def async_setup_entry(hass: HomeAssistant, entry: MyIntegrationConfigEntry) -> bool:
     """Set up my integration from a config entry."""
 

--- a/docs/core/integration-quality-scale/rules/runtime-data.md
+++ b/docs/core/integration-quality-scale/rules/runtime-data.md
@@ -37,7 +37,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyIntegrationConfigEntry
 ```
 
 :::info
-If the integration implements `strict-typing`, the use of a custom typed `MyIntegrationConfigEntry` is required and must be used thoughout.
+If the integration implements `strict-typing`, the use of a custom typed `MyIntegrationConfigEntry` is required and must be used throughout.
 :::
 
 ## Additional resources

--- a/docs/core/integration-quality-scale/rules/runtime-data.md
+++ b/docs/core/integration-quality-scale/rules/runtime-data.md
@@ -36,7 +36,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyIntegrationConfigEntry
     return True
 ```
 
-:::warning
+:::info
 If the integration implements `strict-typing`, the type of a `ConfigEntry` <ins>must</ins> be extended with the type of the data put in `runtime_data`.
 :::
 

--- a/docs/core/integration-quality-scale/rules/strict-typing.md
+++ b/docs/core/integration-quality-scale/rules/strict-typing.md
@@ -19,7 +19,7 @@ This file tells mypy that your library is fully typed, after which it can read t
 In the Home Assistant codebase, you can add your integration to the [`.strict-typing`](https://github.com/home-assistant/core/blob/dev/.strict-typing) file, which will enable strict type checks for your integration.
 
 :::warning
-If the integration implements `runtime-data`, the type of a `ConfigEntry` <ins>must</ins> be extended with the type of the data put in `runtime_data`.
+If the integration implements `runtime-data`, the use of a custom typed `MyIntegrationConfigEntry` is required and must be used thoughout.
 :::
 
 ## Additional resources

--- a/docs/core/integration-quality-scale/rules/strict-typing.md
+++ b/docs/core/integration-quality-scale/rules/strict-typing.md
@@ -1,6 +1,9 @@
 ---
 title: "Strict typing"
----
+related_rules:
+  - runtime-data
+ ---
+import RelatedRules from './_includes/related_rules.jsx'
 
 ## Reasoning
 
@@ -15,6 +18,10 @@ This file tells mypy that your library is fully typed, after which it can read t
 
 In the Home Assistant codebase, you can add your integration to the [`.strict-typing`](https://github.com/home-assistant/core/blob/dev/.strict-typing) file, which will enable strict type checks for your integration.
 
+:::warning
+If the integration implements `runtime-data`, the type of a `ConfigEntry` <ins>must</ins> be extended with the type of the data put in `runtime_data`.
+:::
+
 ## Additional resources
 
 To read more about the `py.typed` file, see [PEP-561](https://peps.python.org/pep-0561/).
@@ -22,3 +29,7 @@ To read more about the `py.typed` file, see [PEP-561](https://peps.python.org/pe
 ## Exceptions
 
 There are no exceptions to this rule.
+
+## Related rules
+
+<RelatedRules relatedRules={frontMatter.related_rules}></RelatedRules>

--- a/docs/core/integration-quality-scale/rules/strict-typing.md
+++ b/docs/core/integration-quality-scale/rules/strict-typing.md
@@ -2,7 +2,7 @@
 title: "Strict typing"
 related_rules:
   - runtime-data
- ---
+---
 import RelatedRules from './_includes/related_rules.jsx'
 
 ## Reasoning

--- a/docs/core/integration-quality-scale/rules/strict-typing.md
+++ b/docs/core/integration-quality-scale/rules/strict-typing.md
@@ -19,7 +19,7 @@ This file tells mypy that your library is fully typed, after which it can read t
 In the Home Assistant codebase, you can add your integration to the [`.strict-typing`](https://github.com/home-assistant/core/blob/dev/.strict-typing) file, which will enable strict type checks for your integration.
 
 :::warning
-If the integration implements `runtime-data`, the use of a custom typed `MyIntegrationConfigEntry` is required and must be used thoughout.
+If the integration implements `runtime-data`, the use of a custom typed `MyIntegrationConfigEntry` is required and must be used throughout.
 :::
 
 ## Additional resources


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
If an integration has both `runtime-data` and `strict-typing`, then I think it should be compulsory to use the typed `CustomConfigEntry` throughout the integration.

cc @allenporter / @joostlek 

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
	- Updated the document on `ConfigEntry.runtime_data` to include a new related rule, "strict-typing," emphasizing type safety.
	- Added an informational note regarding the requirement of a custom typed `MyIntegrationConfigEntry` when implementing strict typing.
	- Enhanced the `strict-typing` document with a new "Related rules" section referencing `runtime-data` and included a warning about the custom entry requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->