### PR TITLE
Update unique-config-entry rule

### DIFF
--- a/docs/core/integration-quality-scale/rules/unique-config-entry.md
+++ b/docs/core/integration-quality-scale/rules/unique-config-entry.md
@@ -17,6 +17,8 @@ This can lead to duplicated devices and entities with unique identifiers collidi
 Any discovery flow must also ensure that a config entry is uniquely identifiable, as otherwise, it would discover devices already set up.
 
 To prevent this, we need to ensure that the user can only set up a device or service once.
+Trying to set up a device or service that is already set up should be prevented by the integration.
+This should be handled by the reconfiguration flow, in where we can be more consistent with what gets updated.
 
 ## Example implementation
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
The current unique-config-entry rule does not cover that a config flow started by the user should not be used to update data of an existing config entry. Instead, devs should implement and users should use the reconfiguration flow. This leaves for a more consistent user experience (since does setting up the device again update every field? Only the Host? Only the password? An end user can only guess).

So let's update the rule to mention that we don't want to re-use the config flow to change existing entry data.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
