### PR TITLE
Fix typos in integration quality scale rules

### DIFF
--- a/docs/core/integration-quality-scale/rules/common-modules.md
+++ b/docs/core/integration-quality-scale/rules/common-modules.md
@@ -45,7 +45,7 @@ class MyEntity(CoordinatorEntity[MyCoordinator]):
     def __init__(self, coordinator: MyCoordinator) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
-        self._attr_device_infp = ...
+        self._attr_device_info = ...
 ```
 
 ## Exceptions

--- a/docs/core/integration-quality-scale/rules/integration-owner.md
+++ b/docs/core/integration-quality-scale/rules/integration-owner.md
@@ -22,7 +22,7 @@ During reviews, we see the integration owner as the expert on the integration, a
 
 Integration owners are set in the `manifest.json`.
 
-```json {3} showLineNumbers
+```json {4} showLineNumbers
 {
   "domain": "my_integration",
   "name": "My Integration",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Minor corrections to the code examples in the integration quality scale rules.


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the "Has an integration owner" document with minor formatting changes and an updated JSON code block example.
- **Refactor**
	- Renamed the attribute `_attr_device_infp` to `_attr_device_info` in the `MyEntity` class for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->