### PR TITLE
Relocate ServiceInfo models

### DIFF
--- a/blog/2025-01-15-service-info.md
+++ b/blog/2025-01-15-service-info.md
@@ -1,10 +1,11 @@
 ---
 author: epenet
 authorURL: https://github.com/epenet
-title: "Relocate dhcp/ssdp/zeroconf ServiceInfo models"
+title: "Relocate dhcp/ssdp/usb/zeroconf ServiceInfo models"
 ---
 
 As of Home Assistant Core 2025.2, the following ServiceInfo models have been relocated:
 - `DhcpServiceInfo` from `homeassistant.components.dhcp` to `homeassistant.helpers.service_info.dhcp`
 - `SsdpServiceInfo` from `homeassistant.components.ssdp` to `homeassistant.helpers.service_info.ssdp`
+- `UsbServiceInfo` from `homeassistant.components.usb` to `homeassistant.helpers.service_info.usb`
 - `ZeroconfServiceInfo` from `homeassistant.components.zeroconf` to `homeassistant.helpers.service_info.zeroconf`

--- a/blog/2025-01-15-service-info.md
+++ b/blog/2025-01-15-service-info.md
@@ -6,13 +6,19 @@ title: "Relocate dhcp/ssdp/usb/zeroconf ServiceInfo models"
 
 ### Summary of changes
 
-In order to reduce current reliance on optional integrations for names that are in essence used as helpers, the following ServiceInfo models have been relocated:
+To reduce current reliance on optional integrations for names that are in essence used as helpers, the following ServiceInfo models have been relocated:
 - `DhcpServiceInfo` from `homeassistant.components.dhcp` to `homeassistant.helpers.service_info.dhcp`
 - `SsdpServiceInfo` from `homeassistant.components.ssdp` to `homeassistant.helpers.service_info.ssdp`
 - `UsbServiceInfo` from `homeassistant.components.usb` to `homeassistant.helpers.service_info.usb`
 - `ZeroconfServiceInfo` from `homeassistant.components.zeroconf` to `homeassistant.helpers.service_info.zeroconf`
 
-Importing these from the old location will fail from 2026.2.
+
+To update your integration:
+1. Replace the import statements as shown in the examples below
+2. Test your integration with the new imports
+
+The old import locations are deprecated and will be removed in Home Assistant 2026.2.
+
 
 ### Examples
 

--- a/blog/2025-01-15-service-info.md
+++ b/blog/2025-01-15-service-info.md
@@ -1,0 +1,10 @@
+---
+author: epenet
+authorURL: https://github.com/epenet
+title: "Relocate dhcp/ssdp/zeroconf ServiceInfo models"
+---
+
+As of Home Assistant Core 2025.2, the following ServiceInfo models have been relocated:
+- `DhcpServiceInfo` from `homeassistant.components.dhcp` to `homeassistant.helpers.service_info.dhcp`
+- `SsdpServiceInfo` from `homeassistant.components.ssdp` to `homeassistant.helpers.service_info.ssdp`
+- `ZeroconfServiceInfo` from `homeassistant.components.zeroconf` to `homeassistant.helpers.service_info.zeroconf`

--- a/blog/2025-01-15-service-info.md
+++ b/blog/2025-01-15-service-info.md
@@ -38,11 +38,11 @@ from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 class MyConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow."""
 
-    async def async_step_usb(self, discovery_info: DhcpServiceInfo) -> ConfigFlowResult:
+    async def async_step_dhcp(self, discovery_info: DhcpServiceInfo) -> ConfigFlowResult:
         """Handle dhcp discovery."""
         ...
 
-    async def async_step_usb(self, discovery_info: SsdpServiceInfo) -> ConfigFlowResult:
+    async def async_step_ssdp(self, discovery_info: SsdpServiceInfo) -> ConfigFlowResult:
         """Handle ssdp discovery."""
         ...
 

--- a/blog/2025-01-15-service-info.md
+++ b/blog/2025-01-15-service-info.md
@@ -4,8 +4,47 @@ authorURL: https://github.com/epenet
 title: "Relocate dhcp/ssdp/usb/zeroconf ServiceInfo models"
 ---
 
-As of Home Assistant Core 2025.2, the following ServiceInfo models have been relocated:
+### Summary of changes
+
+In order to reduce current reliance on optional integrations for names that are in essence used as helpers, the following ServiceInfo models have been relocated:
 - `DhcpServiceInfo` from `homeassistant.components.dhcp` to `homeassistant.helpers.service_info.dhcp`
 - `SsdpServiceInfo` from `homeassistant.components.ssdp` to `homeassistant.helpers.service_info.ssdp`
 - `UsbServiceInfo` from `homeassistant.components.usb` to `homeassistant.helpers.service_info.usb`
 - `ZeroconfServiceInfo` from `homeassistant.components.zeroconf` to `homeassistant.helpers.service_info.zeroconf`
+
+Importing these from the old location will fail from 2026.2.
+
+### Examples
+
+```python
+# Old
+# from homeassistant.components.dhcp import DhcpServiceInfo
+# from homeassistant.components.ssdp import SsdpServiceInfo
+# from homeassistant.components.usb import UsbServiceInfo
+# from homeassistant.components.zeroconf import ZeroconfServiceInfo
+
+# New
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
+from homeassistant.helpers.service_info.usb import UsbServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+
+class MyConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow."""
+
+    async def async_step_usb(self, discovery_info: DhcpServiceInfo) -> ConfigFlowResult:
+        """Handle dhcp discovery."""
+        ...
+
+    async def async_step_usb(self, discovery_info: SsdpServiceInfo) -> ConfigFlowResult:
+        """Handle ssdp discovery."""
+        ...
+
+    async def async_step_usb(self, discovery_info: UsbServiceInfo) -> ConfigFlowResult:
+        """Handle usb discovery."""
+        ...
+
+    async def async_step_zeroconf(self, discovery_info: ZeroconfServiceInfo) -> ConfigFlowResult:
+        """Handle zeroconf discovery."""
+        ...
+```


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Linked to:
- https://github.com/home-assistant/core/pull/135653
- https://github.com/home-assistant/core/pull/135658
- https://github.com/home-assistant/core/pull/135661
- https://github.com/home-assistant/core/pull/135663

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated blog post for Home Assistant Core version 2025.2
	- Documented relocation of ServiceInfo models to a new unified helper directory
	- Clarified new locations for `DhcpServiceInfo`, `SsdpServiceInfo`, `UsbServiceInfo`, and `ZeroconfServiceInfo`
	- Noted that importing models from old locations will fail starting from version 2026.2
<!-- end of auto-generated comment: release notes by coderabbit.ai -->