### PR TITLE
use ghcr image in addon development

### DIFF
--- a/docs/add-ons/testing.md
+++ b/docs/add-ons/testing.md
@@ -42,16 +42,16 @@ docker run \
 
 If you don't want to use the official build tool, you can still build with standalone Docker. If you use `FROM $BUILD_FROM` you'll need to set a base image with build args. Normally you can use following base images:
 
-- armhf: `homeassistant/armhf-base:latest`
-- aarch64: `homeassistant/aarch64-base:latest`
-- amd64: `homeassistant/amd64-base:latest`
-- i386: `homeassistant/i386-base:latest`
+- armhf: `ghcr.io/home-assistant/armhf-base:latest`
+- aarch64: `ghcr.io/home-assistant/aarch64-base:latest`
+- amd64: `ghcr.io/home-assistant/amd64-base:latest`
+- i386: `ghcr.io/home-assistant/i386-base:latest`
 
 Use `docker` from the directory containing the add-on files to build the test addon:
 
 ```shell
 docker build \
-  --build-arg BUILD_FROM="homeassistant/amd64-base:latest" \
+  --build-arg BUILD_FROM="ghcr.io/home-assistant/amd64-base:latest" \
   -t local/my-test-addon \
   .
 ```


### PR DESCRIPTION
The docker hub images seem extremely outdated

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Update docker images similar to #2134

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [x] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
