### PR TITLE
Fix invalid yaml

### DIFF
--- a/docs/documenting/yaml-style-guide.md
+++ b/docs/documenting/yaml-style-guide.md
@@ -227,9 +227,9 @@ list `[]` by default.
 ```yaml
 # Good
 - alias: "Test"
-    triggers:
-      -  trigger: state
-         entity_id: binary_sensor.motion
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.motion
 
 # Bad
 - alias: "Test"

--- a/docs/documenting/yaml-style-guide.md
+++ b/docs/documenting/yaml-style-guide.md
@@ -233,10 +233,10 @@ list `[]` by default.
 
 # Bad
 - alias: "Test"
-    triggers:
-      -  trigger: state
-         entity_id: binary_sensor.motion
-    condition: []
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.motion
+  condition: []
 ```
 
 ### Strings (continued)
@@ -311,8 +311,8 @@ actions:
   - action: light.turn_on
     entity_id: light.living_room
   - action: light.turn_on
-     data:
-       entity_id: light.living_room
+    data:
+      entity_id: light.living_room
 ```
 
 ### Properties that accept a scalar or a list of scalars


### PR DESCRIPTION

## Proposed change
The object keys need to be at the same indentation.

## Type of change
- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated YAML style guide with improved clarity and consistency.
	- Enhanced examples in the "Default values" and "Service action targets" sections.
	- Corrected indentation for the `triggers` and `data` fields to align with established standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->