### PR TITLE
Document created field for supervisor jobs

### DIFF
--- a/docs/api/supervisor/models.md
+++ b/docs/api/supervisor/models.md
@@ -298,6 +298,7 @@ Response only fields will be in responses but cannot be included in requests.
 | progress   | int     | Progress of the job (if accurate progress is obtainable)      |
 | stage      | string  | A name for the stage the job is in (if applicable)            |
 | done       | boolean | Is the job complete                                           |
+| created    | string  | Date and time when job was created in ISO format              |
 | child_jobs | list    | A list of child [jobs](#job) started by this one              |
 | errors     | list    | A list of [errors](#job-error) that occurred during execution |
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Document `created` field added in https://github.com/home-assistant/supervisor/pull/5545


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/supervisor/pull/5545


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated supervisor API documentation to include a new `created` field in the Job model, providing a timestamp for job creation in ISO format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->