### PR TITLE
Revert "Update application_credentials example with redirect_url"

### DIFF
--- a/docs/core/platform/application_credentials.md
+++ b/docs/core/platform/application_credentials.md
@@ -132,7 +132,7 @@ Translations for Application Credentials are defined under the `application_cred
 ```json
 {
     "application_credentials": {
-        "description": "Navigate to the [developer console]({console_url}) to create credentials. Add `{redirect_url}` under *Authorized redirect URI*. Then enter the credentials below.",
+        "description": "Navigate to the [developer console]({console_url}) to create credentials then enter them below.",
     }
 }
 ```
@@ -141,13 +141,11 @@ You may optionally add description placeholder keys that are added to the messag
 
 ```python
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_entry_oauth2_flow
 
 async def async_get_description_placeholders(hass: HomeAssistant) -> dict[str, str]:
     """Return description placeholders for the credentials dialog."""
     return {
         "console_url": "https://example.com/developer/console",
-        "redirect_url": config_entry_oauth2_flow.async_get_redirect_uri(hass),
     }
 ```
 


### PR DESCRIPTION
Reverts home-assistant/developers.home-assistant#2547

See https://github.com/home-assistant/core/pull/137791#issuecomment-2644560510

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Revised the Application Credentials guide for clearer, more concise setup instructions.
  - Removed outdated details, streamlining the process for creating and entering credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->