### PR TITLE
Add hassfest strings.json blog article

### DIFF
--- a/blog/2025-02-11-hassfest-prioritizes-strings-json.md
+++ b/blog/2025-02-11-hassfest-prioritizes-strings-json.md
@@ -4,8 +4,48 @@ authorURL: https://github.com/thomasddn
 title: "Hassfest prioritizes strings.json for custom integrations"
 ---
 
+### Summary of changes
+
 The hassfest validation will now check against `strings.json` instead of `translations/en.json` for custom integrations, but only if `strings.json` exists. If `strings.json` does not exist, then the validation will run against `translations/en.json`, just like it did before.
 
-Custom integrations might resolve to `strings.json` in combination with a translation provider (e.g. Lokalise). The advantage is that you can reference other keys for common translation values, which makes translating to different languages less tedious and less error prone.
+Custom integrations might resolve to `strings.json` in combination with a translation provider (e.g. Lokalise). The advantage is that you can reference other keys for common translation values, which makes translating to different languages less tedious and less error-prone.
 
 If you are not actually using `strings.json` in your custom integration but still have it there (because it was copied from examples or core components), you can remove the file to make hassfest work like before.
+
+### Examples
+
+A `strings.json` file using references to common keys. A translation provider will replace the key references with their actual value. How common keys must be referenced depends on the translation provider.
+
+```json
+{
+    "common": {
+        "error": "Error",
+        "unknown": "Unknown"
+    },
+    "entity": {
+        "sensor": {
+            "charging_connection_status": {
+                "name": "Charging connection status",
+                "state": {
+                    "connection_status_connected_ac": "Connected AC",
+                    "connection_status_connected_dc": "Connected DC",
+                    "connection_status_disconnected": "Disconnected",
+                    "connection_status_fault": "[%key:common::error%]",
+                    "connection_status_unspecified": "[%key:common::unknown%]"
+                }
+            },
+            "charging_system_status": {
+                "name": "Charging status",
+                "state": {
+                    "charging_system_charging": "Charging",
+                    "charging_system_done": "Done",
+                    "charging_system_fault": "[%key:common::error%]",
+                    "charging_system_idle": "Idle",
+                    "charging_system_scheduled": "Scheduled",
+                    "charging_system_unspecified": "[%key:common::unknown%]"
+                }
+            }
+        }
+    }
+}
+```

--- a/blog/2025-02-11-hassfest-prioritizes-strings-json.md
+++ b/blog/2025-02-11-hassfest-prioritizes-strings-json.md
@@ -1,0 +1,11 @@
+---
+author: thomasddn
+authorURL: https://github.com/thomasddn
+title: "Hassfest prioritizes strings.json for custom integrations"
+---
+
+The hassfest validation will now check against `strings.json` instead of `translations/en.json` for custom integrations, but only if `strings.json` exists. If `strings.json` does not exist, then the validation will run against `translations/en.json`, just like it did before.
+
+Custom integrations might resolve to `strings.json` in combination with a translation provider (e.g. Lokalise). The advantage is that you can reference other keys for common translation values, which makes translating to different languages less tedious and less error prone.
+
+If you are not actually using `strings.json` in your custom integration but still have it there (because it was copied from examples or core components), you can remove the file to make hassfest work like before.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

I was instructed to create a blog article about hassfest giving priority to strings.json for custom integrations, for which I made a PR (see link at the bottom). 

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: home-assistant/core#136849


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new documentation entry detailing the hassfest validation process for custom integrations, emphasizing the prioritization of `strings.json` for translation checks. The guide includes an example structure and advises users on reverting to previous validation behavior if `strings.json` is not utilized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->