### PR TITLE
Add remark to Cover entity docs about non-cover usage

### DIFF
--- a/docs/core/entity/cover.md
+++ b/docs/core/entity/cover.md
@@ -5,6 +5,11 @@ sidebar_label: Cover
 
 A cover entity controls an opening or cover, such as a garage door or a window shade. Derive a platform entity from [`homeassistant.components.cover.CoverEntity`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/cover/__init__.py).
 
+:::note
+The cover entity should only be used for devices that control an opening or cover.
+For other types of devices entities such as [Number](/docs/core/entity/number) should be used instead, even if that has not been the case in the past.
+:::
+
 ## Properties
 
 :::tip


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Adds a note to the Cover docs, as discussed with the core team, since we currently have at least 1 integration that is using `cover` for a standing desk and we do not want to repeat this in the future for other integrations.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified guidelines so that the cover entity is used only for devices controlling openings or covers.
  - Enhanced the property usage tip to emphasize returning data from memory while recommending designated methods for data fetching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->