### PR TITLE
Clarify config entry unload quality scale rule

### DIFF
--- a/docs/core/integration-quality-scale/rules/config-entry-unloading.md
+++ b/docs/core/integration-quality-scale/rules/config-entry-unloading.md
@@ -31,10 +31,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
 Integrations can use `entry.async_on_unload` to register callbacks which will be called when the config entry is unloaded or if it fails to set up.
 This can be useful to clean up resources without having to keep track of the removal methods yourself.
 The registered callbacks will be called if :
- - `async_setup_entry` raises either of `ConfigEntryError`, `ConfigEntryAuthFailed` or `ConfigEntryNotReady`
- - `async_unload_entry` suceeds, i.e. it returns True and does not raise.
+ - `async_setup_entry` raises either `ConfigEntryError`, `ConfigEntryAuthFailed`, or `ConfigEntryNotReady`
+ - `async_unload_entry` succeeds, i.e., it returns True and does not raise.
 
- Note that integrations always need to implement `async_unload_entry` to support config entry unloading, just calling `entry.async_on_unload` is not enough.
+Note that integrations always need to implement `async_unload_entry` to support config entry unloading, just calling `entry.async_on_unload` is not enough.
 :::
 
 ## Additional resources

--- a/docs/core/integration-quality-scale/rules/config-entry-unloading.md
+++ b/docs/core/integration-quality-scale/rules/config-entry-unloading.md
@@ -16,7 +16,6 @@ This improves the user experience, since the user can do more actions without ha
 
 In the `async_unload_entry` interface function, the integration should clean up any subscriptions and close any connections opened during the setup of the integration.
 
-The method that has to be added to `__init__.py` looks very similar to the `async_setup_entry` method.
 In this example we have a listener, stored in the `runtime_data` of the config entry, which we want to clean up to avoid memory leaks.
 
 `__init__.py`:
@@ -29,8 +28,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
 ```
 
 :::info
-You can also use `entry.async_on_unload` to register a callback that will be called when the config entry is unloaded.
+Integrations can use `entry.async_on_unload` to register callbacks which will be called when the config entry is unloaded or if it fails to set up.
 This can be useful to clean up resources without having to keep track of the removal methods yourself.
+The registered callbacks will be called if :
+ - `async_setup_entry` raises either of `ConfigEntryError`, `ConfigEntryAuthFailed` or `ConfigEntryNotReady`
+ - `async_unload_entry` suceeds, i.e. it returns True and does not raise.
+
+ Note that integrations always need to implement `async_unload_entry` to support config entry unloading, just calling `entry.async_on_unload` is not enough.
 :::
 
 ## Additional resources


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Clarify config entry unload quality scale rule

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved guidance on integration unloading processes to ensure effective resource cleanup.
	- Clarified how and when registered callbacks are invoked during both unloading and setup failures.
	- Reinforced the importance of implementing proper unloading support for smoother integration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->