### PR TITLE
Update backup agent reload listener docs

### DIFF
--- a/docs/core/platform/backup.md
+++ b/docs/core/platform/backup.md
@@ -56,7 +56,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
 
-async def _notify_backup_listeners(hass: HomeAssistant) -> None:
+def _notify_backup_listeners(hass: HomeAssistant) -> None:
     for listener in hass.data.get(DATA_BACKUP_AGENT_LISTENERS, []):
         listener()
 ```

--- a/docs/core/platform/backup.md
+++ b/docs/core/platform/backup.md
@@ -43,22 +43,20 @@ def async_register_backup_agents_listener(
     return remove_listener
 ```
 
-The listener stored in `async_register_backup_agents_listener` should be called every time there is the need to reload backup agents, to remove stale agents and add new ones, such as when the integration is reloaded. For example:
+The listener stored in `async_register_backup_agents_listener` should be called every time there is the need to reload backup agents, to remove stale agents and add new ones. This can be done by registering the listeners during `async_setup_entry`:
 
 ```python
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload config entry."""
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up config entry."""
+    # do things to set up your config entry
+
     # Notify backup listeners
-    _notify_backup_listeners(hass)
+    def notify_backup_listeners() -> None:
+        for listener in hass.data.get(DATA_BACKUP_AGENT_LISTENERS, []):
+            listener()
+    entry.async_on_unload(entry.async_on_state_change(notify_backup_listeners))
 
-    return await hass.config_entries.async_unload_platforms(
-        entry, PLATFORMS
-    )
-
-
-def _notify_backup_listeners(hass: HomeAssistant) -> None:
-    for listener in hass.data.get(DATA_BACKUP_AGENT_LISTENERS, []):
-        listener()
+    return True
 ```
 
 A backup agent should implement the abstract interface of the `BackupAgent` base class as shown in this example:

--- a/docs/core/platform/backup.md
+++ b/docs/core/platform/backup.md
@@ -49,7 +49,7 @@ The listener stored in `async_register_backup_agents_listener` should be called 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload config entry."""
     # Notify backup listeners
-    hass.async_create_task(_notify_backup_listeners(hass), eager_start=False)
+    _notify_backup_listeners(hass)
 
     return await hass.config_entries.async_unload_platforms(
         entry, PLATFORMS


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
- In the platform example in `async_get_backup_agents` there's a condition that is dependent on the loaded config entries. Before https://github.com/home-assistant/core/pull/138522, the config entry being unloaded that is calling the backup listener from `async_unload_entry` would be included in loaded config entries until after `async_unload_entry` completed. To make the condition work, and not include the unloading config entry in the condition in `async_get_backup_agents`, a task had to be scheduled to call the backup listener. After https://github.com/home-assistant/core/pull/138522 this is no longer needed, since the state of the config entry that is unloading, will be `ConfigEntry.UNLOAD_IN_PROGRESS`.
- Adapt the docs to reflect the above changes.
- Also adapt the docs to use `entry.async_on_state_state` instead

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/138522


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added hooks to perform operations before and after backups, offering enhanced control over your backup processes.

- **Refactor**
  - Streamlined the backup listener registration and notification process, consolidating logic into the setup phase.
  - Simplified the notification mechanism by removing asynchronous task creation for backup listeners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->