### PR TITLE
Revert "Add codeowner approval requirement to Platinum tier"

### DIFF
--- a/docs/core/integration-quality-scale/index.md
+++ b/docs/core/integration-quality-scale/index.md
@@ -74,7 +74,6 @@ The platinum tier has the following characteristics:
 - All source code follows all coding and Home Assistant integration standards and best practices and is fully typed with type annotations and clear code comments for better code clarity and maintenance.
 - A fully asynchronous integration code base ensures efficient operation.
 - Implements efficient data handling, reducing network and CPU usage.
-- Code owner approval is required on pull requests before merging.
 
 
 ### Keeping track of the implemented rules


### PR DESCRIPTION
Reverts home-assistant/developers.home-assistant#2595

See discussion here:

https://github.com/home-assistant/developers.home-assistant/pull/2595#pullrequestreview-2686790580

The issue with this addition is: It isn't true. We will try to respect most of the codeowners, but we also will override when we need or want to move forward. Defining it as it is now, may lead to codeowners that don't agree with us making those calls.

../Frenck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated integration quality guidelines for the platinum tier.
  - Removed the requirement for code owner approval before merging changes.
  - Continued emphasis on high standards in code quality, asynchronous operations, and efficient data handling.
  - This update streamlines the review process while preserving our commitment to excellence in integration quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->