### PR TITLE
Improve config flow translation documentation

### DIFF
--- a/docs/internationalization/core.md
+++ b/docs/internationalization/core.md
@@ -56,7 +56,11 @@ Strings which are used more than once should be not be duplicated, instead refer
 
 ### Config / Options / Subentry flows
 
-The translation strings for the configuration flow handler, the option flow handler and config subentry handlers are defined under the `config`, `options` and `config_subentries` keys respectively. An example strings file below describes the different supported keys. Although the example shows translations for a configuration flow, the translations for an option flow is exactly the same.
+The translation strings for the configuration flow handler, the option flow handler and config subentry handlers are defined under the `config`, `options` and `config_subentries` keys respectively.
+
+Note that `config_subentries` is a map of maps, where the keys are the subentry types supported by the integration.
+
+The example strings file below describes the different supported keys. Although the example shows translations for a configuration flow, the translations for an option flow is exactly the same.
 
 ```json
 {
@@ -95,6 +99,17 @@ The translation strings for the configuration flow handler, the option flow hand
     },
     "progress": {
       "slow_task": "This message will be displayed if `slow_task` is returned as `progress_action` for `async_show_progress`."
+    }
+  },
+  "options": {
+    // Same format as for config flow
+  },
+  "config_subentries": {
+    "subentry_type_1": {
+      // Same format as for config flow
+    },
+    "subentry_type_2": {
+      // Same format as for config flow
     }
   }
 }

--- a/docs/internationalization/core.md
+++ b/docs/internationalization/core.md
@@ -60,7 +60,7 @@ The translation strings for the configuration flow handler, the option flow hand
 
 Note that `config_subentries` is a map of maps, where the keys are the subentry types supported by the integration.
 
-The example strings file below describes the different supported keys. Although the example shows translations for a configuration flow, the translations for an option flow is exactly the same.
+The example strings file below describes the different supported keys. Although the example shows translations for a configuration flow, the options and subentry flow translations follow the same format.
 
 ```json
 {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Improve config flow translation documentation to make it clearer how to translate options and config subentry flows

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced clarity in the `config_subentries` section for translation strings related to configuration and options flows.
  - Expanded example JSON structure to include `options` and `config_subentries`, providing clearer guidance on formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->