### PR TITLE
Add documentation for the new translation field mappings option of Data Entry Flow forms

### DIFF
--- a/docs/data_entry_flow_index.md
+++ b/docs/data_entry_flow_index.md
@@ -42,6 +42,8 @@ If the result type is `FlowResultType.FORM`, the result should look like:
     "errors": errors,
     # a detail information about the step
     "description_placeholders": description_placeholders,
+    # the translation mappings for dynamic form fields
+    "translation_field_mappings": translation_field_mappings, 
 }
 ```
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
**Documentation for the following new feature:**
Provide a way to translate dynamic fields/sections in the form `data_schema` of Config / Options / Subentry flows.

_[Reusing the documentation from this PR]_
Add a `translation_field_mappings` dictionary to map each dynamic field key to its corresponding translation key `translation_key` and its specific translation placeholders `description_placeholders` if needed.

These specific placeholders are used only within these specific field translation strings and for this dynamic field key, allowing different values to be used for each dynamic field. They are merged with the `description_placeholders` form placeholders and take precedence in case of conflict.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue or discussion:
  - an old PR implementing a way to translate dynamic fields in form data_schema: #4195
  -  an issue feature request: https://github.com/home-assistant/core/issues/92619
- Link to relevant existing code or pull request:
  - Link to core pull request: https://github.com/home-assistant/core/pull/141346
  - Link to frontend pull request: https://github.com/home-assistant/frontend/pull/24771


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced translation capabilities for forms, enabling context-sensitive dynamic translations for user inputs.
  
- **Documentation**
	- Expanded internationalization guidance with new sections and examples on using translation placeholders and mapping dynamic fields for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->