### PR TITLE
Document pre-announcement

### DIFF
--- a/docs/core/entity/assist-satellite.md
+++ b/docs/core/entity/assist-satellite.md
@@ -63,7 +63,7 @@ A [websocket command](#setting-the-active-wake-words) is available for setting t
 
 ### Announcements
 
-If the device has the `ANNOUNCE` [supported feature](#supported-features), then the `async_announce` method should be implemented to announce the provided `media_id` within `AssistSatelliteAnnouncement`.
+If the device has the `ANNOUNCE` [supported feature](#supported-features), then the `async_announce` method should be implemented to announce the provided `media_id` within `AssistSatelliteAnnouncement`. If `preannouncement_media_id` is provided, it should be played before the `media_id`.
 The `async_announce` method should only return when the announcement is finished playing on the device.
 
 An [announce action](https://home-assistant.io/integrations/assist_satellite#action-assist_satelliteannounce) is available for automating announcements.
@@ -72,8 +72,9 @@ An [announce action](https://home-assistant.io/integrations/assist_satellite#act
 
 If the device has the `START_CONVERSATION` [supported feature](#supported-features), then the `async_start_conversation` method should be implemented to:
 
-1. Announce the provided `media_id` within `AssistSatelliteAnnouncement`, then
-2. Listen for one or more follow-up voice commands
+1. Announce `preannouncement_media_id` within `AssistSatelliteAnnouncement`, if provided
+2. Announce the provided `media_id` within `AssistSatelliteAnnouncement`, then
+3. Listen for one or more follow-up voice commands
 
 The `async_start_conversation` method should only return when the announcement is finished playing on the device. The conversation will continue between the user and the satellite.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Docs for https://github.com/home-assistant/architecture/discussions/1213 

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to clarify how an optional preannouncement media is handled. The changes explain that when this parameter is provided, the system plays the preannouncement before the main media, ensuring the correct sequence of operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->