### PR TITLE
Remove translation link from android section

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -355,6 +355,5 @@ module.exports = {
     "android/linter",
     "android/submit",
     "android/release",
-    "translations",
   ]
 };


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
In https://github.com/home-assistant/developers.home-assistant/pull/2626 I've introduced the Android documentation and I thought that it was nice to have the link for the translation in the sidebar. But I didn't see initially that it actually broke the translation category. We can't open the translation category without ending up into the android section. Since this link is not that helpful on Android I've decided to remove it to fix the issue.

Thanks to @joostlek for spotting the issue.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [x] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Streamlined the Android section navigation by removing an outdated translations link for clearer access to relevant content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->