### PR TITLE
Add exception for dynamic devices

### DIFF
--- a/docs/core/integration-quality-scale/rules/dynamic-devices.md
+++ b/docs/core/integration-quality-scale/rules/dynamic-devices.md
@@ -66,7 +66,10 @@ async def async_setup_entry(
 
 ## Exceptions
 
-There are no exceptions to this rule.
+Since this rule isn't always reasonable, we have a few exceptions:
+- If there are rate limits applied by the manufacturer, which would degrade the overall user experience.
+- If the device is considered a big purchase that does not happen often for the average household, like a car or smart coffee machine.
+- If adding or replacing a device is a big maintenance task, like adding a new phase to an electricity meter.
 
 ## Related rules
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Okay so after this rule has been added, we have seen a couple of integrations where we think its not reasonable to enforce this rule. I am not 100% yet on the wording so I would love some feedback on this one. To give some examples and reasoning behind them, I will add some examples so we can also discuss those.

- Philips hue
  - While someone does not add a new light every day or week, or maybe after someone has their whole house filled with hue it won't happen anymore at all. I do think that we should enforce the rule here, since it works locally and the origin of purchase generally is a small one.
- Homewizard
   - So a friend recently went from 1 phase to 3 phases, and after that was completed the integration didn't work. turned out that his instance was running on an UPS. The integration expected the power in the whole house to go down during this maintenance and thus be rebooted once finished. I think this makes sense, but in this case, if possible, it would be nice to detect this and reload the integration automatically. (also keeping in mind batteries are getting more popular and thus this could happen more often).
- Renault
  - So what I understand from @epenet is that this involves a rate limit. So polling the list of all the cars every hour (?) would have an impact on the amount of requests that we can do for the rest of the integration. Since changing a car is quite a big purchase and doesn't happen often for the majority of households, I think we can exempt it.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [ ] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
