### PR TITLE
Update config flow docs for read-only selectors

### DIFF
--- a/docs/data_entry_flow_index.md
+++ b/docs/data_entry_flow_index.md
@@ -315,6 +315,31 @@ class ExampleOptionsFlow(config_entries.OptionsFlow):
         )
 ```
 
+#### Displaying read-only information
+
+Some integrations have configuration which is frozen after initial configuration. When displaying an options flow, you can show this information in a read-only way, so that users may remember which options were selected during the initial configuration. To show this, define an optional selector in the same manner as the original selector, but add the `read_only=True` flag to its configuration. 
+
+```python
+# Example Config Flow Schema
+DATA_SCHEMA_SETUP = vol.Schema(
+    {
+        vol.Required(CONF_ENTITY_ID): EntitySelector()
+    }
+)
+
+# Example Options Flow Schema
+DATA_SCHEMA_OPTIONS = vol.Schema(
+    {
+        vol.Optional(CONF_ENTITY_ID): EntitySelector(
+            EntitySelectorConfig(read_only=True)
+        ),
+        vol.Optional(CONF_TEMPLATE): TemplateSelector(),
+    }
+)
+```
+
+This will show the entity selected in the initial configuration as a read-only property whenever the options flow is launched. 
+
 #### Validation
 
 After the user has filled in the form, the step method will be called again and the user input is passed in. Your step will only be called if the user input passes your data schema. When the user passes in data, you will have to do extra validation of the data. For example, you can verify that the passed in username and password are valid.

--- a/docs/data_entry_flow_index.md
+++ b/docs/data_entry_flow_index.md
@@ -317,7 +317,7 @@ class ExampleOptionsFlow(config_entries.OptionsFlow):
 
 #### Displaying read-only information
 
-Some integrations have configuration which is frozen after initial configuration. When displaying an options flow, you can show this information in a read-only way, so that users may remember which options were selected during the initial configuration. To show this, define an optional selector in the same manner as the original selector, but add the `read_only=True` flag to its configuration. 
+Some integrations have options which are frozen after initial configuration. When displaying an options flow, you can show this information in a read-only way, so that users may remember which options were selected during the initial configuration. For this, define an optional selector as usual, but with the `read_only` flag set to `True`.
 
 ```python
 # Example Config Flow Schema


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Give an example of how to use read-only selectors in an options flow. For https://github.com/home-assistant/core/pull/129456/

Is `master` the right branch for this? I expected to see a `next` or `dev` or something similar...

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/129456/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new section explaining how to display read-only information in data entry flows, including usage instructions and code examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->