### PR TITLE
Add blog post about default precision for sensors

### DIFF
--- a/blog/2025-05-26-sensor-default-display-precision.md
+++ b/blog/2025-05-26-sensor-default-display-precision.md
@@ -1,0 +1,15 @@
+---
+author: Abílio Costa
+authorURL: https://github.com/abmantis
+title: "Sensor device classes now have default display precision"
+---
+
+If a numeric sensor doesn't have a suggested display precision set by its integration, Home Assistant will now use a default display precision based on the sensor's device class.
+
+New device classes should be added to `UNITS_PRECISION` in `homeassistant/components/sensor/const.py`, along with the proper unit and the desired default display precision. See the docstring of that constant for more details on how to choose the right unit and precision.
+
+The rounding that was previously applied to the sensor state when a unit conversion was happening is now removed, and the sensor state contains the full raw value.
+
+It is still recommended that integrations set the `suggested_display_precision` on their sensors. This change is a fallback mechanism to ensure a consistent experience across all numeric sensors.
+
+For more details check the implementation [pull request](https://github.com/home-assistant/core/pull/145013).

--- a/blog/2025-05-26-sensor-default-display-precision.md
+++ b/blog/2025-05-26-sensor-default-display-precision.md
@@ -12,4 +12,4 @@ The rounding that was previously applied to the sensor state when a unit convers
 
 It is still recommended that integrations set the `suggested_display_precision` on their sensors. This change is a fallback mechanism to ensure a consistent experience across all numeric sensors.
 
-For more details check the implementation [pull request](https://github.com/home-assistant/core/pull/145013).
+For more details check the implementation [pull request](https://github.com/home-assistant/core/pull/145013) and the [Sensor entity documentation](/docs/core/entity/sensor).


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Add a blog post regarding the changes to the sensor display precision and state rounding.


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/145013


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a blog post detailing the new default display precision for numeric sensors in Home Assistant, improving consistency in how sensor values are shown when integrations do not specify precision. The update also highlights that sensor values now retain their full raw state without automatic rounding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->