### PR TITLE
Add inH₂O unit of measurement for sensor and number pressure device classes

### DIFF
--- a/docs/core/entity/number.md
+++ b/docs/core/entity/number.md
@@ -34,7 +34,7 @@ If specifying a device class, your number entity will need to also return the co
 | `NumberDeviceClass.APPARENT_POWER` | VA | Apparent power
 | `NumberDeviceClass.AQI` | None | Air Quality Index
 | `NumberDeviceClass.AREA` | m², cm², km², mm², in², ft², yd², mi², ac, ha | Area
-| `NumberDeviceClass.ATMOSPHERIC_PRESSURE` | cbar, bar, hPa, mmHG, inHg, inH2O, kPa, mbar, Pa, psi | Atmospheric pressure
+| `NumberDeviceClass.ATMOSPHERIC_PRESSURE` | cbar, bar, hPa, mmHG, inHg, inH₂O, kPa, mbar, Pa, psi | Atmospheric pressure
 | `NumberDeviceClass.BATTERY` | % | Percentage of battery that is left
 | `NumberDeviceClass.BLOOD_GLUCOSE_CONCENTRATION` | mg/dL, mmol/L | Blood glucose concentration```
 | `NumberDeviceClass.CO2` | ppm | Concentration of carbon dioxide.

--- a/docs/core/entity/sensor.md
+++ b/docs/core/entity/sensor.md
@@ -35,7 +35,7 @@ If specifying a device class, your sensor entity will need to also return the co
 | `SensorDeviceClass.APPARENT_POWER` | VA | Apparent power
 | `SensorDeviceClass.AQI` | None | Air Quality Index
 | `SensorDeviceClass.AREA` | m², cm², km², mm², in², ft², yd², mi², ac, ha | Area
-| `SensorDeviceClass.ATMOSPHERIC_PRESSURE` | cbar, bar, hPa, mmHG, inHg, inH2O, kPa, mbar, Pa, psi | Atmospheric pressure
+| `SensorDeviceClass.ATMOSPHERIC_PRESSURE` | cbar, bar, hPa, mmHG, inHg, inH₂O, kPa, mbar, Pa, psi | Atmospheric pressure
 | `SensorDeviceClass.BATTERY` | % | Percentage of battery that is left
 | `SensorDeviceClass.BLOOD_GLUCOSE_CONCENTRATION` | mg/dL, mmol/L | Blood glucose concentration
 | `SensorDeviceClass.CO2` | ppm | Concentration of carbon dioxide.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Add support for inches of water (`inH2O`) to the atmospheric pressure device class in `sensor` and `number`.
This is a standard unit of measure for static pressure in HVAC systems. There are more complex HVAC integrations under development that report this sensor value and need and industry-standard UOM that will be understood by people knowledgable in the field.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [X] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [X] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [X] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/148289


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "inH2O" (inches of water) as a supported unit for atmospheric pressure across relevant device classes and updated docs accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->