### PR TITLE
Update off and unavailable in standby state

### DIFF
--- a/docs/core/entity.md
+++ b/docs/core/entity.md
@@ -73,7 +73,7 @@ To avoid calculations in a property method, set the corresponding [entity class 
 | ------------------------ | ------------------------------| ------- | -----------
 | assumed_state            | `bool`                        | `False` | Return `True` if the state is based on our assumption instead of reading it from the device.
 | attribution              | <code>str &#124; None</code>  | `None`  | The branding text required by the API provider.
-| available                | `bool`                        | `True`  | Indicate if Home Assistant is able to read the state and control the underlying device.
+| available                | `bool`                        | `True`  | Indicate if Home Assistant is able to read the state or control the underlying device, see [entity-unavailable](/docs/core/integration-quality-scale/rules/entity-unavailable.md) for more details.
 | device_class             | <code>str &#124; None</code>  | `None`  | Extra classification of what the device is. Each domain specifies their own. Device classes can come with extra requirements for unit of measurement and supported features.
 | entity_picture           | <code>str &#124; None</code>  | `None`  | Url of a picture to show for the entity.
 | extra_state_attributes   | <code>dict &#124; None</code> | `None`  | Extra information to store in the state machine. It needs to be information that further explains the state, it should not be static information like firmware version.

--- a/docs/core/entity/media-player.md
+++ b/docs/core/entity/media-player.md
@@ -92,6 +92,12 @@ The state of a media player is defined by using values in the `MediaPlayerState`
 | `PAUSED`    | Entity has an active media and is currently paused                                                                |
 | `BUFFERING` | Entity is preparing to start playback of some media                                                                 |
 
+:::note
+
+It is common that media players can't be controlled when in a standby state,  If Home Assistant can turn on the device using another protocol or method it should be shown as `OFF` even if the main channel used to control the device is currently unavailable, if Home Assistant has no way to turn on the device it should be shown as `unavailable`, see [entity-unavailable Exceptions](/docs/core/integration-quality-scale/rules/entity-unavailable.md#Exceptions) for more details.
+
+:::
+
 ## Methods
 
 ### Play media

--- a/docs/core/integration-quality-scale/rules/entity-unavailable.md
+++ b/docs/core/integration-quality-scale/rules/entity-unavailable.md
@@ -81,7 +81,14 @@ For more information about managing integration state, see the [documentation](/
 
 ## Exceptions
 
-There are no exceptions to this rule.
+If an integration has a way to turn on a device, either via a user-defined automation trigger or by automatically creating a secondary control channel (e.g., using Wake On Lan or Infra-Red blaster) - then the device should be reported as `off` when it is in standby and unresponsive to the main channel (e.g., TCP).
+If no such method exists, and the device cannot be controlled in its current state, it should be reported as `unavailable`.
+
+An example scenario, for a media player that enters standby mode and can only be turned on using an external device (e.g., an IR blaster):
+
+- When first added to Home Assistant, and there's no active connection, the device will be shown as `unavailable`.
+- If the user configures an automation (e.g., using an IR blaster) to turn it on, the device will be shown as `off` while in standby.
+- Once turned on via the external method, and the main connection is established, the state will update to `on`.
 
 ## Related rules
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
**Define when to show a device as off and when as unavailable in standby state.**

Update developer documentation to reflect the accepted change from https://github.com/home-assistant/architecture/discussions/1251

This pull request updates the documentation to clarify the behavior of entities in Home Assistant when they are unavailable or in standby mode. It also introduces exceptions to the rules for handling unavailable entities, particularly for devices like media players that may require alternative methods to turn on. Below are the key changes grouped by theme:

### Documentation Updates for Entity Behavior:
* Updated the description of the `available` property in `docs/core/entity.md` to specify that Home Assistant can read the state or control the device, with a reference to the `entity-unavailable` rules for more details.
* Added a note in `docs/core/entity/media-player.md` explaining how media players should be represented when in standby or unavailable states, with a link to the exceptions in the `entity-unavailable` rules.

### New Exceptions for Unavailable Entities:
* Expanded the `entity-unavailable` rules in `docs/core/integration-quality-scale/rules/entity-unavailable.md` to include scenarios where devices can be turned on using alternative methods, such as automations or secondary control channels. Provided an example for media players in standby mode.
## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
