### PR TITLE
Update reference to discord channels

### DIFF
--- a/docs/development_index.md
+++ b/docs/development_index.md
@@ -7,4 +7,7 @@ The core of Home Assistant is built from the ground up to be easily extensible u
 
 Before you start, make sure that you have read up on the overall [Home Assistant architecture](architecture_index.md) so that you are familiar with the concepts that make up Home Assistant.
 
-If you run into trouble following this documentation, don't hesitate to join our #devs_core channel on [Discord](https://www.home-assistant.io/join-chat/).
+For support and questions about contributing to Home Assistant development, join channel [#developers](https://discord.com/channels/330944238910963714/554842238073700352) or create a thread in [#support](https://discord.com/channels/330944238910963714/1257019582112334014) on [Discord](https://www.home-assistant.io/join-chat/).
+If you joined the Home Assistant Discord but do not have access to these channels, you will need to give yourself the Developer role. Do this by selecting `Channels & Roles` in the sidebar, and selecting "I want to contribute dev skills to Home Assistant" to be granted access.
+
+

--- a/docs/development_index.md
+++ b/docs/development_index.md
@@ -7,7 +7,5 @@ The core of Home Assistant is built from the ground up to be easily extensible u
 
 Before you start, make sure that you have read up on the overall [Home Assistant architecture](architecture_index.md) so that you are familiar with the concepts that make up Home Assistant.
 
-For support and questions about contributing to Home Assistant development, join channel [#developers](https://discord.com/channels/330944238910963714/554842238073700352) or create a thread in [#support](https://discord.com/channels/330944238910963714/1257019582112334014) on [Discord](https://www.home-assistant.io/join-chat/).
-If you joined the Home Assistant Discord but do not have access to these channels, you will need to give yourself the Developer role. Do this by selecting `Channels & Roles` in the sidebar, and selecting "I want to contribute dev skills to Home Assistant" to be granted access.
-
-
+For support or questions about contributing to Home Assistant development, join **#developers** or create a thread in **#support** on [Discord](https://www.home-assistant.io/join-chat/).
+Assign the Developer role: in the sidebar, select **Channels & Roles**, then choose **I want to contribute dev skills to Home Assistant** to gain access to these channels.


### PR DESCRIPTION

## Proposed change
I failed to find the original channel in discord, but luckily got help via https://github.com/home-assistant/service-hub/blob/main/data/discord/messages/homeassistant.yaml#L1416-L1421 :-)

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation
**none of the above?**
## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidance to specify which Discord channels to use for support and questions.
  * Added instructions on how to assign the Developer role in Discord to access relevant channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->