### PR TITLE
Remove deprecation notice from async_show_progress blog post

### DIFF
--- a/blog/2024-01-11-async-show-progress-changes.md
+++ b/blog/2024-01-11-async-show-progress-changes.md
@@ -5,7 +5,6 @@ title: "Changes to FlowManager.async_show_progress"
 ---
 
 `FlowHandler.async_show_progress` has been updated:
-- The `step_id` parameter is deprecated and will be removed in Home Assistant core release 2024.8
 - A new argument `progress_task` has been added, which will be mandatory in Home Assistant core release 2024.8
 
 If `progress_task` is passed, `FlowManager` will:
@@ -16,4 +15,4 @@ This means derived classes are no longer responsible for interaction between the
 
 `FlowHandler.async_show_progress` will log a warning if it's called without a `progress_task`. In Home Assistant core release 2024.8, the call will instead fail.
 
-More details can be found in the [documentation](/docs/data_entry_flow_index/#show-progress--show-progress-done) and in [core PR #107668](https://github.com/home-assistant/core/pull/107668) and ["107802](https://github.com/home-assistant/core/pull/107802).
+More details can be found in the [documentation](/docs/data_entry_flow_index/#show-progress--show-progress-done) and in [core PR #107668](https://github.com/home-assistant/core/pull/107668) and [#107802](https://github.com/home-assistant/core/pull/107802).


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
The deprecation was reverted for now in https://github.com/home-assistant/core/pull/149714

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [ ] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/149714


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to remove references to the deprecated `step_id` parameter.
  * Clarified that `progress_task` is now mandatory.
  * Fixed formatting issues in link text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->