### PR TITLE
Extend UnitOfReactivePower with 'mvar' 

### DIFF
--- a/docs/core/entity/number.md
+++ b/docs/core/entity/number.md
@@ -70,7 +70,7 @@ If specifying a device class, your number entity will need to also return the co
 | `NumberDeviceClass.PRECIPITATION_INTENSITY` | in/d, in/h, mm/d, mm/h | Precipitation intensity
 | `NumberDeviceClass.PRESSURE` | cbar, bar, hPa, mmHg, inHg, kPa, mbar, Pa, psi | Pressure.
 | `NumberDeviceClass.REACTIVE_ENERGY` | varh, kvarh | Reactive energy
-| `NumberDeviceClass.REACTIVE_POWER` | var, kvar | Reactive power
+| `NumberDeviceClass.REACTIVE_POWER` | mvar, var, kvar | Reactive power
 | `NumberDeviceClass.SIGNAL_STRENGTH` | dB, dBm | Signal strength
 | `NumberDeviceClass.SOUND_PRESSURE` | dB, dBA | Sound pressure
 | `NumberDeviceClass.SPEED` | ft/s, in/d, in/h, in/s, km/h, kn, m/s, mph, mm/d, mm/s | Generic speed

--- a/docs/core/entity/number.md
+++ b/docs/core/entity/number.md
@@ -70,7 +70,7 @@ If specifying a device class, your number entity will need to also return the co
 | `NumberDeviceClass.PRECIPITATION_INTENSITY` | in/d, in/h, mm/d, mm/h | Precipitation intensity
 | `NumberDeviceClass.PRESSURE` | cbar, bar, hPa, mmHg, inHg, kPa, mbar, Pa, psi | Pressure.
 | `NumberDeviceClass.REACTIVE_ENERGY` | varh, kvarh | Reactive energy
-| `NumberDeviceClass.REACTIVE_POWER` | var, kvar, Mvar | Reactive power
+| `NumberDeviceClass.REACTIVE_POWER` | mvar, var, kvar | Reactive power
 | `NumberDeviceClass.SIGNAL_STRENGTH` | dB, dBm | Signal strength
 | `NumberDeviceClass.SOUND_PRESSURE` | dB, dBA | Sound pressure
 | `NumberDeviceClass.SPEED` | ft/s, in/d, in/h, in/s, km/h, kn, m/s, mph, mm/d, mm/s | Generic speed

--- a/docs/core/entity/number.md
+++ b/docs/core/entity/number.md
@@ -70,7 +70,7 @@ If specifying a device class, your number entity will need to also return the co
 | `NumberDeviceClass.PRECIPITATION_INTENSITY` | in/d, in/h, mm/d, mm/h | Precipitation intensity
 | `NumberDeviceClass.PRESSURE` | cbar, bar, hPa, mmHg, inHg, kPa, mbar, Pa, psi | Pressure.
 | `NumberDeviceClass.REACTIVE_ENERGY` | varh, kvarh | Reactive energy
-| `NumberDeviceClass.REACTIVE_POWER` | mvar, var, kvar | Reactive power
+| `NumberDeviceClass.REACTIVE_POWER` | var, kvar, Mvar | Reactive power
 | `NumberDeviceClass.SIGNAL_STRENGTH` | dB, dBm | Signal strength
 | `NumberDeviceClass.SOUND_PRESSURE` | dB, dBA | Sound pressure
 | `NumberDeviceClass.SPEED` | ft/s, in/d, in/h, in/s, km/h, kn, m/s, mph, mm/d, mm/s | Generic speed

--- a/docs/core/entity/sensor.md
+++ b/docs/core/entity/sensor.md
@@ -73,7 +73,7 @@ If specifying a device class, your sensor entity will need to also return the co
 | `SensorDeviceClass.PRECIPITATION_INTENSITY` | in/d, in/h, mm/d, mm/h | Precipitation intensity
 | `SensorDeviceClass.PRESSURE` | cbar, bar, hPa, mmHg, inHg, kPa, mbar, Pa, psi | Pressure.
 | `SensorDeviceClass.REACTIVE_ENERGY` | varh, kvarh | Reactive energy
-| `SensorDeviceClass.REACTIVE_POWER` | var, kvar | Reactive power
+| `SensorDeviceClass.REACTIVE_POWER` | mvar, var, kvar | Reactive power
 | `SensorDeviceClass.SIGNAL_STRENGTH` | dB, dBm | Signal strength
 | `SensorDeviceClass.SOUND_PRESSURE` | dB, dBA | Sound pressure
 | `SensorDeviceClass.SPEED` | ft/s, in/d, in/h, in/s, km/h, kn, m/s, mph, mm/d, mm/s | Generic speed


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Add mvar (mili var) as a unit for reactive power.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [X] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request:  https://github.com/home-assistant/core/pull/150415


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added mvar as a supported reactive power unit alongside var and kvar in Number and Sensor entity docs.
  * Clarifies accepted units for reactive power readings to improve consistency and reduce ambiguity when configuring energy/power monitoring.
  * Improves discoverability of supported units to help prevent misconfiguration and ensure accurate display across integrations and dashboards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->