### PR TITLE
Document Supervisor's detect_blocking_io option

### DIFF
--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -3399,6 +3399,7 @@ Returns information about the supervisor
 | diagnostics         | bool or null | Sending diagnostics is enabled                                |
 | addons_repositories | list         | A list of add-on repository URL's as strings                  |
 | auto_update         | bool         | Is auto update enabled for supervisor                         |
+| detect_blocking_io  | bool         | Supervisor raises exceptions for blocking I/O in event loop   |
 
 **Example response:**
 
@@ -3419,7 +3420,8 @@ Returns information about the supervisor
   "debug_block": false,
   "diagnostics": null,
   "addons_repositories": ["https://example.com/addons"],
-  "auto_update": true
+  "auto_update": true,
+  "detect_blocking_io": false
 }
 ```
 
@@ -3476,6 +3478,7 @@ You need to call `/supervisor/reload` after updating the options.
 | logging             | string | Set logging level                                      |
 | addons_repositories | list   | Set a list of URL's as strings for add-on repositories |
 | auto_update         | bool   | Enable/disable auto update for supervisor              |
+| detect_blocking_io  | string | Enable blocking I/O in event loop detection. Valid values are `on`, `off` and `on_at_startup`. |
 
 </ApiEndpoint>
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Document Supervisor's `detect_blocking_io` option added in https://github.com/home-assistant/supervisor/pull/5746


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [ ] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/supervisor/pull/5746


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Supervisor API now exposes detect_blocking_io in GET /supervisor/info to indicate blocking I/O detection status.
  * Added configuration option detect_blocking_io to POST /supervisor/options with values: on, off, on_at_startup.

* **Documentation**
  * Updated supervisor API docs and examples to include detect_blocking_io, showing it in the info response and options payload.
  * Minor example formatting tweaks in JSON samples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->