### PR TITLE
Fix documentation gaps in /host/info API

### DIFF
--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -1708,6 +1708,11 @@ Return information about the host.
 | llmnr_hostname   | string or null | The hostname currently exposed on the network via LLMNR for host |
 | operating_system | string         | The operating system on the host          |
 | startup_time     | float          | The time in seconds it took for last boot |
+| disk_life_time   | float          | Percent of disk life time used based on manufacturer estimate |
+| timezone         | string         | The current timezone of host              |
+| dt_utc           | string         | Current date and time on host in UTC timezone and ISO 8601 format |
+| dt_synchronized  | bool           | True if the host is synchronized with an NTP service |
+| use_ntp          | bool           | True if host is using an NTP service for time synchronization |
 
 **Example response:**
 
@@ -1729,7 +1734,13 @@ Return information about the host.
   "boot_timestamp": 1234567788,
   "startup_time": 12.345,
   "broadcast_llmnr": true,
-  "broadcast_mdns": false
+  "broadcast_mdns": false,
+  "virtualization": "",
+  "disk_life_time": 10.0,
+  "timezone": "Europe/Tomorrowland",
+  "dt_utc": "2025-09-08T12:00:00.000000+00:00",
+  "dt_synchronized": true,
+  "use_ntp": true
 }
 ```
 

--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -1708,7 +1708,7 @@ Return information about the host.
 | llmnr_hostname   | string or null | The hostname currently exposed on the network via LLMNR for host |
 | operating_system | string         | The operating system on the host          |
 | startup_time     | float          | The time in seconds it took for last boot |
-| disk_life_time   | float          | Percentage of estimated disk lifetime used (0–100). |
+| disk_life_time   | float or null  | Percentage of estimated disk lifetime used (0–100). Not all disks provide this information, returns `null` if unavailable. |
 | timezone         | string         | The current timezone of the host. |
 | dt_utc           | string         | Current UTC date/time of the host in ISO 8601 format. |
 | dt_synchronized  | bool           | `true` if the host is synchronized with an NTP service. |

--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -1708,11 +1708,11 @@ Return information about the host.
 | llmnr_hostname   | string or null | The hostname currently exposed on the network via LLMNR for host |
 | operating_system | string         | The operating system on the host          |
 | startup_time     | float          | The time in seconds it took for last boot |
-| disk_life_time   | float          | Percent of disk life time used based on manufacturer estimate |
-| timezone         | string         | The current timezone of host              |
-| dt_utc           | string         | Current date and time on host in UTC timezone and ISO 8601 format |
-| dt_synchronized  | bool           | True if the host is synchronized with an NTP service |
-| use_ntp          | bool           | True if host is using an NTP service for time synchronization |
+| disk_life_time   | float          | Percentage of estimated disk lifetime used (0–100). |
+| timezone         | string         | The current timezone of the host. |
+| dt_utc           | string         | Current UTC date/time of the host in ISO 8601 format. |
+| dt_synchronized  | bool           | `true` if the host is synchronized with an NTP service. |
+| use_ntp          | bool           | `true` if the host is using an NTP service for time synchronization. |
 
 **Example response:**
 
@@ -1737,7 +1737,7 @@ Return information about the host.
   "broadcast_mdns": false,
   "virtualization": "",
   "disk_life_time": 10.0,
-  "timezone": "Europe/Tomorrowland",
+  "timezone": "Europe/Brussels",
   "dt_utc": "2025-09-08T12:00:00.000000+00:00",
   "dt_synchronized": true,
   "use_ntp": true
@@ -2215,7 +2215,7 @@ Returns a dict with selected keys from other `/*/info` endpoints.
   "channel": "stable",
   "logging": "info",
   "state": "running",
-  "timezone": "Europe/Tomorrowland"
+  "timezone": "Europe/Brussels"
 }
 ```
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Fix documentation gaps in `/host/info` API that were forgotten from PR https://github.com/home-assistant/supervisor/pull/2901 and https://github.com/home-assistant/supervisor/pull/2413


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [ ] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request:
    - https://github.com/home-assistant/supervisor/pull/2901
    - https://github.com/home-assistant/supervisor/pull/2413


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Host Information endpoint docs to include new response fields: disk_life_time, timezone, dt_utc (ISO 8601 UTC), dt_synchronized, use_ntp, and virtualization.
  * Refreshed the Returned Data table and example response to show sample values (time fields, timezone, disk life and virtualization) and adjusted examples (including supervisor root/info timezone) for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->