### PR TITLE
Document config flow next_flow parameter

### DIFF
--- a/docs/config_entries_config_flow_handler.md
+++ b/docs/config_entries_config_flow_handler.md
@@ -501,7 +501,7 @@ class LocationSubentryFlowHandler(ConfigSubentryFlow):
 A config flow can start another config flow and tell the frontend that it should show the other flow once the first flow is finished. To do this the first flow needs to pass the `next_flow` parameter to the `async_create_entry` method. The argument should be a tuple of the form `(flow_type, flow_id)`.
 
 ```python
-from homeassistant.config_entries import ConfigFlow, FlowType
+from homeassistant.config_entries import SOURCE_USER, ConfigFlow, FlowType
 
 
 class ExampleFlow(ConfigFlow):
@@ -513,7 +513,7 @@ class ExampleFlow(ConfigFlow):
         """Show create entry with next_flow parameter."""
         result = await self.hass.config_entries.flow.async_init(
             "another_integration_domain",
-            context={"source": config_entries.SOURCE_USER},
+            context={"source": SOURCE_USER},
         )
         return self.async_create_entry(
             title="Example",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
- Describe the `next_flow` parameter.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [ ] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/151998


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on continuing a configuration in another flow, showing how to hand off to a subsequent flow using flow identifiers and a usage example.
  * Clarifies how to initiate a follow-up flow from an existing configuration step.
  * Updates inserted into relevant sections covering subentry flow handling and reconfiguration scenarios.
  * No functional or behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->