### PR TITLE
Add blog post on update coordinator change

### DIFF
--- a/blog/2025-10-05-coordinator-retrigger.md
+++ b/blog/2025-10-05-coordinator-retrigger.md
@@ -4,7 +4,7 @@ authorURL: https://github.com/elupus
 title: "Update coordinator now allows retriggering"
 ---
 
-The update coordinator with debouncer active will now accept a request for update
+The update coordinator with debouncer active will now accept a request for an update
 while an update is currently in progress. The request will be queued up to be performed
 after the current update finishes.
 
@@ -18,14 +18,14 @@ async def _update():
     return (a,b)
 ```
 
-The user or code that request an update at `A` expects that the entities
-will get all new data from that time. However since we previously ignore that request,
-entities would have data for `a` that is before the call to update when logic finishes.
+A user or code that request an update at timestamp `A` expects that the entities linked will
+all get new data from that time. However, since we previously ignore that request, entities
+would have data for the value of `a` that is from a time before update request that was ignored.
 
 To make sure we avoid this case, the update coordinator will now schedule an additional
-update, if a request is received while currently executing a update.
+update, if a request is received while currently executing an update.
 
-A side effect of this is that it is now possible to schedule a update from inside an update
+A side effect of this is that it is now possible to schedule an update from inside an update
 function of the coordinator. That is useful if for example a connection is lost mid update,
 and we want all entities to indicate directly as unavailable, yet we want to attempt a
 re-connect as quick as possible but do that in the next update cycle.

--- a/blog/2025-10-05-coordinator-retrigger.md
+++ b/blog/2025-10-05-coordinator-retrigger.md
@@ -20,7 +20,7 @@ async def _update():
 
 A user or code that request an updates at timestamp `A` expects that the entities linked will
 all get new data from that time. However, since we previously ignored that request, entities
-would have data for the value of `a` that is from a time before update request that was ignored.
+would have data for the value of `a` that is from a time before the update request that was ignored.
 
 To make sure we avoid this case, the update coordinator will now schedule an additional
 update, if a request is received while currently executing an update.

--- a/blog/2025-10-05-coordinator-retrigger.md
+++ b/blog/2025-10-05-coordinator-retrigger.md
@@ -1,0 +1,31 @@
+---
+author: Joakim Plate
+authorURL: https://github.com/elupus
+title: "Update coordinator now allow retriggering"
+---
+
+The update coordinator with debounce:er active will now accept a request for update
+while an update is currently in progress. The request will be queued up to be performed
+after the current update finishes.
+
+Consider the following case:
+
+```python
+async def _update()
+   a = await get_a()
+   # A: User or other logic request a new update here through async_schedule_update()
+   b = await get_b()
+   return (a,b)
+```
+
+The user or code that request an update at `A` expects that the entities
+will get all new data from that time. However since we previously ignore that request,
+entities would have data for `a` that is before the call to update when logic finishes.
+
+To make sure we avoid this case, the update coordinator will now schedule an additional
+update, if a request is received while currently executing a update.
+
+A side effect of this is that it is now possible to schedule a update from inside an update
+function of the coordinator. That is useful if for example a connection is lost mid update,
+and we want all entities to indicate directly as unavailable, yet we want to attempt a
+re-connect as quick as possible but do that in the next update cycle.

--- a/blog/2025-10-05-coordinator-retrigger.md
+++ b/blog/2025-10-05-coordinator-retrigger.md
@@ -1,10 +1,10 @@
 ---
 author: Joakim Plate
 authorURL: https://github.com/elupus
-title: "Update coordinator now allow retriggering"
+title: "Update coordinator now allows retriggering"
 ---
 
-The update coordinator with debounce:er active will now accept a request for update
+The update coordinator with debouncer active will now accept a request for update
 while an update is currently in progress. The request will be queued up to be performed
 after the current update finishes.
 

--- a/blog/2025-10-05-coordinator-retrigger.md
+++ b/blog/2025-10-05-coordinator-retrigger.md
@@ -18,8 +18,8 @@ async def _update():
     return (a,b)
 ```
 
-A user or code that request an update at timestamp `A` expects that the entities linked will
-all get new data from that time. However, since we previously ignore that request, entities
+A user or code that request an updates at timestamp `A` expects that the entities linked will
+all get new data from that time. However, since we previously ignored that request, entities
 would have data for the value of `a` that is from a time before update request that was ignored.
 
 To make sure we avoid this case, the update coordinator will now schedule an additional

--- a/blog/2025-10-05-coordinator-retrigger.md
+++ b/blog/2025-10-05-coordinator-retrigger.md
@@ -11,11 +11,11 @@ after the current update finishes.
 Consider the following case:
 
 ```python
-async def _update()
-   a = await get_a()
-   # A: User or other logic request a new update here through async_schedule_update()
-   b = await get_b()
-   return (a,b)
+async def _update():
+    a = await get_a()
+    # A: User or other logic request a new update here through async_schedule_update()
+    b = await get_b()
+    return (a,b)
 ```
 
 The user or code that request an update at `A` expects that the entities


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Add blog post for change to update coordinator behaviour

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/153596


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a blog post describing an update coordinator debouncer that queues retrigger requests arriving during an in-progress update to run afterward.
  * Documents that a retrigger during execution schedules an additional update once the current run completes.
  * Includes a concrete example and notes the side effect of allowing an update to schedule a follow-up (useful for quick reconnects).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->