### PR TITLE
Reapply "Add support for mg/m³ unit of measurment device class Carbon Monoxide (sensor and number) (#2796)"

### DIFF
--- a/docs/core/entity/number.md
+++ b/docs/core/entity/number.md
@@ -39,7 +39,7 @@ If specifying a device class, your number entity will need to also return the co
 | `NumberDeviceClass.BATTERY` | % | Percentage of battery that is left
 | `NumberDeviceClass.BLOOD_GLUCOSE_CONCENTRATION` | mg/dL, mmol/L | Blood glucose concentration```
 | `NumberDeviceClass.CO2` | ppm | Concentration of carbon dioxide.
-| `NumberDeviceClass.CO` | ppm | Concentration of carbon monoxide.
+| `NumberDeviceClass.CO` | ppm, mg/m³ | Concentration of carbon monoxide.
 | `NumberDeviceClass.CONDUCTIVITY` | S/cm, mS/cm, µS/cm | Conductivity
 | `NumberDeviceClass.CURRENT` | A, mA | Current
 | `NumberDeviceClass.DATA_RATE` | bit/s, kbit/s, Mbit/s, Gbit/s, B/s, kB/s, MB/s, GB/s, KiB/s, MiB/s, GiB/s | Data rate

--- a/docs/core/entity/sensor.md
+++ b/docs/core/entity/sensor.md
@@ -40,7 +40,7 @@ If specifying a device class, your sensor entity will need to also return the co
 | `SensorDeviceClass.BATTERY` | % | Percentage of battery that is left
 | `SensorDeviceClass.BLOOD_GLUCOSE_CONCENTRATION` | mg/dL, mmol/L | Blood glucose concentration
 | `SensorDeviceClass.CO2` | ppm | Concentration of carbon dioxide.
-| `SensorDeviceClass.CO` | ppm | Concentration of carbon monoxide.
+| `SensorDeviceClass.CO` | ppm, mg/m³ | Concentration of carbon monoxide.
 | `SensorDeviceClass.CONDUCTIVITY` | S/cm, mS/cm, µS/cm | Conductivity
 | `SensorDeviceClass.CURRENT` | A, mA | Current
 | `SensorDeviceClass.DATA_RATE` | bit/s, kbit/s, Mbit/s, Gbit/s, B/s, kB/s, MB/s, GB/s, KiB/s, MiB/s, GiB/s | Data rate


### PR DESCRIPTION
Reverts home-assistant/developers.home-assistant#2814

Core PR: https://github.com/home-assistant/core/pull/154074

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated CO device class guidance to list mg/m³ alongside ppm as supported units for relevant Number and Sensor entities.
  - Clarified unit options in the CO sections to help users configure and interpret CO measurements more accurately.
  - Ensures documentation reflects current unit support, improving consistency and reducing confusion for users selecting measurement units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->