### PR TITLE
Document async_clear_address_from_match_history Bluetooth API

### DIFF
--- a/docs/core/bluetooth/api.md
+++ b/docs/core/bluetooth/api.md
@@ -242,6 +242,32 @@ from homeassistant.components import bluetooth
 bluetooth.async_rediscover_address(hass, "44:44:33:11:23:42")
 ```
 
+### Clearing match history for rediscovery
+
+The Bluetooth integration tracks which advertisement fields (manufacturer_data UUIDs, service_data UUIDs, service_uuids) have been seen for each device to determine when to trigger discovery. It only checks if the UUIDs have been seen before, not whether their content has changed.
+
+For devices that change state but maintain the same UUIDs (such as devices that are factory reset or transition between operational states), you can clear the match history to allow rediscovery when the device advertises again with different content.
+
+The `bluetooth.async_clear_address_from_match_history` API clears the match history for a specific address without immediately re-triggering discovery. This differs from `async_rediscover_address`, which clears history AND immediately re-triggers discovery with cached data.
+
+Use this API when:
+- A device is factory reset (state changes but UUIDs remain the same)
+- A device transitions between operational states with the same advertisement UUIDs
+- You want to prepare for future rediscovery without immediately triggering a flow
+
+```python
+from homeassistant.components import bluetooth
+
+# Clear match history to allow future advertisements to trigger discovery
+bluetooth.async_clear_address_from_match_history(hass, "44:44:33:11:23:42")
+```
+
+:::warning Performance Considerations
+Do not use this API for devices whose advertisement data changes frequently (e.g., sensors that update temperature readings in advertisement data). Clearing match history for such devices will cause a new discovery flow to be triggered on every advertisement change, which can overwhelm the system and create a poor user experience.
+
+This API is intended for infrequent state changes such as factory resets or major operational mode transitions, not for regular data updates.
+:::
+
 ### Waiting for a specific advertisement
 
 To wait for a specific advertisement, call the `bluetooth.async_process_advertisements` API.


### PR DESCRIPTION
## Proposed change

Documents the new `async_clear_address_from_match_history` Bluetooth API that was added to Home Assistant Core. This API allows integrations to clear match history for a Bluetooth device address without immediately re-triggering discovery, enabling rediscovery of devices that change state but maintain the same advertisement UUIDs (such as factory reset devices).

The documentation:
- Explains how the Bluetooth integration's match history tracking works
- Clarifies the key difference between this API and `async_rediscover_address`
- Provides use cases for when this API should be used
- Includes a clear code example
- Adds a performance warning against using this API for frequently changing advertisement data

## Type of change

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: home-assistant/core#154355


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Bluetooth API docs to include a way to clear a device’s advertisement match history without triggering rediscovery.
  * Clarified differences between clearing history only vs. clearing and immediately rediscovering using cached data.
  * Added usage guidance, performance caveats for devices with frequently changing advertisements, and a Python example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->