### PR TITLE
Clarify API endpoint path requirement

### DIFF
--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -79,6 +79,8 @@ curl \
   -H "Content-Type: application/json" http://localhost:8123/api/
 ```
 
+Note: make sure you include the trailing `/`, the full path is `/api/`, NOT `/api`
+
 </ApiEndpoint>
 
 <ApiEndpoint path="/api/config" method="get">


### PR DESCRIPTION

## Proposed change
Added note about trailing slash in API endpoint. This tripped me up because I didn't expect it (many/most other API's I've used don't include a trailing `/` in paths). I hope that by including this note it will help someone else who is getting started with the API for the first time (since this is likely the API endpoint that they will try first)

## Type of change
- [x] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified API path requirements in documentation, noting that the API endpoint path must include a trailing slash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->