### PR TITLE
Add async_on_create_entry documentation

### DIFF
--- a/docs/core/integration/config_flow.md
+++ b/docs/core/integration/config_flow.md
@@ -532,7 +532,7 @@ class ExampleFlow(ConfigFlow):
 
 The `async_on_create_entry` provides an option to modify the final `ConfigFlowResult` after the config entry has been created and the flow finalizes.
 
-As subentry flows and option flows are dependent on that the main config entry exist before they can be started, it is suitable to use for this purpose as provided in the following example:
+As subentry flows and option flows are dependent on that the main config entry exist before they can be started, these flow types can only be used with the `async_on_create_entry()` method in your config flow:
 
 ```python
 from homeassistant.config_entries import (

--- a/docs/core/integration/config_flow.md
+++ b/docs/core/integration/config_flow.md
@@ -528,6 +528,48 @@ class ExampleFlow(ConfigFlow):
         )
 ```
 
+### Use async_on_create_entry
+
+The `async_on_create_entry` provides an option to modify the final `ConfigFlowResult` after the config entry has been created and the flow finalizes.
+
+As subentry flows and option flows are dependent on that the main config entry exist before they can be started, it is suitable to use for this purpose as provided in the following example:
+
+```python
+from homeassistant.config_entries import (
+    ConfigFlow,
+    FlowType,
+    SOURCE_USER,
+    SubentryFlowContext,
+)
+
+
+class ExampleFlow(ConfigFlow):
+    """Example flow."""
+
+    async def async_on_create_entry(
+        self, result: ConfigFlowResult
+    ) -> ConfigFlowResult:
+        """Create subentry flow after creating the main entry."""
+        subentry_result = await self.hass.config_entries.subentries.async_init(
+            (result["result"].entry_id, "subentry_type"),
+            context=SubentryFlowContext(source=SOURCE_USER),
+        )
+        result["next_flow"] = (
+            FlowType.CONFIG_SUBENTRIES_FLOW,
+            subentry_result["flow_id"],
+        )
+        return result
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Create entry."""
+        return self.async_create_entry(
+            title="Example",
+            data={},
+        )
+```
+
 ## Use SchemaConfigFlowHandler for simple flows
 
 For helpers and integrations with simple config flows, you can use the `SchemaConfigFlowHandler` instead.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Adds description for use of `async_on_create_entry`
Core PR: https://github.com/home-assistant/core/pull/155016

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the async_on_create_entry functionality
  * Includes practical code examples demonstrating how to modify configuration entry results
  * Shows how to enable subsequent subentry configuration flows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->