### PR TITLE
warning for restoring Odroid

### DIFF
--- a/docs/operating-system/boards/odroid-m1s.md
+++ b/docs/operating-system/boards/odroid-m1s.md
@@ -25,6 +25,8 @@ Then, on the Odroid M1S device use the HA CLI, enter `login` command to reach th
 From there, copy the binary file from your PC (e.g. `ssh user@mypc.local:/path_to/ODROID-M1S_EMMC2UMS.img /tmp` - replace the user with your username on the PC, the mypc.local with your computer name or IP address and the path_to with the actual path to your downloaded binary). This command will then copy the binary to /tmp/ on your HAOS.
 Next, run `dd if=/tmp/ORDOID-M1S_EMMC2UMS.img of=/dev/mmcblk0` - this will write the binary image into the boot part of your eMMC.
 
+**Warning:** As the odroid.com page has robot detection, do not use the curl command as it will NOT download the actual; risking your device to be bricked!
+
 This way the device will start in the UMS mode on the next boot with the SD card removed. Alternatively you can use the [Hardkernel installer image][2] directly instead of the EMMC2UMS image.
 
 ## NVMe


### PR DESCRIPTION
There is huge problem with the curl command - odroid.com page requires robot confirmation. The command in the page results in overwriting the EMMC boot partition with HTML webpage, instead of the binary image. This will brick the device completely.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
This is very important warning to prevent complete brick of M1S.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->
This needs to be taken with priority. People that will run the command and not realize what just happen will completely brick their device.

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced the single-step reflashing instruction with a guided, host-assisted procedure that walks through downloading the image to a PC, transferring it to the device over SSH, and writing it to eMMC.
  * Added explicit transfer and write commands, removed the inline one-liner, and added a warning about automated-download restrictions on the vendor site plus an alternative image option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->