### PR TITLE
Add migration guide for pyserial-asyncio to fast

### DIFF
--- a/blog/2026-01-05-pyserial-asyncio-fast.md
+++ b/blog/2026-01-05-pyserial-asyncio-fast.md
@@ -12,7 +12,7 @@ Library maintainers and custom integrations are advised to migrate to `pyserial-
 
 ### Background
 
-`pyserial-asyncio` blocks the event loop because it does a blocking `sleep` and is not maintained.
+`pyserial-asyncio` blocks the event loop because it does a blocking `sleep`. The library is also not maintained so efforts to improve the situation haven't been released.
 
 `pyserial-asyncio-fast` was created as a drop-in replacement (see [the repository](https://github.com/home-assistant-libs/pyserial-asyncio-fast)), and all core integrations have now been migrated.
 


### PR DESCRIPTION
Document the migration from pyserial-asyncio to pyserial-asyncio-fast due to blocking I/O issues and lack of maintenance.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Blog post for https://github.com/home-assistant/core/pull/159368
(Also linked to https://github.com/home-assistant/core/pull/116635)

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/159368


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  - Added a blog post explaining that pyserial-asyncio will be deprecated/blocked in 2026.7 and why.
  - Provided a migration guide recommending pyserial-asyncio-fast as a drop-in replacement, with updated installation instructions, usage migration steps, and examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->