### PR TITLE
Added powersave option to Wifi configuration

### DIFF
--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -2629,12 +2629,13 @@ Update the settings for a network interface.
 
 **wifi:**
 
-| key    | type   | optional | description                                                                    |
-| ------ | ------ | -------- | ------------------------------------------------------------------------------ |
-| mode   | string | True     | Set the mode `infrastructure` (default), `mesh`, `adhoc` or `ap`               |
-| auth   | string | True     | Set the auth mode: `open` (default), `web`, `wpa-psk`                          |
-| ssid   | string | True     | Set the SSID for connect into                                                  |
-| psk    | string | True     | The shared key which is used with `web` or `wpa-psk`                           |
+| key       | type   | optional | description                                                                    |
+| --------- | ------ | -------- | ------------------------------------------------------------------------------ |
+| mode      | string | True     | Set the mode `infrastructure` (default), `mesh`, `adhoc` or `ap`               |
+| auth      | string | True     | Set the auth mode: `open` (default), `web`, `wpa-psk`                          |
+| ssid      | string | True     | Set the SSID for connect into                                                  |
+| psk       | string | True     | The shared key which is used with `web` or `wpa-psk`                           |
+| powersave | int    | True     | WiFi powersave: `0`=default, `1`=ignore, `2`=disable, `3`=enable               |
 
 </ApiEndpoint>
 

--- a/docs/api/supervisor/models.md
+++ b/docs/api/supervisor/models.md
@@ -129,12 +129,13 @@ These models are describing objects that are getting returned from the superviso
 
 ### Wifi configuration
 
-| key         | type    | description                                                                  |
-| ----------- | ------- | ---------------------------------------------------------------------------- |
-| mode        | string  | Set the mode `infrastructure`, `mesh`, `adhoc` or `ap`.                      |
-| auth        | string  | Set the auth mode: `open`, `web` or `wpa-psk`.                               |
-| ssid        | string  | Set the SSID for the Wireless.                                               |
-| signal      | integer | Percentage of signal strength.                                               |
+| key         | type            | description                                                             |
+| ----------- | --------------- | ----------------------------------------------------------------------- |
+| mode        | string          | Set the mode `infrastructure`, `mesh`, `adhoc` or `ap`.                 |
+| auth        | string          | Set the auth mode: `open`, `web` or `wpa-psk`.                          |
+| ssid        | string          | Set the SSID for the Wireless.                                          |
+| signal      | integer         | Percentage of signal strength.                                          |
+| powersave   | integer or null | WiFi powersave mode: `0`=default, `1`=ignore, `2`=disable, `3`=enable.  |
 
 ### VLAN configuration
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Add support for configuring WiFi powersave mode via the network update command. This flag allows users to control the 802-11-wireless.powersave NetworkManager setting.

Usage: `ha network update <interface> --wifi-powersave <0-3>`

This PR dependents on: https://github.com/home-assistant/supervisor/pull/6536

Values:
- 0: default (use NM default)
- 1: ignore (don't change current setting)
- 2: disable (powersave off)
- 3: enable (powersave on)

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/supervisor/pull/6536


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API endpoint and model documentation to include a new powersave field for WiFi network configuration, expanding available WiFi settings options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->