### PR TITLE
Deprecate async_listen in labs

### DIFF
--- a/blog/2026-02-16-labs-async-listen-deprecation.md
+++ b/blog/2026-02-16-labs-async-listen-deprecation.md
@@ -4,7 +4,7 @@ authorURL: https://github.com/arturpragacz
 title: "async_listen in Labs is deprecated"
 ---
 
-The `async_listen` helper in the `labs` component has been deprecated in favor of `async_subscribe_preview_feature`.
+The `async_listen` helper in the `labs` integration has been deprecated in favor of `async_subscribe_preview_feature`.
 
 The new `async_subscribe_preview_feature` function provides a more consistent API, where the listener callback receives an `EventLabsUpdatedData` parameter containing the updated feature state. This eliminates the need to separately call `async_is_preview_feature_enabled` inside the listener to check the current value.
 
@@ -44,7 +44,7 @@ async_subscribe_preview_feature(
 )
 ```
 
-Note that the new listener is an `async` function and receives `EventLabsUpdatedData` as a parameter.
+Note that the new listener is a coroutine function and receives `EventLabsUpdatedData` as a parameter.
 
 `async_listen` will be removed in Home Assistant 2027.3.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Deprecate async_listen in labs.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/162648


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented deprecation of the legacy listener helper, with removal scheduled for Home Assistant 2027.3
  * Introduced a new async listener API as the recommended replacement
  * Added migration guidance and side-by-side examples showing the old vs. new listener usage and required async handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->