### PR TITLE
Add service action target rule

### DIFF
--- a/docs/dev_101_services.md
+++ b/docs/dev_101_services.md
@@ -263,7 +263,7 @@ The guiding principle is: **target the thing the action actually acts on.** If t
 :::caution
 When a service action requires a target, this target should not be optional. Do not implement a default target when none is specified.
 
-Making the target optional seems convenient, but it makes automations and scripts unpredictable when the configuration changes by adding entities or entries. Requiring an explicit target keeps action calls predictable and consistent regardless of the user's current configuration.
+Making the target optional seems convenient, but it makes automations and scripts unpredictable when the configuration changes by adding entities or entries. Requiring an explicit target keeps action calls predictable regardless of the user's current configuration.
 :::
 
 ## Entity service actions


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Add a rule for service action calls. If the service action call requires a target, it should not fallback to a default one when the target is none. This is in response to https://github.com/home-assistant/core/pull/159588 as it hasn't been made clear in the documentation wheter it is possible to set a default entry_config id for service action calls.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/159588


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added caution notes clarifying that action targets must always be specified — they should not be optional.
  * Clarified there should be no default target when unspecified; guidance placed alongside target and guidance sections to reduce misconfiguration risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->