### PR TITLE
docs: add WebSocket API for managing exposed entities

### DIFF
--- a/docs/api/websocket.md
+++ b/docs/api/websocket.md
@@ -724,6 +724,76 @@ Each entity object in the `entities` array uses abbreviated property names for p
 | `dp` | integer | No | Display Precision - sensor-specific precision for displaying values. The user-configured `display_precision` takes priority; falls back to the integration-provided `suggested_display_precision` | `RegistryEntry.options["sensor"]["display_precision"]` (preferred) or `RegistryEntry.options["sensor"]["suggested_display_precision"]` (sensor domain only, only if set) |
 
 
+## Manage exposed entities
+
+These commands manage which entities are exposed to voice assistants (`conversation` for Assist, `cloud.alexa` for Alexa, `cloud.google_assistant` for Google Assistant).
+
+### List exposed entities
+
+Returns the exposure status of all entities across all assistants.
+
+```json
+{
+  "id": 18,
+  "type": "homeassistant/expose_entity/list"
+}
+```
+
+The server will respond with a mapping of entity IDs to their exposure status per assistant:
+
+```json
+{
+  "id": 18,
+  "type": "result",
+  "success": true,
+  "result": {
+    "exposed_entities": {
+      "light.living_room": {
+        "conversation": true,
+        "cloud.alexa": false,
+        "cloud.google_assistant": false
+      },
+      "sensor.temperature": {
+        "conversation": true
+      }
+    }
+  }
+}
+```
+
+Only entities that have been explicitly exposed or unexposed will appear in the result. Entities not present in the response have not been configured and use the default exposure setting.
+
+### Expose or unexpose entities
+
+Expose or unexpose one or more entities to one or more voice assistants. Changes take effect immediately without requiring a Home Assistant restart.
+
+```json
+{
+  "id": 19,
+  "type": "homeassistant/expose_entity",
+  "assistants": ["conversation"],
+  "entity_ids": ["light.living_room", "sensor.temperature"],
+  "should_expose": true
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `assistants` | array[string] | List of assistant identifiers: `"conversation"`, `"cloud.alexa"`, `"cloud.google_assistant"` |
+| `entity_ids` | array[string] | List of entity IDs to expose or unexpose |
+| `should_expose` | boolean | `true` to expose, `false` to unexpose |
+
+The server will respond with a result message:
+
+```json
+{
+  "id": 19,
+  "type": "result",
+  "success": true,
+  "result": null
+}
+```
+
 ## Error handling
 
 If an error occurs, the `success` key in the `result` message will be set to `false`. It will contain an `error` key containing an object with two keys: `code` and `message`.


### PR DESCRIPTION
## Summary

Documents two WebSocket commands for programmatically managing entities exposed to voice assistants:

- `homeassistant/expose_entity/list` — list exposure status per assistant
- `homeassistant/expose_entity` — expose/unexpose entities in bulk

These commands have been available in HA core since 2024.x ([source](https://github.com/home-assistant/core/blob/dev/homeassistant/components/homeassistant/exposed_entities.py)) but were not documented.

## Motivation

When using LLM-based conversation agents (Ollama, OpenAI, etc.) with Home Assistant, developers need to programmatically control which entities are exposed to avoid saturating the LLM context window. Currently, the only documented way is toggling entities one by one in the UI.

The WebSocket API supports bulk operations and takes effect immediately without restarting HA.

## Changes

- Added "Manage exposed entities" section to `docs/api/websocket.md`
- Documents request/response format for both commands
- Includes field descriptions table for the expose command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive API documentation for managing exposed entities to voice assistants
  * Includes endpoints for listing exposed entities and configuring exposure status per assistant
  * Details request/response structures and field descriptions for entity exposure management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->