### PR TITLE
Add feature_flags to supervisor info and options API docs

### DIFF
--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -3554,6 +3554,7 @@ Returns information about the supervisor
 | addons_repositories | list         | A list of app repository URL's as strings                  |
 | auto_update         | bool         | Is auto update enabled for supervisor                         |
 | detect_blocking_io  | bool         | Supervisor raises exceptions for blocking I/O in event loop   |
+| feature_flags       | dict         | Map of development feature flag names to their enabled state  |
 
 **Example response:**
 
@@ -3575,7 +3576,10 @@ Returns information about the supervisor
   "diagnostics": null,
   "addons_repositories": ["https://example.com/addons"],
   "auto_update": true,
-  "detect_blocking_io": false
+  "detect_blocking_io": false,
+  "feature_flags": {
+    "supervisor_v2_api": false
+  }
 }
 ```
 
@@ -3641,6 +3645,7 @@ You need to call `/supervisor/reload` after updating the options.
 | addons_repositories | list   | Set a list of URL's as strings for app repositories |
 | auto_update         | bool   | Enable/disable auto update for supervisor              |
 | detect_blocking_io  | string | Enable blocking I/O in event loop detection. Valid values are `on`, `off` and `on_at_startup`. |
+| feature_flags       | dict   | Partial update of development feature flags. Keys are feature flag names (e.g. `supervisor_v2_api`), values are booleans. Omitted keys are left unchanged. |
 
 </ApiEndpoint>
 


### PR DESCRIPTION
Documents the new development feature toggle system introduced in home-assistant/supervisor#6719.

## Changes

- Add `feature_flags` to the `/supervisor/info` response table and example JSON
- Add `feature_flags` to the `/supervisor/options` payload table, noting the partial-update semantics (omitted keys are left unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated supervisor API documentation. The `/supervisor/info` endpoint now includes a documented `feature_flags` response field for retrieving development feature flag states. The `/supervisor/options` endpoint now supports documented `feature_flags` parameters for managing feature flag configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->