### PR TITLE
Document detection_callback kwarg for bluetooth.async_get_scanner

### DIFF
--- a/docs/core/bluetooth/api.md
+++ b/docs/core/bluetooth/api.md
@@ -82,9 +82,14 @@ scanner = bluetooth.async_get_scanner(hass)
 If the underlying library needs a detection callback, pass it via the `detection_callback` keyword argument. `bleak` removed `register_detection_callback`, so the callback must be supplied at construction time.
 
 ```python
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import AdvertisementData
+
 from homeassistant.components import bluetooth
 
-def _detection_callback(device, advertisement_data):
+def _detection_callback(
+    device: BLEDevice, advertisement_data: AdvertisementData
+) -> None:
     ...
 
 scanner = bluetooth.async_get_scanner(hass, detection_callback=_detection_callback)

--- a/docs/core/bluetooth/api.md
+++ b/docs/core/bluetooth/api.md
@@ -79,6 +79,17 @@ from homeassistant.components import bluetooth
 scanner = bluetooth.async_get_scanner(hass)
 ```
 
+If the underlying library needs a detection callback, pass it via the `detection_callback` keyword argument. `bleak` removed `register_detection_callback`, so the callback must be supplied at construction time.
+
+```python
+from homeassistant.components import bluetooth
+
+def _detection_callback(device, advertisement_data):
+    ...
+
+scanner = bluetooth.async_get_scanner(hass, detection_callback=_detection_callback)
+```
+
 
 ### Determine if a scanner is running
 


### PR DESCRIPTION
## Proposed change

bleak removed register_detection_callback, so the detection callback must now be supplied at BleakScanner construction time. bluetooth.async_get_scanner now accepts an optional detection_callback kwarg and forwards it to the wrapped scanner; document the new usage.

## Type of change

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: home-assistant/core#168525

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Bluetooth API documentation with guidance on using BLE detection callbacks with `async_get_scanner`. Includes code examples and clarification on providing callbacks at scanner construction time, reflecting the updated callback requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->