### PR TITLE
Remove `BUILD_FROM` references from app examples, suggest replacement

### DIFF
--- a/docs/apps/configuration.md
+++ b/docs/apps/configuration.md
@@ -54,11 +54,10 @@ then there will be a variable `TARGET` containing `beer` in the environment of y
 
 ## App Dockerfile
 
-All apps (formerly known as add-ons) are based on the latest Alpine Linux image. Home Assistant will automatically substitute the right base image based on the machine architecture. Add `tzdata` if you need to run in a different timezone. `tzdata` Is is already added to our base images.
+Most of the apps (formerly known as add-ons) are based on the latest Alpine Linux image. Add `tzdata` if you need to run in a different timezone. `tzdata` is already added to our base images.
 
 ```dockerfile
-ARG BUILD_FROM=ghcr.io/home-assistant/base:latest
-FROM $BUILD_FROM
+FROM ghcr.io/home-assistant/base:latest
 
 # Install requirements for app
 RUN \
@@ -71,6 +70,12 @@ RUN chmod a+x /run.sh
 
 CMD [ "/run.sh" ]
 ```
+
+:::note
+
+When Supervisor built an app with no `build.yaml`, it previously passed `BUILD_FROM=ghcr.io/home-assistant/base:latest` automatically. Since Supervisor 2026.04.0 that fallback is no longer applied, make sure your Dockerfile doesn't rely on externally provided base image through the default `BUILD_FROM` argument.
+
+:::
 
 If you are not using Home Assistant GitHub builder actions (see [Publishing your app](/docs/apps/publishing)), make sure that the Dockerfile also has a set of labels that include:
 
@@ -87,9 +92,14 @@ We support the following build arguments by default:
 
 | ARG | Description |
 |-----|-------------|
-| `BUILD_FROM` | Holds the image for dynamic builds or buildings over our systems.
 | `BUILD_VERSION` | App version (read from `config.yaml`).
 | `BUILD_ARCH` | Holds the current build arch inside.
+
+:::note
+
+Since Supervisor 2026.04.0, the `BUILD_FROM` argument is no longer provided by default. Use explicit `FROM ghcr.io/home-assistant/base:latest` in your Dockerfile to achieve the same build result as before. Using a pinned version of the base image is recommended for better build stability.
+
+:::
 
 ## App configuration
 

--- a/docs/apps/presentation.md
+++ b/docs/apps/presentation.md
@@ -173,8 +173,7 @@ Our example `Dockerfile` is configured to support only our Nginx server and does
 Dockerfile
 
 ```dockerfile
-ARG BUILD_FROM
-FROM $BUILD_FROM
+FROM ghcr.io/home-assistant/base:latest
 
 #Add nginx and create the run folder for nginx.
 RUN \

--- a/docs/apps/tutorial.md
+++ b/docs/apps/tutorial.md
@@ -29,8 +29,7 @@ Once you have located your app directory, it's time to get started!
 This is the image that will be used to build your app.
 
 ```dockerfile
-ARG BUILD_FROM
-FROM $BUILD_FROM
+FROM ghcr.io/home-assistant/base:latest
 
 # Copy data for app
 COPY run.sh /
@@ -115,8 +114,7 @@ To do this, we will need to update our files as follows:
 Update your `Dockerfile`:
 
 ```dockerfile
-ARG BUILD_FROM
-FROM $BUILD_FROM
+FROM ghcr.io/home-assistant/base:latest
 
 # Install requirements for app
 RUN \


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Since `BUILD_FROM` argument is no longer used, remove it completely from the examples to avoid confusion. We still use it conventionally in our images, but this shouldn't lead to unpredictable behavior with different Supervisor versions, unlike for apps without `build.yaml`.



## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [ ] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #3001
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated app development documentation to reflect Supervisor 2026.04.0 behavior changes. Apps must now specify explicit base image references in Dockerfiles instead of relying on auto-provided defaults.
  * Added clarifications that container base images must be defined explicitly and cannot depend on external argument fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->