### PR TITLE
docs: replace stale dhcp_server link with apps-example in apps tutorial

### DIFF
--- a/docs/apps/tutorial.md
+++ b/docs/apps/tutorial.md
@@ -191,7 +191,7 @@ schema:
 ...
 ```
 
-Reload the app store and re-install your app. You will now see the options available in the app config screen. When you now go back to our Python 3 server and download `options.json`, you'll see the options you set. [Example of how options.json can be used inside `run.sh`](https://github.com/home-assistant/addons/blob/master/dhcp_server/data/run.sh#L10-L13)
+Reload the app store and re-install your app. You will now see the options available in the app config screen. When you now go back to our Python 3 server and download `options.json`, you'll see the options you set. [Example of how options.json can be used inside `run.sh`](https://github.com/home-assistant/apps-example/blob/main/example/rootfs/etc/services.d/example/run#L12-L17)
 
 ## Bonus: Template app repository
 


### PR DESCRIPTION
Closes #2891

The "Bonus: Working with app options" section in `docs/apps/tutorial.md` linked to a snippet in `home-assistant/addons/dhcp_server/data/run.sh#L10-L13`, which now 404s. The `dhcp_server` addon was removed from the addons repo at some point.

Updates the link to the equivalent snippet in `home-assistant/apps-example`, the actively maintained reference for app development. The new target shows the same idea (reading `options.json` inside a run script) using the modern `bashio::config` pattern that the rest of the docs already teach.

Verification:
- Old URL returns 404
- New URL exists and points at lines 12-17 of `example/rootfs/etc/services.d/example/run`, which is the read-config-and-use-it block

Open question: if there's a different canonical example you'd prefer pointed at here, happy to swap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tutorial reference links to point to current example implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->