### PR TITLE
Fix `translation_key` property to return str instead of variable

### DIFF
--- a/docs/core/entity.md
+++ b/docs/core/entity.md
@@ -192,7 +192,7 @@ class MySwitch(SwitchEntity):
     @property
     def translation_key(self):
         """Return the translation key to translate the entity's name and states."""
-        return my_switch
+        return "my_switch"
 ```
 
 #### Example of an untranslated switch entity which is either not the main feature of a device, or is not part of a device:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Fix the entity documentation `translation_key` example code to return a string instead of an undefined variable. 


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed switch entity example to display correct translation key usage with proper string syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->