### PR TITLE
Data entry flow previews

### DIFF
--- a/docs/data_entry_flow_index.md
+++ b/docs/data_entry_flow_index.md
@@ -592,6 +592,168 @@ class ExampleConfigFlow(data_entry_flow.FlowHandler):
 
 Passing `sort=True` to async_show_menu will also sort the menu items by their label in the user's language.
 
+### Entity previews
+
+Currently preview entities are only supported for config entry flows, option Flows, subentry config Flows, and repair flows. To implement flow previews in a flow manager you'll need to complete the following basic steps:
+
+#### 1. Create the websocket endpoint
+
+The below is specific to `ConfigFlow` or `ConfigSubentryFlow` flows. 
+
+```python
+# In config_flow.py
+
+from homeassistant.components import websocket_api
+from homeassistant.config_entry import ConfigFlow, FlowType, SubentryFlowResult, ConfigEntry
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "preview_name/start_preview", # "preview_name" corresponds to the value in async_show_form(..., preview="preview_name") and needs to be unique so use something like f"{DOMAIN}_my_flow_handler"
+        vol.Required("flow_id"): str,
+        vol.Required("flow_type"): vol.Any(FlowType.CONFIG_FLOW, FlowType.CONFIG_SUBENTRIES_FLOW),
+        vol.Required("user_input"): dict,
+    }
+)
+@websocket_api.async_response
+async def ws_start_preview( 
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Generate a preview.
+    
+    The client sends a message calling this endpoint when the form is rendered and when any field changes.
+    """
+
+    user_input: dict[str, Any] = msg["user_input"] # the current user input on the form
+
+    # Get the partial flow result
+    if msg["flow_type"] is FlowType.CONFIG_SUBENTRIES_FLOW:
+        flow_status: SubentryFlowResult = hass.config_entries.subentries.async_get(msg["flow_id"])
+        # get the config entry (if applicable or needed)
+        entry_id, _ = cur_step["handler"] # handler for subentry flow is a tuple of str of form (entry_id, subentry_flow_type)
+        config_entry: ConfigEntry = hass.config_entries.async_get(entry_id)
+
+    ... # process the data, validate for errors (tip: use the same schema/validation used in the data entry flow step)
+
+    @callback
+    def async_preview_callback(
+        state: str | None,
+        attributes: Mapping[str, Any] | None,
+        error: str | None,
+        domain: str | None,
+    ) -> None:
+        """Forward preview updates to websocket."""
+        # Errors sent here will appear in the preview element on the data entry form.  Note that this isn't required and data input validation errors should be sent using connection.send_message below.  Use this for ValueErrors raised by the entity in _calculate_state for example.
+        if error is not None:
+            connection.send_message(
+                websocket_api.event_message(msg["id"], {"error": error})
+            )
+            return
+        connection.send_message(
+            websocket_api.event_message(
+                msg["id"],
+                {
+                    "attributes": attributes,
+                    "domain": domain, # optional, see note below
+                    "state": state,
+                },
+            )
+        )
+
+    # errors: Mapping[str, str] = {"user_input_key": "error_translation_key"} similar to the value expected by async_show_form(..., errors = errors)
+    if errors is not None:
+        connection.send_message(
+            {
+                "id": msg["id"],
+                "type": websocket_api.TYPE_RESULT,
+                "success": False,
+                "error": {"code": "invalid_user_input", "message": errors},
+            }
+        )
+        return
+    
+    # Create the preview entity.
+    preview = PreviewSensorEntity(hass, value=value, config=config)
+
+    connection.send_result(msg["id"])
+    connection.subscriptions[msg["id"]] = preview.async_show_preview(
+        async_preview_callback
+    )
+```
+
+> [!NOTE]
+> `domain` in omitted in async_preview_callback refers to the the preview entity's domain (e.g. `"sensor"` or `"select"`). If `domain` is omitted in the event message in `async_preview_callback` above the frontend will fall back first to the flow's current `step_id` which is fine if you want a `SelectEntity` preview and `async_show_form` is being called from `async_step_select`.  If `step_id` doesn't match any domains the frontend will fallback and render a `SensorEntity` with applicable attributes.
+
+#### 2. Create the preview entity
+
+Ideally one would leverage an entity class already created for an integration but a simple entity can be created at runtime.
+
+```python
+class PreviewSensorEntity(SensorEntity):
+    """Preview sensor entity for subentry flows."""
+
+    def __init__(value: str, config: dict[str, str]) -> None:
+        self._attr_native_value = value
+        self._attr_device_class = config.get(CONF_DEVICE_CLASS)
+        self._attr_native_unit_of_measurement = config.get(CONF_UNIT_OF_MEASUREMENT)
+        self._attr_state_class = config.get(CONF_STATE_CLASS)
+    
+    @callback
+    def async_show_preview(
+        self,
+        preview_callback: Callable[
+            [
+                str | None,  # state
+                Mapping[str, Any] | None,  # attributes
+                str | None,  # errors
+                str | None,  # domain
+            ],
+            None,
+        ],
+    ) -> CALLBACK_TYPE:
+        """Start a preview."""
+        error: str | None = None
+        try:
+            calculated_state: CalculatedState = self._async_calculate_state()
+            preview_callback(
+                calculated_state.state,
+                calculated_state.attributes,
+                None, # error
+                self.domain,
+            )
+        except ValueError as ex:
+            error = str(ex)
+            if len(error) > 255:
+                error = error[:254]
+        if error:
+            preview_callback(None, None, error, None)
+
+        return self._call_on_remove_callbacks
+```
+
+#### 3. Register the websocket preview command
+
+Add a static method `async_setup_preview` to the flow handler.
+
+```python
+@staticmethod
+async def async_setup_preview(hass: HomeAssistant) -> None:
+    """Set up preview WS API."""
+    websocket_api.async_register_command(hass, ws_start_preview)
+```
+
+#### 4. Specify the preview in `async_show_form`
+
+```python
+return self.async_show_form(
+    step_id="my_step",
+    data_schema=schema,
+    errors=errors,
+    preview="my_integration_subentry_preview", # This same value set in the websocket_command schema in step 1.
+)
+```
+
 ## Initializing a config flow from an external source
 
 You might want to initialize a config flow programmatically. For example, if we discover a device on the network that requires user interaction to finish setup. To do so, pass a source parameter and optional user input when initializing a flow:

--- a/docs/data_entry_flow_index.md
+++ b/docs/data_entry_flow_index.md
@@ -594,11 +594,11 @@ Passing `sort=True` to async_show_menu will also sort the menu items by their la
 
 ### Entity previews
 
-Currently preview entities are only supported for config entry flows, option Flows, subentry config Flows, and repair flows. To implement flow previews in a flow manager you'll need to complete the following basic steps:
+Currently preview entities are only supported for config entry flows, option flows, subentry config flows, and repair flows. To implement flow previews in a flow manager you'll need to complete the following basic steps:
 
 #### 1. Create the websocket endpoint
 
-The below is specific to `ConfigFlow` or `ConfigSubentryFlow` flows. 
+The below is specific to `ConfigFlow` or `ConfigSubentryFlow` flows but is easily adaptable to an `OptionsFlow` or `RepairsFlow`.
 
 ```python
 # In config_flow.py
@@ -682,8 +682,11 @@ async def ws_start_preview(
     )
 ```
 
-> [!NOTE]
-> `domain` in omitted in async_preview_callback refers to the the preview entity's domain (e.g. `"sensor"` or `"select"`). If `domain` is omitted in the event message in `async_preview_callback` above the frontend will fall back first to the flow's current `step_id` which is fine if you want a `SelectEntity` preview and `async_show_form` is being called from `async_step_select`.  If `step_id` doesn't match any domains the frontend will fallback and render a `SensorEntity` with applicable attributes.
+:::tip
+
+ `domain` in omitted in async_preview_callback refers to the the preview entity's domain (e.g. `"sensor"` or `"select"`). If `domain` is omitted in the event message in `async_preview_callback` above the frontend will fall back first to the flow's current `step_id` which is fine if you want a `SelectEntity` preview and `async_show_form` is being called from `async_step_select`.  If `step_id` doesn't match any domains the frontend will fallback and render a `SensorEntity` with applicable attributes.
+
+:::
 
 #### 2. Create the preview entity
 

--- a/docs/data_entry_flow_index.md
+++ b/docs/data_entry_flow_index.md
@@ -604,16 +604,18 @@ The below is specific to `ConfigFlow` or `ConfigSubentryFlow` flows but is easil
 # In config_flow.py
 
 from homeassistant.components import websocket_api
-from homeassistant.config_entry import (
+from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,
     FlowType, 
     SubentryFlowResult, 
 )
 from homeassistant.const import (
-    ATTR_ICON
+    ATTR_ICON,
     ATTR_NAME
 )
+
+
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "preview_name/start_preview", # "preview_name" corresponds to the value in async_show_form(..., preview="preview_name") and needs to be unique so use something like f"{DOMAIN}_my_flow_handler"

--- a/docs/data_entry_flow_index.md
+++ b/docs/data_entry_flow_index.md
@@ -774,7 +774,7 @@ class ExampleConfigFlow(data_entry_flow.FlowHandler):
         websocket_api.async_register_command(hass, ws_start_preview)
 
     async def async_step_user(self, user_input: dict[str, Any] | None
-        ) -> FlowResult:
+        ) -> data_entry_flow.FlowResult:
 
         ...
 

--- a/docs/data_entry_flow_index.md
+++ b/docs/data_entry_flow_index.md
@@ -638,12 +638,12 @@ async def ws_start_preview(
     user_input: dict[str, Any] = msg["user_input"] 
 
     # Get the partial flow result
-    if msg["flow_type"] is FlowType.CONFIG_SUBENTRIES_FLOW:
+    if msg["flow_type"] == FlowType.CONFIG_SUBENTRIES_FLOW:
         flow_status: SubentryFlowResult = hass.config_entries.subentries.async_get(msg["flow_id"])
         # TODO: get the config entry (if applicable or needed)
         # handler for subentry flow is a tuple of str of form 
         # (entry_id, subentry_flow_type)
-        entry_id, _ = cur_step["handler"] 
+        entry_id, _ = flow_status["handler"] 
         config_entry: ConfigEntry = hass.config_entries.async_get(entry_id)
 
     # Process the data and validate for errors (tip: use the 
@@ -651,7 +651,7 @@ async def ws_start_preview(
     errors: dict[str, str] | None = None
     preview_value: str = ...
     config: dict[str, str] = {
-        ATTR_ICON: "mdi:eye"
+        ATTR_ICON: "mdi:eye",
         ATTR_NAME: "Entity Preview"
     }
     ... 
@@ -719,11 +719,11 @@ Ideally one would leverage an entity class already created for an integration bu
 class PreviewSensorEntity(SensorEntity):
     """Preview sensor entity for subentry flows."""
 
-    def __init__(hass: HomeAssistant, preview_value: str, config: dict[str, str]) -> None:
+    def __init__(self, hass: HomeAssistant, preview_value: str, config: dict[str, str]) -> None:
         self.hass = hass
         self._attr_native_value = preview_value
-        self._attr_icon = config.get[ATTR_ICON]
-        self._attr_name = config.get[ATTR_NAME]
+        self._attr_icon = config.get(ATTR_ICON)
+        self._attr_name = config.get(ATTR_NAME)
         self._attr_device_class = config.get(CONF_DEVICE_CLASS)
         self._attr_native_unit_of_measurement = config.get(CONF_UNIT_OF_MEASUREMENT)
         self._attr_state_class = config.get(CONF_STATE_CLASS)
@@ -778,7 +778,7 @@ return self.async_show_form(
     data_schema=schema,
     errors=errors,
     # Same value set in the websocket_command schema in step 1:
-    preview="my_integration_subentry_preview",
+    preview="preview_name",
 )
 ```
 

--- a/docs/data_entry_flow_index.md
+++ b/docs/data_entry_flow_index.md
@@ -717,7 +717,8 @@ Ideally one would leverage an entity class already created for an integration bu
 class PreviewSensorEntity(SensorEntity):
     """Preview sensor entity for subentry flows."""
 
-    def __init__(preview_value: str, config: dict[str, str]) -> None:
+    def __init__(hass: HomeAssistant, preview_value: str, config: dict[str, str]) -> None:
+        self.hass = hass
         self._attr_native_value = preview_value
         self._attr_icon = config.get[ATTR_ICON]
         self._attr_name = config.get[ATTR_NAME]

--- a/docs/data_entry_flow_index.md
+++ b/docs/data_entry_flow_index.md
@@ -648,13 +648,13 @@ async def ws_start_preview(
 
     # Process the data and validate for errors (tip: use the 
     # same schema/validation used in the data entry flow step)  
-+   errors: dict[str, str] | None = None
+    errors: dict[str, str] | None = None
     preview_value: str = ...
     config: dict[str, str] = {
         ATTR_ICON: "mdi:eye"
         ATTR_NAME: "Entity Preview"
     }
-+   ... 
+    ... 
 
     @callback
     def async_preview_callback(

--- a/docs/data_entry_flow_index.md
+++ b/docs/data_entry_flow_index.md
@@ -707,7 +707,7 @@ async def ws_start_preview(
 
 :::tip
 
- `domain` in async_preview_callback refers to the the preview entity's domain (e.g. `"sensor"` or `"select"`). If `domain` is not provided or `None` the frontend will fallback to render a `SensorEntity` with applicable attributes.
+ `domain` in async_preview_callback refers to the preview entity's domain (e.g. `"sensor"` or `"select"`). If `domain` is not provided or `None` the frontend will fallback to render a `SensorEntity` with applicable attributes.
 
 :::
 

--- a/docs/data_entry_flow_index.md
+++ b/docs/data_entry_flow_index.md
@@ -647,14 +647,14 @@ async def ws_start_preview(
         config_entry: ConfigEntry = hass.config_entries.async_get(entry_id)
 
     # Process the data and validate for errors (tip: use the 
-    # same schema/validation used in the data entry flow step)  
+    # same schema/validation used in the data entry flow step)
     errors: dict[str, str] | None = None
     preview_value: str = ...
     config: dict[str, str] = {
         ATTR_ICON: "mdi:eye",
         ATTR_NAME: "Entity Preview"
     }
-    ... 
+    ...
 
     @callback
     def async_preview_callback(
@@ -678,7 +678,7 @@ async def ws_start_preview(
                 msg["id"],
                 {
                     "attributes": attributes,
-                    "domain": domain, # optional, see note below
+                    "domain": domain, # see note below
                     "state": state,
                 },
             )
@@ -716,6 +716,8 @@ async def ws_start_preview(
 Ideally one would leverage an entity class already created for an integration but a simple entity can be created at runtime.
 
 ```python
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+
 class PreviewSensorEntity(SensorEntity):
     """Preview sensor entity for subentry flows."""
 
@@ -749,7 +751,7 @@ class PreviewSensorEntity(SensorEntity):
                 calculated_state.state,
                 calculated_state.attributes,
                 None, # error
-                self.domain,
+                SENSOR_DOMAIN,
             )
         except ValueError as ex:
             error = str(ex)
@@ -759,27 +761,30 @@ class PreviewSensorEntity(SensorEntity):
         return self._call_on_remove_callbacks
 ```
 
-#### 3. Register the websocket preview command
+#### 3. Register the websocket preview command, and specify preview in `async_show_form`
 
-Add a static method `async_setup_preview` to the flow handler (the platform integration of `ConfigFlow`):
-
-```python
-@staticmethod
-async def async_setup_preview(hass: HomeAssistant) -> None:
-    """Set up preview WS API."""
-    websocket_api.async_register_command(hass, ws_start_preview)
-```
-
-#### 4. Specify the preview in `async_show_form`
+Add a static method `async_setup_preview` to the flow handler and then notify the frontend to use the preview by specifying the preview name in `async_show_form`.
 
 ```python
-return self.async_show_form(
-    step_id="my_step",
-    data_schema=schema,
-    errors=errors,
-    # Same value set in the websocket_command schema in step 1:
-    preview="preview_name",
-)
+class ExampleConfigFlow(data_entry_flow.FlowHandler):
+
+    @staticmethod
+    async def async_setup_preview(hass: HomeAssistant) -> None:
+        """Set up preview WS API."""
+        websocket_api.async_register_command(hass, ws_start_preview)
+
+    async def async_step_user(self, user_input: dict[str, Any] | None
+        ) -> FlowResult:
+
+        ...
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=FLOW_SCHEMA,
+            errors=errors,
+            # Same value set in the websocket_command schema in step 1:
+            preview="preview_name",
+        )
 ```
 
 ## Initializing a config flow from an external source

--- a/docs/data_entry_flow_index.md
+++ b/docs/data_entry_flow_index.md
@@ -604,8 +604,16 @@ The below is specific to `ConfigFlow` or `ConfigSubentryFlow` flows but is easil
 # In config_flow.py
 
 from homeassistant.components import websocket_api
-from homeassistant.config_entry import ConfigFlow, FlowType, SubentryFlowResult, ConfigEntry
-
+from homeassistant.config_entry import (
+    ConfigEntry,
+    ConfigFlow,
+    FlowType, 
+    SubentryFlowResult, 
+)
+from homeassistant.const import (
+    ATTR_ICON
+    ATTR_NAME
+)
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "preview_name/start_preview", # "preview_name" corresponds to the value in async_show_form(..., preview="preview_name") and needs to be unique so use something like f"{DOMAIN}_my_flow_handler"
@@ -624,17 +632,27 @@ async def ws_start_preview(
     
     The client sends a message calling this endpoint when the form is rendered and when any field changes.
     """
-
-    user_input: dict[str, Any] = msg["user_input"] # the current user input on the form
+    # the current user input on the form
+    user_input: dict[str, Any] = msg["user_input"] 
 
     # Get the partial flow result
     if msg["flow_type"] is FlowType.CONFIG_SUBENTRIES_FLOW:
         flow_status: SubentryFlowResult = hass.config_entries.subentries.async_get(msg["flow_id"])
-        # get the config entry (if applicable or needed)
-        entry_id, _ = cur_step["handler"] # handler for subentry flow is a tuple of str of form (entry_id, subentry_flow_type)
+        # TODO: get the config entry (if applicable or needed)
+        # handler for subentry flow is a tuple of str of form 
+        # (entry_id, subentry_flow_type)
+        entry_id, _ = cur_step["handler"] 
         config_entry: ConfigEntry = hass.config_entries.async_get(entry_id)
 
-    ... # process the data, validate for errors (tip: use the same schema/validation used in the data entry flow step)
+    # Process the data and validate for errors (tip: use the 
+    # same schema/validation used in the data entry flow step)  
++   errors: dict[str, str] | None = None
+    preview_value: str = ...
+    config: dict[str, str] = {
+        ATTR_ICON = "mdi:eye"
+        ATTR_NAME = "Entity Preview"
+    }
++   ... 
 
     @callback
     def async_preview_callback(
@@ -644,7 +662,10 @@ async def ws_start_preview(
         domain: str | None,
     ) -> None:
         """Forward preview updates to websocket."""
-        # Errors sent here will appear in the preview element on the data entry form.  Note that this isn't required and data input validation errors should be sent using connection.send_message below.  Use this for ValueErrors raised by the entity in _calculate_state for example.
+        # Errors sent here will appear in the preview element on the data 
+        # entry form.  Note that this isn't required and data input validation
+        # errors should be sent using connection.send_message below.  For example: 
+        # Send ValueErrors to the client raised by the entity in _async_calculate_state.
         if error is not None:
             connection.send_message(
                 websocket_api.event_message(msg["id"], {"error": error})
@@ -661,7 +682,7 @@ async def ws_start_preview(
             )
         )
 
-    # errors: Mapping[str, str] = {"user_input_key": "error_translation_key"} similar to the value expected by async_show_form(..., errors = errors)
+    # Send user_input errors to the client. 
     if errors is not None:
         connection.send_message(
             {
@@ -674,7 +695,7 @@ async def ws_start_preview(
         return
     
     # Create the preview entity.
-    preview = PreviewSensorEntity(hass, value=value, config=config)
+    preview = PreviewSensorEntity(hass, preview_value=preview_value, config=config)
 
     connection.send_result(msg["id"])
     connection.subscriptions[msg["id"]] = preview.async_show_preview(
@@ -696,8 +717,10 @@ Ideally one would leverage an entity class already created for an integration bu
 class PreviewSensorEntity(SensorEntity):
     """Preview sensor entity for subentry flows."""
 
-    def __init__(value: str, config: dict[str, str]) -> None:
-        self._attr_native_value = value
+    def __init__(preview_value: str, config: dict[str, str]) -> None:
+        self._attr_native_value = preview_value
+        self._attr_icon = config.get[ATTR_ICON]
+        self._attr_name = config.get[ATTR_NAME]
         self._attr_device_class = config.get(CONF_DEVICE_CLASS)
         self._attr_native_unit_of_measurement = config.get(CONF_UNIT_OF_MEASUREMENT)
         self._attr_state_class = config.get(CONF_STATE_CLASS)
@@ -709,7 +732,7 @@ class PreviewSensorEntity(SensorEntity):
             [
                 str | None,  # state
                 Mapping[str, Any] | None,  # attributes
-                str | None,  # errors
+                str | None,  # error
                 str | None,  # domain
             ],
             None,
@@ -727,8 +750,6 @@ class PreviewSensorEntity(SensorEntity):
             )
         except ValueError as ex:
             error = str(ex)
-            if len(error) > 255:
-                error = error[:254]
         if error:
             preview_callback(None, None, error, None)
 
@@ -753,7 +774,8 @@ return self.async_show_form(
     step_id="my_step",
     data_schema=schema,
     errors=errors,
-    preview="my_integration_subentry_preview", # This same value set in the websocket_command schema in step 1.
+    # Same value set in the websocket_command schema in step 1:
+    preview="my_integration_subentry_preview",
 )
 ```
 

--- a/docs/data_entry_flow_index.md
+++ b/docs/data_entry_flow_index.md
@@ -594,11 +594,11 @@ Passing `sort=True` to async_show_menu will also sort the menu items by their la
 
 ### Entity previews
 
-Currently preview entities are only supported for config entry flows, option flows, subentry config flows, and repair flows. To implement flow previews in a flow manager you'll need to complete the following basic steps:
+Currently preview entities are only supported for config entry flows, option flows, subentry config flows, and repair flows. To implement a flow preview in a data entry flow, implement these steps:
 
 #### 1. Create the websocket endpoint
 
-The below is specific to `ConfigFlow` or `ConfigSubentryFlow` flows but is easily adaptable to an `OptionsFlow` or `RepairsFlow`.
+The example is specific to `ConfigFlow` or `ConfigSubentryFlow` flows but it is easily adaptable to an `OptionsFlow` or `RepairsFlow`.
 
 ```python
 # In config_flow.py

--- a/docs/data_entry_flow_index.md
+++ b/docs/data_entry_flow_index.md
@@ -618,7 +618,7 @@ from homeassistant.const import (
 
 @websocket_api.websocket_command(
     {
-        vol.Required("type"): "preview_name/start_preview", # "preview_name" corresponds to the value in async_show_form(..., preview="preview_name") and needs to be unique so use something like f"{DOMAIN}_my_flow_handler"
+        vol.Required("type"): "preview_name/start_preview", # "preview_name" corresponds to the value in async_show_form(..., preview="preview_name")
         vol.Required("flow_id"): str,
         vol.Required("flow_type"): vol.Any(FlowType.CONFIG_FLOW, FlowType.CONFIG_SUBENTRIES_FLOW),
         vol.Required("user_input"): dict,
@@ -644,7 +644,7 @@ async def ws_start_preview(
         # handler for subentry flow is a tuple of str of form 
         # (entry_id, subentry_flow_type)
         entry_id, _ = flow_status["handler"] 
-        config_entry: ConfigEntry = hass.config_entries.async_get(entry_id)
+        config_entry: ConfigEntry = hass.config_entries.async_get_entry(entry_id)
 
     # Process the data and validate for errors (tip: use the 
     # same schema/validation used in the data entry flow step)
@@ -657,7 +657,7 @@ async def ws_start_preview(
     ...
 
     @callback
-    def async_preview_callback(
+    def async_preview_updated(
         state: str | None,
         attributes: Mapping[str, Any] | None,
         error: str | None,
@@ -700,8 +700,8 @@ async def ws_start_preview(
     preview = PreviewSensorEntity(hass, preview_value=preview_value, config=config)
 
     connection.send_result(msg["id"])
-    connection.subscriptions[msg["id"]] = preview.async_show_preview(
-        async_preview_callback
+    connection.subscriptions[msg["id"]] = preview.async_start_preview(
+        async_preview_updated
     )
 ```
 
@@ -731,7 +731,7 @@ class PreviewSensorEntity(SensorEntity):
         self._attr_state_class = config.get(CONF_STATE_CLASS)
     
     @callback
-    def async_show_preview(
+    def async_start_preview(
         self,
         preview_callback: Callable[
             [

--- a/docs/data_entry_flow_index.md
+++ b/docs/data_entry_flow_index.md
@@ -651,8 +651,8 @@ async def ws_start_preview(
 +   errors: dict[str, str] | None = None
     preview_value: str = ...
     config: dict[str, str] = {
-        ATTR_ICON = "mdi:eye"
-        ATTR_NAME = "Entity Preview"
+        ATTR_ICON: "mdi:eye"
+        ATTR_NAME: "Entity Preview"
     }
 +   ... 
 

--- a/docs/data_entry_flow_index.md
+++ b/docs/data_entry_flow_index.md
@@ -661,7 +661,7 @@ async def ws_start_preview(
         state: str | None,
         attributes: Mapping[str, Any] | None,
         error: str | None,
-        domain: str | None,
+        domain: str | None, # e.g. "sensor", "select", "datetime" etc.
     ) -> None:
         """Forward preview updates to websocket."""
         # Errors sent here will appear in the preview element on the data 
@@ -707,7 +707,7 @@ async def ws_start_preview(
 
 :::tip
 
- `domain` in omitted in async_preview_callback refers to the the preview entity's domain (e.g. `"sensor"` or `"select"`). If `domain` is omitted in the event message in `async_preview_callback` above the frontend will fall back first to the flow's current `step_id` which is fine if you want a `SelectEntity` preview and `async_show_form` is being called from `async_step_select`.  If `step_id` doesn't match any domains the frontend will fallback and render a `SensorEntity` with applicable attributes.
+ `domain` in async_preview_callback refers to the the preview entity's domain (e.g. `"sensor"` or `"select"`). If `domain` is not provided or `None` the frontend will fallback to render a `SensorEntity` with applicable attributes.
 
 :::
 
@@ -761,7 +761,7 @@ class PreviewSensorEntity(SensorEntity):
 
 #### 3. Register the websocket preview command
 
-Add a static method `async_setup_preview` to the flow handler.
+Add a static method `async_setup_preview` to the flow handler (the platform integration of `ConfigFlow`):
 
 ```python
 @staticmethod


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Add documentation for using data entry flow previews.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [X] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [X] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

Creating an integration config flow with previews took hours of reverse engineering existing code and detailed review of existing components that use previews (for example):
- `homeassistant.components.templates`
- `homeassistant.components.group`

This additional documentation seeks to help others to avoid this deep dive into the inner workings of the core and frontend to get previews working in their code.  Please note the use of `domain` in the code is dependent on the frontend PR referenced below.  We should discuss if we should use the key "domain" or something like "entity_domain" which might be a bit more clear.

- Link to relevant existing code or pull request:  https://github.com/home-assistant/frontend/pull/51829


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive "Entity previews" guide for config, option, subentry, and repair flows: explains live input previews, validation with client-side error responses, and how preview updates (state, attributes, or errors) are forwarded to the frontend.
  * Includes an example preview implementation, instructions for registering preview handlers, how to enable previews when showing forms, and a frontend fallback tip for missing domain info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->