### PR TITLE
MQTT publish API changes for None fallbacks qos and retain

### DIFF
--- a/blog/2026-05-07-mqtt-publish-api-changes
+++ b/blog/2026-05-07-mqtt-publish-api-changes
@@ -1,0 +1,37 @@
+---
+author: Jan Bouwhuis
+authorURL: https://github.com/jbouwh
+authorImageURL: https://avatars.githubusercontent.com/u/7188918?s=96&v=4
+title: MQTT publish API changes
+---
+The MQTT publish API no longer accepts `None` values as fallback for the `qos` and `retain` args. Custom integrations that use the fallbacks should update their code to accept the defaults, or pass valid typed arguements.
+The fallbacks to `None` for `qos` and `retain` will stop working with HA Core 2027.6.
+
+The new API signatures are:
+
+```python
+def publish(
+    hass: HomeAssistant,
+    topic: str,
+    payload: PublishPayloadType,
+    qos: int = 0,
+    retain: bool = False,
+    encoding: str | None = DEFAULT_ENCODING,
+) -> None:
+    """Publish message to a MQTT topic."""
+    hass.create_task(async_publish(hass, topic, payload, qos, retain, encoding))
+```
+
+and
+
+```python
+async def async_publish(
+    hass: HomeAssistant,
+    topic: str,
+    payload: PublishPayloadType,
+    qos: int = 0,
+    retain: bool = False,
+    encoding: str | None = DEFAULT_ENCODING,
+) -> None:
+    """Publish message to a MQTT topic."""
+```

--- a/blog/2026-05-07-mqtt-publish-api-changes
+++ b/blog/2026-05-07-mqtt-publish-api-changes
@@ -4,8 +4,9 @@ authorURL: https://github.com/jbouwh
 authorImageURL: https://avatars.githubusercontent.com/u/7188918?s=96&v=4
 title: MQTT publish API changes
 ---
-The MQTT publish API no longer accepts `None` values as fallback for the `qos` and `retain` args. Custom integrations that use the fallbacks should update their code to accept the defaults, or pass valid typed arguements.
-The fallbacks to `None` for `qos` and `retain` will stop working with HA Core 2027.6.
+In the future, the MQTT publish API will require explicit values for `qos` and `retain`. Passing `None` for either argument will no longer be supported.
+Custom integrations should update their code to accept the defaults, or pass valid typed arguments.
+The fallbacks of `None` to a valid value for `qos` and `retain` will stop working with HA Core 2027.6.
 
 The new API signatures are:
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Add blogpost to explain MQTT publish API changes for None fallbacks qos and retain

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [x] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/169936


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * MQTT publish API behavior changed: `qos` and `retain` no longer accept `None` and now default to `qos: 0` and `retain: False`; `encoding` default unchanged.
  * Custom integrations should explicitly pass the new typed values or rely on these defaults. Deprecated `None` fallback ends in HA Core 2027.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->