### PR TITLE
Document hass.formatEntityName helper for custom cards

### DIFF
--- a/blog/2026-05-11-format-entity-name-helper.md
+++ b/blog/2026-05-11-format-entity-name-helper.md
@@ -1,0 +1,23 @@
+---
+author: Paul Bottein
+authorURL: https://github.com/piitaya
+title: "Format entity names in custom cards"
+---
+
+As of Home Assistant 2026.4, the `hass` object exposes a `formatEntityName` helper. It is the same function used by the built-in cards (tile card, entity rows, ...) to compute the display name of an entity from its registry context (entity, device, area, floor). Custom cards can use it to produce names that stay consistent with the rest of the dashboard.
+
+Given a temperature sensor named `Temperature` on a device named `Thermostat`:
+
+```js
+const stateObj = hass.states["sensor.living_room_thermostat_temperature"];
+
+hass.formatEntityName(
+  stateObj,
+  [{ type: "device" }, { type: "entity" }],
+  { separator: " · " }
+); // "Thermostat · Temperature"
+```
+
+The frontend also ships an `entity_name` selector. If your card uses the [built-in form editor](/docs/frontend/custom-ui/custom-card#using-the-built-in-form-editor), you can offer users the same name picker the built-in cards use — accepting either a free-form string or a composition of registry items.
+
+Take a look at the updated [data documentation](/docs/frontend/data#hassformatentitynamestateobj-name-options) for the full reference and more examples.

--- a/docs/frontend/data.md
+++ b/docs/frontend/data.md
@@ -223,3 +223,112 @@ Format the attribute name of an entity. You need to pass the entity state object
 ```js
 hass.formatEntityAttributeName(hass.states["climate.thermostat"], "current_temperature"); // "Current temperature"
 ```
+
+### `hass.formatEntityName(stateObj, name, options)`
+
+_Available since Home Assistant 2026.4._
+
+Format the display name of an entity using its registry context (entity, device, area, floor). This is the same helper used by the built-in cards (tile, entity rows, etc.) so custom cards can produce consistent labels.
+
+The `name` argument can be:
+
+- A plain `string` — returned as-is. Use this to honor a user-provided override.
+- A single name item, like `{ type: "entity" }`.
+- An array of name items, joined with the separator. Items can reference registry data (`entity`, `device`, `area`, `floor`) or be literal `text`.
+- `undefined` — falls back to the entity's friendly name.
+
+```ts
+type EntityNameItem =
+  | { type: "entity" | "device" | "area" | "floor" }
+  | { type: "text"; text: string };
+
+interface EntityNameOptions {
+  separator?: string; // defaults to " "
+}
+```
+
+For the examples below, assume `sensor.living_room_thermostat_temperature` is the temperature sensor of a thermostat device, where:
+
+- entity name: `Temperature`
+- device name: `Thermostat`
+- area: `Living room`
+- floor: `Ground floor`
+
+```js
+const stateObj = hass.states["sensor.living_room_thermostat_temperature"];
+
+// Friendly name fallback
+hass.formatEntityName(stateObj, undefined); // "Thermostat Temperature"
+
+// User-provided override
+hass.formatEntityName(stateObj, "Indoor temperature"); // "Indoor temperature"
+
+// Single registry item
+hass.formatEntityName(stateObj, { type: "entity" }); // "Temperature"
+hass.formatEntityName(stateObj, { type: "area" }); // "Living room"
+
+// Composed display with a custom separator
+hass.formatEntityName(
+  stateObj,
+  [{ type: "device" }, { type: "entity" }],
+  { separator: " · " }
+); // "Thermostat · Temperature"
+
+// Mix literal text and registry items
+hass.formatEntityName(
+  stateObj,
+  [{ type: "text", text: "Floor:" }, { type: "floor" }]
+); // "Floor: Ground floor"
+```
+
+#### Using it in a custom card
+
+A common pattern is to accept a `name` option in the card configuration and forward it directly to `formatEntityName`. This lets users either provide a string or use the structured form to combine registry data.
+
+```yaml
+type: custom:my-card
+entity: sensor.living_room_thermostat_temperature
+name:
+  - type: area
+  - type: entity
+```
+
+Inside your card class:
+
+```js
+setConfig(config) {
+  if (!config.entity) {
+    throw new Error("You need to define an entity");
+  }
+  this._config = config;
+}
+
+render() {
+  const stateObj = this.hass.states[this._config.entity];
+  const name = this.hass.formatEntityName(stateObj, this._config.name);
+  return html`<div>${name}</div>`;
+}
+```
+
+#### Editing it in the visual editor
+
+The frontend ships an `entity_name` selector that produces values in the shape `formatEntityName` accepts. In a card using the [built-in form editor](/docs/frontend/custom-ui/custom-card#using-the-built-in-form-editor), reference the entity field through `context` so the selector knows which entity to resolve the registry context against:
+
+```js
+{
+  name: "name",
+  selector: {
+    entity_name: {},
+  },
+  context: {
+    entity: "entity",
+  },
+}
+```
+
+The value produced by the selector matches what `formatEntityName` accepts: either a plain string (free-form custom name) or one or more `EntityNameItem` entries (composed from registry data). The selector UI lets users switch between the two modes.
+
+The selector accepts two options:
+
+- `entity_id`: hardcode the entity used to preview names (overrides `context.entity`).
+- `default_name`: the value shown when the field is empty. Accepts the same `string | EntityNameItem | EntityNameItem[]` shape.


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Add documentation and blog post for the new `hass.formatEntityName` helper, available since Home Assistant 2026.4.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [ ] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/frontend/pull/26057

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the new `formatEntityName` helper method, available in Home Assistant 2026.4
  * Custom card developers can now generate consistent display names using entity registry context (entity/device/area/floor)
  * Includes usage examples and configuration patterns for implementation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->