### PR TITLE
Document getConfigElement for custom dashboard strategies

### DIFF
--- a/docs/frontend/custom-ui/creating-custom-panels.md
+++ b/docs/frontend/custom-ui/creating-custom-panels.md
@@ -1,5 +1,6 @@
 ---
 title: "Creating custom panels"
+sidebar_label: "Custom panels"
 ---
 
 Panels are pages that show information within Home Assistant and can allow controlling it. Panels are linked from the sidebar and rendered full screen. They have real-time access to the Home Assistant object via JavaScript. Examples of panels in the app are dashboards, Map, Logbook and History.

--- a/docs/frontend/custom-ui/custom-strategy.md
+++ b/docs/frontend/custom-ui/custom-strategy.md
@@ -1,5 +1,6 @@
 ---
-title: "Custom strategies"
+title: "Custom dashboard strategies"
+sidebar_label: "Custom dashboards"
 ---
 
 _Introduced in Home Assistant 2021.5._
@@ -145,6 +146,68 @@ Use the following dashboard configuration to use this strategy:
 strategy:
   type: custom:my-demo
 ```
+
+## Graphical configuration
+
+Your strategy can define a static `getConfigElement` method that returns a custom element for editing the strategy configuration. Home Assistant will display this element in the dashboard settings dialog.
+
+Set `configRequired` to `true` if your strategy requires configuration to work. This prevents Home Assistant from creating a dashboard with this strategy without first showing the configuration editor.
+
+Set `noEditor` to `true` if your strategy does not support graphical configuration.
+
+```js
+class MyDemoDashboardStrategy extends HTMLElement {
+
+  static getConfigElement() {
+    return document.createElement("my-demo-strategy-editor");
+  }
+
+  static configRequired = true;
+
+  static async generate(config, hass) {
+    return {
+      views: [
+        {
+          cards: [
+            {
+              type: "iframe",
+              url: config.url,
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+}
+
+customElements.define("ll-strategy-dashboard-my-demo", MyDemoDashboardStrategy);
+```
+
+```js
+class MyDemoStrategyEditor extends HTMLElement {
+  setConfig(config) {
+    this._config = config;
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+  }
+
+  configChanged(newConfig) {
+    const event = new Event("config-changed", {
+      bubbles: true,
+      composed: true,
+    });
+    event.detail = { config: newConfig };
+    this.dispatchEvent(event);
+  }
+}
+
+customElements.define("my-demo-strategy-editor", MyDemoStrategyEditor);
+```
+
+Home Assistant will call the `setConfig` method of the config element on setup. The `hass` property will be updated on state changes. Changes to the configuration are communicated back by dispatching a `config-changed` event with the new configuration in its detail.
 
 ## Views
 

--- a/docs/frontend/custom-ui/custom-strategy.md
+++ b/docs/frontend/custom-ui/custom-strategy.md
@@ -195,12 +195,13 @@ class MyDemoStrategyEditor extends HTMLElement {
   }
 
   configChanged(newConfig) {
-    const event = new Event("config-changed", {
-      bubbles: true,
-      composed: true,
-    });
-    event.detail = { config: newConfig };
-    this.dispatchEvent(event);
+    this.dispatchEvent(
+      new CustomEvent("config-changed", {
+        bubbles: true,
+        composed: true,
+        detail: { config: newConfig },
+      })
+    );
   }
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Adds a "Graphical configuration" section to the custom strategy docs covering `getConfigElement`, `configRequired`, and `noEditor` — mirroring the existing custom card documentation, so strategy authors know how to ship a graphical editor for their dashboards.

While in there, also tweaks the page title and sidebar labels:
- Page title: "Custom Strategies" → "Custom dashboard strategies"
- Sidebar label for that page: "Custom dashboards"
- Sidebar label for "Creating custom panels": "Custom panels"

Replaces #3079 (closed due to stale Netlify deploy preview cache causing build failures).

## Type of change

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information

- Link to relevant existing code or pull request: https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/strategies/types.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Enhanced documentation organization for custom panels with improved sidebar navigation.
* Expanded custom strategy documentation with new section on graphical configuration capabilities, including examples of implementing visual configuration editors and handling configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->