### PR TITLE
Fixed return data of  GET /host/info (Supervisor API)

### DIFF
--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -1760,31 +1760,31 @@ Return information about the host.
 
 **Returned data**
 
-| key              | type           | description                               |
-| ---------------- | -------------- | ----------------------------------------- |
-| agent_version    | string or null | Agent version running on the Host         |
-| apparmor_version | string or null | The AppArmor version from host            |
-| boot_timestamp   | int            | The timestamp for the last boot in microseconds |
-| broadcast_llmnr  | bool or null   | Host is broadcasting its LLMNR hostname   |
-| broadcast_mdns   | bool or null   | Host is broadcasting its MulticastDNS hostname |
-| chassis          | string or null | The chassis type                          |
-| virtualization   | string or null | Virtualization hypervisor in use (if any) |
-| cpe              | string or null | The local CPE                             |
-| deployment       | string or null | The deployment stage of the OS if any     |
-| disk_total       | float          | Total space of the disk in MB             |
-| disk_used        | float          | Used space of the disk in MB              |
-| disk_free        | float          | Free space of the disk in MB              |
-| features         | list           | A list of features available for the host |
-| hostname         | string or null | The hostname of the host                  |
-| kernel           | string or null | The kernel version on the host            |
-| llmnr_hostname   | string or null | The hostname currently exposed on the network via LLMNR for host |
-| operating_system | string         | The operating system on the host          |
-| startup_time     | float          | The time in seconds it took for last boot |
+| key              | type           | description                                                                                                                |
+| ---------------- | -------------- |----------------------------------------------------------------------------------------------------------------------------|
+| agent_version    | string or null | Agent version running on the Host                                                                                          |
+| apparmor_version | string or null | The AppArmor version from host                                                                                             |
+| boot_timestamp   | int            | The timestamp for the last boot in microseconds                                                                            |
+| broadcast_llmnr  | bool or null   | Host is broadcasting its LLMNR hostname                                                                                    |
+| broadcast_mdns   | bool or null   | Host is broadcasting its MulticastDNS hostname                                                                             |
+| chassis          | string or null | The chassis type                                                                                                           |
+| virtualization   | string or null | Virtualization hypervisor in use (if any)                                                                                  |
+| cpe              | string or null | The local CPE                                                                                                              |
+| deployment       | string or null | The deployment stage of the OS if any                                                                                      |
+| disk_total       | float          | Total space of the disk in GB                                                                                              |
+| disk_used        | float          | Used space of the disk in GB                                                                                               |
+| disk_free        | float          | Free space of the disk in GB                                                                                               |
+| features         | list           | A list of features available for the host                                                                                  |
+| hostname         | string or null | The hostname of the host                                                                                                   |
+| kernel           | string or null | The kernel version on the host                                                                                             |
+| llmnr_hostname   | string or null | The hostname currently exposed on the network via LLMNR for host                                                           |
+| operating_system | string         | The operating system on the host                                                                                           |
+| startup_time     | float          | The time in seconds it took for last boot                                                                                  |
 | disk_life_time   | float or null  | Percentage of estimated disk lifetime used (0–100). Not all disks provide this information, returns `null` if unavailable. |
-| timezone         | string         | The current timezone of the host. |
-| dt_utc           | string         | Current UTC date/time of the host in ISO 8601 format. |
-| dt_synchronized  | bool           | `true` if the host is synchronized with an NTP service. |
-| use_ntp          | bool           | `true` if the host is using an NTP service for time synchronization. |
+| timezone         | string         | The current timezone of the host.                                                                                          |
+| dt_utc           | string         | Current UTC date/time of the host in ISO 8601 format.                                                                      |
+| dt_synchronized  | bool           | `true` if the host is synchronized with an NTP service.                                                                    |
+| use_ntp          | bool           | `true` if the host is using an NTP service for time synchronization.                                                       |
 
 **Example response:**
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

The fields `disk_total`, `disk_used` and `disk_free` of the returned data of GET /host/info was wrongly stated MB instead of GB.

You can see the change in `/docs/api/supervisor/endpoints`


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

Fixes https://github.com/home-assistant/home-assistant.io/issues/43845


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `/host/info` endpoint documentation to reflect disk space units as GB for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->