### PR TITLE
Document scan_interval and scan_duration for bluetooth.async_register_callback

### DIFF
--- a/docs/core/bluetooth/api.md
+++ b/docs/core/bluetooth/api.md
@@ -69,6 +69,29 @@ entry.async_on_unload(
 )
 ```
 
+#### Requesting on-demand active scanning
+
+When the matcher targets a specific `address` and `mode` is not `PASSIVE`, the callback registration can also opt that address in to the active-scan scheduler used by `AUTO`-mode scanners. This lets an integration ask for short active-scan windows on a cadence that suits its device, without forcing the whole system into continuous active scanning.
+
+Pass `scan_interval` (seconds between window starts) and/or `scan_duration` (seconds per window) as keyword arguments. Both are optional; when omitted, habluetooth's defaults (5 minutes interval, 10 seconds duration) are used. The effective window is clamped to habluetooth's allowed range. Without an `address` in the matcher the active-scan request is skipped; the callback itself still fires normally.
+
+```python
+from homeassistant.components import bluetooth
+
+...
+
+entry.async_on_unload(
+    bluetooth.async_register_callback(
+        hass,
+        _async_specific_device_found,
+        {"address": "44:33:11:22:33:22"},
+        bluetooth.BluetoothScanningMode.ACTIVE,
+        scan_interval=600.0,
+        scan_duration=10.0,
+    )
+)
+```
+
 ### Fetch the shared BleakScanner instance
 
 Integrations that need an instance of a `BleakScanner` should call the `bluetooth.async_get_scanner` API. This API returns a wrapper around a single `BleakScanner` that allows integrations to share without overloading the system.
@@ -309,6 +332,8 @@ service_info = await bluetooth.async_process_advertisements(
     ADDITIONAL_DISCOVERY_TIMEOUT
 )
 ```
+
+When `mode` is not `PASSIVE` and the matcher contains an `address`, `timeout` is also forwarded to the active-scan scheduler as `scan_duration`, so `AUTO`-mode scanners flip ACTIVE for the address while waiting for the advertisement.
 
 ### Registering an external scanner
 


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Document the new optional ``scan_interval`` and ``scan_duration`` keyword arguments on ``bluetooth.async_register_callback`` so integrations can opt a specific address in to habluetooth's on-demand active-scan scheduler; also note that ``async_process_advertisements`` now forwards its ``timeout`` as ``scan_duration``.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: home-assistant/core#171806

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved Bluetooth API documentation with comprehensive guidance on configuring on-demand active scanning
  * Added details on scan timing parameters and address-based matching configuration options
  * Clarified how timeout settings interact with active scanning modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->