### PR TITLE
Document bluetooth.async_request_active_scan

### DIFF
--- a/docs/core/bluetooth/api.md
+++ b/docs/core/bluetooth/api.md
@@ -242,6 +242,18 @@ from homeassistant.components import bluetooth
 bluetooth.async_rediscover_address(hass, "44:44:33:11:23:42")
 ```
 
+### Triggering a one-shot active scan
+
+For config flow discovery and other one-shot probes, `bluetooth.async_request_active_scan` runs an on-demand active sweep across every `AUTO` mode scanner without waiting for the periodic rediscovery cadence. It awaits `duration` seconds so the caller can then read newly discovered advertisements. `duration` is optional; when omitted, habluetooth's on-demand sweep duration is used. The scheduler clamps the value to its allowed range. Concurrent callers dedupe to a single bus wide window.
+
+Only `AUTO` mode scanners are affected; `PASSIVE` and `ACTIVE` scanners are user explicit choices and are left alone.
+
+```python
+from homeassistant.components import bluetooth
+
+await bluetooth.async_request_active_scan(hass)
+```
+
 ### Clearing match history for rediscovery
 
 The Bluetooth integration tracks which advertisement fields (manufacturer_data UUIDs, service_data UUIDs, service_uuids) have been seen for each device to determine when to trigger discovery. It only checks if the UUIDs have been seen before, not whether their content has changed.

--- a/docs/core/bluetooth/api.md
+++ b/docs/core/bluetooth/api.md
@@ -246,7 +246,7 @@ bluetooth.async_rediscover_address(hass, "44:44:33:11:23:42")
 
 For config flow discovery and other one-shot probes, `bluetooth.async_request_active_scan` runs an on-demand active sweep across every `AUTO` mode scanner without waiting for the periodic rediscovery cadence. It awaits `duration` seconds so the caller can then read newly discovered advertisements. `duration` is optional; when omitted, habluetooth's on-demand sweep duration is used. The scheduler clamps the value to its allowed range. Concurrent callers dedupe to a single bus wide window.
 
-Only `AUTO` mode scanners are affected; `PASSIVE` and `ACTIVE` scanners are user explicit choices and are left alone.
+Only `AUTO` mode scanners are affected; `PASSIVE` and `ACTIVE` scanners are user-explicit choices and are left alone.
 
 ```python
 from homeassistant.components import bluetooth


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Document the new bluetooth.async_request_active_scan API for one-shot active scan sweeps across AUTO mode scanners.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [ ] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: home-assistant/core#172010

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new docs subsection describing one-shot active scan behavior for on-demand Bluetooth discovery. Covers scan duration handling with scheduler clamping, how simultaneous requests are deduplicated into a single scan window, behavior across scanner modes, and includes a minimal Python usage example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->