### PR TITLE
Document scan_interval and scan_duration on Bluetooth processor coordinators

### DIFF
--- a/docs/core/bluetooth/bluetooth_fetching_data.md
+++ b/docs/core/bluetooth/bluetooth_fetching_data.md
@@ -269,7 +269,7 @@ coordinator = ActiveBluetoothProcessorCoordinator(
 )
 ```
 
-Both arguments default to `None`, which leaves the underlying scheduler at its built in cadence. `PASSIVE` and `ACTIVE` scanners are user explicit choices and are not affected; only `AUTO` mode scanners honor the request.
+Both arguments default to `None`, which leaves the underlying scheduler at its built-in cadence. `PASSIVE` and `ACTIVE` scanners are user-explicit choices and are not affected; only `AUTO` mode scanners honor the request.
 
 ## BluetoothCoordinator
 

--- a/docs/core/bluetooth/bluetooth_fetching_data.md
+++ b/docs/core/bluetooth/bluetooth_fetching_data.md
@@ -246,6 +246,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 ```
 
+#### Requesting an active scan cadence
+
+`PassiveBluetoothProcessorCoordinator` and `ActiveBluetoothProcessorCoordinator` accept two optional keyword arguments, `scan_interval` and `scan_duration`, that are forwarded to the Bluetooth manager when the coordinator starts. They request a periodic active scan window for the coordinator's address from any `AUTO` mode scanner, so the device keeps emitting advertisements that contain its full payload without having to flip the scanner to `ACTIVE` mode permanently.
+
+This is useful for devices that fall back to a connectable poll when they have not been actively scanned for some time; pick a `scan_interval` shorter than that fallback and a `scan_duration` long enough to capture the next advertisement.
+
+```python
+coordinator = ActiveBluetoothProcessorCoordinator(
+    hass,
+    _LOGGER,
+    address=address,
+    mode=BluetoothScanningMode.PASSIVE,
+    update_method=data.update,
+    needs_poll_method=_needs_poll,
+    poll_method=_async_poll,
+    connectable=False,
+    # Ask AUTO mode scanners to flip ACTIVE for 10 seconds
+    # every 165 seconds for this address.
+    scan_interval=165.0,
+    scan_duration=10.0,
+)
+```
+
+Both arguments default to `None`, which leaves the underlying scheduler at its built in cadence. `PASSIVE` and `ACTIVE` scanners are user explicit choices and are not affected; only `AUTO` mode scanners honor the request.
+
 ## BluetoothCoordinator
 
 The `ActiveBluetoothDataUpdateCoordinator` and `PassiveBluetoothCoordinator` coordinators function similar


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Documents the new `scan_interval` and `scan_duration` keyword arguments on `PassiveBluetoothProcessorCoordinator` and `ActiveBluetoothProcessorCoordinator`. These are forwarded to the Bluetooth manager when the coordinator starts so the device's address gets a periodic active scan window from any AUTO mode scanner; the example shows the pattern of picking an interval shorter than a device's connect fallback and a duration long enough to capture the next advertisement.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: home-assistant/core#172015

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on requesting an active scan cadence for Bluetooth coordinators. The new section describes optional scan_interval and scan_duration parameters to request periodic active scan windows from AUTO-mode scanners, shows a configuration example, explains default behavior (None), and clarifies that only scanners in AUTO mode will honor the request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->