### PR TITLE
Align device tracker documentation with core changes

### DIFF
--- a/docs/core/entity/device-tracker.md
+++ b/docs/core/entity/device-tracker.md
@@ -9,7 +9,7 @@ A device tracker is a read-only entity that provides presence information. There
 
 A BaseScannerEntity reports the connected state of a device, for example to a bluetooth beacon. If the device is connected the BaseScannerEntity's state will be the name of the associated zone, e.g `home` if associated with the home zone, and if the device is not connected the state will be `not_home`.
 
-The base class sets the `in_zones` state attribute will be populated with the `entity_id` of the associated zone and zones containing it when the device is connected and empty when not connected.
+The base class sets the `in_zones` state attribute. It will be populated with the `entity_id` of the associated zone and zones containing it when the device is connected and empty when not connected.
 
 The base class also sets the `tracking_type` capability attribute to `TrackingType.CONNECTION`.
 
@@ -30,7 +30,7 @@ Properties should always only return information from memory and not do I/O (lik
 
 A ScannerEntity reports the connected state of a device on the local network. If the device is connected the ScannerEntity's state will be the name of the associated zone, e.g `home` if associated with the home zone, and if the device is not connected the state will be `not_home`.
 
-The base class sets the `in_zones` state attribute will be populated with the `entity_id` of the associated zone and zones containing it when the device is connected and empty when not connected.
+The base class sets the `in_zones` state attribute. It will be populated with the `entity_id` of the associated zone and zones containing it when the device is connected and empty when not connected.
 
 The base class also sets the `tracking_type` capability attribute to `TrackingType.CONNECTION`.
 

--- a/docs/core/entity/device-tracker.md
+++ b/docs/core/entity/device-tracker.md
@@ -60,7 +60,7 @@ DHCP discover packets to find existing devices.
 
 ## TrackerEntity
 
-A TrackerEntity tracks the location of a device and reports it either as a zone name or `home` or `not_home` states. A TrackerEntity can use GPS coordinates or a list of `Zone` entity_ids to determine its state. Either `in_zones` or `latitude` and `longitude` should be set to report state. If both `in_zones` and `latitude` + `longitude` are present, `in_zones` has priority. If `in_zones` is not provided, the base class calculates an `in_zones` list, including both active anc passive zone the device is currently in. The state of the entity is the first active zone in the `in_zones` list, `home` if the first active zone is the home zone or `not_home` if there is no active zone in the `in_zones` list.
+A TrackerEntity tracks the location of a device and reports it either as a zone name or `home` or `not_home` states. A TrackerEntity can use GPS coordinates or a list of `Zone` entity_ids to determine its state. Either `in_zones` or `latitude` and `longitude` should be set to report state. If both `in_zones` and `latitude` + `longitude` are present, `in_zones` has priority. If `in_zones` is not provided, the base class calculates an `in_zones` list, including both active and passive zones the device is currently in. The state of the entity is the first active zone in the `in_zones` list, `home` if the first active zone is the home zone or `not_home` if there is no active zone in the `in_zones` list.
 
 The base class sets the `tracking_type` capability attribute to `TrackingType.POSITION`.
 

--- a/docs/core/entity/device-tracker.md
+++ b/docs/core/entity/device-tracker.md
@@ -9,7 +9,7 @@ A device tracker is a read-only entity that provides presence information. There
 
 A BaseScannerEntity reports the connected state of a device, for example to a bluetooth beacon. If the device is connected the BaseScannerEntity's state will be the name of the associated zone, e.g `home` if associated with the home zone, and if the device is not connected the state will be `not_home`.
 
-The base class sets the `in_zones` state attribute. It will be populated with the `entity_id` of the associated zone and zones containing it when the device is connected and empty when not connected.
+The base class sets the `in_zones` state attribute. It will be populated with the `entity_id` of the associated zone and zones containing it, sorted by size, when the device is connected and empty when not connected.
 
 The base class also sets the `tracking_type` capability attribute to `TrackingType.CONNECTION`.
 
@@ -30,7 +30,7 @@ Properties should always only return information from memory and not do I/O (lik
 
 A ScannerEntity reports the connected state of a device on the local network. If the device is connected the ScannerEntity's state will be the name of the associated zone, e.g `home` if associated with the home zone, and if the device is not connected the state will be `not_home`.
 
-The base class sets the `in_zones` state attribute. It will be populated with the `entity_id` of the associated zone and zones containing it when the device is connected and empty when not connected.
+The base class sets the `in_zones` state attribute. It will be populated with the `entity_id` of the associated zone and zones containing it, sorted by size, when the device is connected and empty when not connected.
 
 The base class also sets the `tracking_type` capability attribute to `TrackingType.CONNECTION`.
 
@@ -74,7 +74,7 @@ Properties should always only return information from memory and not do I/O (lik
 
 | Name              | Type                | Default          | Description                              |
 | ----------------- | --------------------| ---------------- | ---------------------------------------- |
-| in_zones          | `list[str] \| None` | `None`           | The zones the device is in, including passive zones. |
+| in_zones          | `list[str] \| None` | `None`           | The zones the device is in, including passive zones. Should be sorted by size of the zone, then by distance to center of zones. |
 | latitude          | `float \| None`     | `None`           | The latitude coordinate of the device, ignored if `in_zones` is not `None`.   |
 | location_accuracy | `float`             | `0`              | The location accuracy (m) of the device. |
 | longitude         | `float \| None`     | `None`           | The longitude coordinate of the device, ignored if `in_zones` is not `None`.  |

--- a/docs/core/entity/device-tracker.md
+++ b/docs/core/entity/device-tracker.md
@@ -56,7 +56,7 @@ DHCP discover packets to find existing devices.
 
 ## TrackerEntity
 
-A TrackerEntity tracks the location of a device and reports it either as a location name, a zone name or `home` or `not_home` states. A TrackerEntity normally receives GPS coordinates to determine its state. Either `in_zones` or `latitude` and `longitude` should be set to report state.
+A TrackerEntity tracks the location of a device and reports it either as a zone name or `home` or `not_home` states. A TrackerEntity can use GPS coordinates or a list of `Zone` entity_ids to determine its state. Either `in_zones` or `latitude` and `longitude` should be set to report state. If both `in_zones` and `latitude` + `longitude` are present, `in_zones` has priority. If `in_zones` is not provided, the base class calculates an `in_zones` list, including both active anc passive zone the device is currently in. The state of the entity is the first active zone in the `in_zones` list, `home` if the first active zone is the home zone or `not_home` if there is no active zone in the `in_zones` list.
 
 Derive a platform entity from [`homeassistant.components.device_tracker.config_entry.TrackerEntity`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/device_tracker/config_entry.py)
 
@@ -68,8 +68,8 @@ Properties should always only return information from memory and not do I/O (lik
 
 | Name              | Type                | Default          | Description                              |
 | ----------------- | --------------------| ---------------- | ---------------------------------------- |
-| in_zones          | `list[str] \| None` | `None`           | The zones the device is in, ignored if latitude and longitude are not `None` |
-| latitude          | `float \| None`     | `None`           | The latitude coordinate of the device.   |
+| in_zones          | `list[str] \| None` | `None`           | The zones the device is in, including passive zones. |
+| latitude          | `float \| None`     | `None`           | The latitude coordinate of the device, ignored if `in_zones` is not `None`.   |
 | location_accuracy | `float`             | `0`              | The location accuracy (m) of the device. |
-| longitude         | `float \| None`     | `None`           | The longitude coordinate of the device.  |
+| longitude         | `float \| None`     | `None`           | The longitude coordinate of the device, ignored if `in_zones` is not `None`.  |
 | source_type       | SourceType          | `SourceType.GPS` | The source type of the device.           |

--- a/docs/core/entity/device-tracker.md
+++ b/docs/core/entity/device-tracker.md
@@ -7,7 +7,9 @@ A device tracker is a read-only entity that provides presence information. There
 
 ## BaseScannerEntity
 
-A BaseScannerEntity reports the connected state of a device, for example to a bluetooth beacon. If the device is connected the BaseScannerEntity will have state `home` and if the device is not connected the state will be `not_home`.
+A BaseScannerEntity reports the connected state of a device, for example to a bluetooth beacon. If the device is connected the BaseScannerEntity' state will be the name of the associated zone, e.g `home` if associated with the home zone, and if the device is not connected the state will be `not_home`.
+
+The in_zones state attribute will be populated with the entity_id of the associated zone and zones containing it when the device is connected and empty when not connected.
 
 Derive a platform entity from [`homeassistant.components.device_tracker.config_entry.BaseScannerEntity`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/device_tracker/config_entry.py)
 
@@ -19,13 +21,14 @@ Properties should always only return information from memory and not do I/O (lik
 
 | Name          | Type                         | Default             | Description                         |
 | ------------- | ---------------| ------------------- | ----------------------------------- |
-| battery_level | `int \| None`  | `None`              | The battery level of the device.    |
 | is_connected  | `bool \| None` | **Required**        | The connection state of the device. |
 | source_type   | `SourceType`   | **Required**        | The source type of the device.      |
 
 ## ScannerEntity
 
-A ScannerEntity reports the connected state of a device on the local network. If the device is connected the ScannerEntity will have state `home` and if the device is not connected the state will be `not_home`.
+A ScannerEntity reports the connected state of a device on the local network. If the device is connected the ScannerEntity' state will be the name of the associated zone, e.g `home` if associated with the home zone, and if the device is not connected the state will be `not_home`.
+
+The in_zones state attribute will be populated with the entity_id of the associated zone and zones containing it when the device is connected and empty when not connected.
 
 ScannerEntity is based on BaseScannerEntity and is meant for tracking devices which connect to an IP network and can be identified by MAC address.
 
@@ -39,7 +42,6 @@ Properties should always only return information from memory and not do I/O (lik
 
 | Name          | Type           | Default             | Description                         |
 | ------------- | ---------------| ------------------- | ----------------------------------- |
-| battery_level | `int \| None`  | `None`              | The battery level of the device.    |
 | hostname      | `str \| None`  | `None`              | The hostname of the device.         |
 | ip_address    | `str \| None`  | `None`              | The IP address of the device.       |
 | is_connected  | `bool \| None` | **Required**        | The connection state of the device. |
@@ -64,11 +66,10 @@ Derive a platform entity from [`homeassistant.components.device_tracker.config_e
 Properties should always only return information from memory and not do I/O (like network requests). Implement `update()` or `async_update()` to fetch data.
 :::
 
-| Name              | Type                           | Default          | Description                              |
-| ----------------- | ------------------------------ | ---------------- | ---------------------------------------- |
-| battery_level     | `int \| None`   | `None`           | The battery level of the device.         |
-| latitude          | `float \| None` | `None`           | The latitude coordinate of the device.   |
-| location_accuracy | `float`                        | `0`              | The location accuracy (m) of the device. |
-| location_name     | `str \| None`   | `None`           | The location name of the device.         |
-| longitude         | `float \| None` | `None`           | The longitude coordinate of the device.  |
-| source_type       | SourceType                     | `SourceType.GPS` | The source type of the device.           |
+| Name              | Type                | Default          | Description                              |
+| ----------------- | --------------------| ---------------- | ---------------------------------------- |
+| in_zones          | `list[str] \| None` | `None`           | The zones the devics is in, ignored if latitude and longitude are not `None` |
+| latitude          | `float \| None`     | `None`           | The latitude coordinate of the device.   |
+| location_accuracy | `float`             | `0`              | The location accuracy (m) of the device. |
+| longitude         | `float \| None`     | `None`           | The longitude coordinate of the device.  |
+| source_type       | SourceType          | `SourceType.GPS` | The source type of the device.           |

--- a/docs/core/entity/device-tracker.md
+++ b/docs/core/entity/device-tracker.md
@@ -9,7 +9,9 @@ A device tracker is a read-only entity that provides presence information. There
 
 A BaseScannerEntity reports the connected state of a device, for example to a bluetooth beacon. If the device is connected the BaseScannerEntity's state will be the name of the associated zone, e.g `home` if associated with the home zone, and if the device is not connected the state will be `not_home`.
 
-The in_zones state attribute will be populated with the entity_id of the associated zone and zones containing it when the device is connected and empty when not connected.
+The base class sets the `in_zones` state attribute will be populated with the `entity_id` of the associated zone and zones containing it when the device is connected and empty when not connected.
+
+The base class also sets the `tracking_type` capability attribute to `TrackingType.CONNECTION`.
 
 Derive a platform entity from [`homeassistant.components.device_tracker.config_entry.BaseScannerEntity`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/device_tracker/config_entry.py)
 
@@ -28,7 +30,9 @@ Properties should always only return information from memory and not do I/O (lik
 
 A ScannerEntity reports the connected state of a device on the local network. If the device is connected the ScannerEntity's state will be the name of the associated zone, e.g `home` if associated with the home zone, and if the device is not connected the state will be `not_home`.
 
-The in_zones state attribute will be populated with the entity_id of the associated zone and zones containing it when the device is connected and empty when not connected.
+The base class sets the `in_zones` state attribute will be populated with the `entity_id` of the associated zone and zones containing it when the device is connected and empty when not connected.
+
+The base class also sets the `tracking_type` capability attribute to `TrackingType.CONNECTION`.
 
 ScannerEntity is based on BaseScannerEntity and is meant for tracking devices which connect to an IP network and can be identified by MAC address.
 
@@ -57,6 +61,8 @@ DHCP discover packets to find existing devices.
 ## TrackerEntity
 
 A TrackerEntity tracks the location of a device and reports it either as a zone name or `home` or `not_home` states. A TrackerEntity can use GPS coordinates or a list of `Zone` entity_ids to determine its state. Either `in_zones` or `latitude` and `longitude` should be set to report state. If both `in_zones` and `latitude` + `longitude` are present, `in_zones` has priority. If `in_zones` is not provided, the base class calculates an `in_zones` list, including both active anc passive zone the device is currently in. The state of the entity is the first active zone in the `in_zones` list, `home` if the first active zone is the home zone or `not_home` if there is no active zone in the `in_zones` list.
+
+The base class sets the `tracking_type` capability attribute to `TrackingType.POSITION`.
 
 Derive a platform entity from [`homeassistant.components.device_tracker.config_entry.TrackerEntity`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/device_tracker/config_entry.py)
 

--- a/docs/core/entity/device-tracker.md
+++ b/docs/core/entity/device-tracker.md
@@ -60,7 +60,7 @@ DHCP discover packets to find existing devices.
 
 ## TrackerEntity
 
-A TrackerEntity tracks the location of a device and reports it either as a zone name or `home` or `not_home` states. A TrackerEntity can use GPS coordinates or a list of `Zone` entity_ids to determine its state. Either `in_zones` or `latitude` and `longitude` should be set to report state. If both `in_zones` and `latitude` + `longitude` are present, `in_zones` has priority. If `in_zones` is not provided, the base class calculates an `in_zones` list, including both active and passive zones the device is currently in. The state of the entity is the first active zone in the `in_zones` list, `home` if the first active zone is the home zone or `not_home` if there is no active zone in the `in_zones` list.
+A TrackerEntity tracks the location of a device and reports it either as a zone name or `home` or `not_home` states. A TrackerEntity can use GPS coordinates or a list of `Zone` entity_ids to determine its state. Either `in_zones` or `latitude` and `longitude` should be set to report state. If both `in_zones` and `latitude` + `longitude` are present, `in_zones` has priority. If `in_zones` is not provided, the base class calculates an `in_zones` list, including both the active and passive zones the device is currently in. The state of the entity is either the first active zone in the `in_zones` list, `home` if the first active zone is the home zone or `not_home` if there is no active zone in the `in_zones` list.
 
 The base class sets the `tracking_type` capability attribute to `TrackingType.POSITION`.
 

--- a/docs/core/entity/device-tracker.md
+++ b/docs/core/entity/device-tracker.md
@@ -56,7 +56,7 @@ DHCP discover packets to find existing devices.
 
 ## TrackerEntity
 
-A TrackerEntity tracks the location of a device and reports it either as a location name, a zone name or `home` or `not_home` states. A TrackerEntity normally receives GPS coordinates to determine its state. Either `location_name` or `latitude` and `longitude` should be set to report state.
+A TrackerEntity tracks the location of a device and reports it either as a location name, a zone name or `home` or `not_home` states. A TrackerEntity normally receives GPS coordinates to determine its state. Either `in_zones` or `latitude` and `longitude` should be set to report state.
 
 Derive a platform entity from [`homeassistant.components.device_tracker.config_entry.TrackerEntity`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/device_tracker/config_entry.py)
 

--- a/docs/core/entity/device-tracker.md
+++ b/docs/core/entity/device-tracker.md
@@ -74,7 +74,7 @@ Properties should always only return information from memory and not do I/O (lik
 
 | Name              | Type                | Default          | Description                              |
 | ----------------- | --------------------| ---------------- | ---------------------------------------- |
-| in_zones          | `list[str] \| None` | `None`           | The zones the device is in, including passive zones. Should be sorted by size of the zone, then by distance to center of zones. |
+| in_zones          | `list[str] \| None` | `None`           | The zones the device is in, including passive zones. This list should be sorted by size of the zones, then by distance to center of the zones. |
 | latitude          | `float \| None`     | `None`           | The latitude coordinate of the device, ignored if `in_zones` is not `None`.   |
 | location_accuracy | `float`             | `0`              | The location accuracy (m) of the device. |
 | longitude         | `float \| None`     | `None`           | The longitude coordinate of the device, ignored if `in_zones` is not `None`.  |

--- a/docs/core/entity/device-tracker.md
+++ b/docs/core/entity/device-tracker.md
@@ -7,7 +7,7 @@ A device tracker is a read-only entity that provides presence information. There
 
 ## BaseScannerEntity
 
-A BaseScannerEntity reports the connected state of a device, for example to a bluetooth beacon. If the device is connected the BaseScannerEntity' state will be the name of the associated zone, e.g `home` if associated with the home zone, and if the device is not connected the state will be `not_home`.
+A BaseScannerEntity reports the connected state of a device, for example to a bluetooth beacon. If the device is connected the BaseScannerEntity's state will be the name of the associated zone, e.g `home` if associated with the home zone, and if the device is not connected the state will be `not_home`.
 
 The in_zones state attribute will be populated with the entity_id of the associated zone and zones containing it when the device is connected and empty when not connected.
 
@@ -26,7 +26,7 @@ Properties should always only return information from memory and not do I/O (lik
 
 ## ScannerEntity
 
-A ScannerEntity reports the connected state of a device on the local network. If the device is connected the ScannerEntity' state will be the name of the associated zone, e.g `home` if associated with the home zone, and if the device is not connected the state will be `not_home`.
+A ScannerEntity reports the connected state of a device on the local network. If the device is connected the ScannerEntity's state will be the name of the associated zone, e.g `home` if associated with the home zone, and if the device is not connected the state will be `not_home`.
 
 The in_zones state attribute will be populated with the entity_id of the associated zone and zones containing it when the device is connected and empty when not connected.
 
@@ -68,7 +68,7 @@ Properties should always only return information from memory and not do I/O (lik
 
 | Name              | Type                | Default          | Description                              |
 | ----------------- | --------------------| ---------------- | ---------------------------------------- |
-| in_zones          | `list[str] \| None` | `None`           | The zones the devics is in, ignored if latitude and longitude are not `None` |
+| in_zones          | `list[str] \| None` | `None`           | The zones the device is in, ignored if latitude and longitude are not `None` |
 | latitude          | `float \| None`     | `None`           | The latitude coordinate of the device.   |
 | location_accuracy | `float`             | `0`              | The location accuracy (m) of the device. |
 | longitude         | `float \| None`     | `None`           | The longitude coordinate of the device.  |


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Align device tracker documentation with core changes:

- Add `in_zones` poprerty to `TrackerEntity`: https://github.com/home-assistant/core/pull/171765
- Deprecate device tracker `battery_level` property: https://github.com/home-assistant/core/pull/171819
- Deprecate `TrackerEntity` `location_name` property: https://github.com/home-assistant/core/pull/171820
- Add state attribute `in_zones` to `BaseScannerEntity`: https://github.com/home-assistant/core/pull/171832
- Add entity registry option for associating `BaseScannerEntity` with other zone than the home zone: https://github.com/home-assistant/core/pull/172157
- Add capability attribute `tracking_type`: https://github.com/home-assistant/core/pull/173027
- Sort zones by size, then distance to center https://github.com/home-assistant/core/pull/173106

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [ ] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Clarified device tracker state semantics: shows zone name when connected/in a zone and `"not_home"` when disconnected.
  * Explained how tracker entity state is determined (zone membership vs. latitude/longitude).
  * Updated the documented properties tables: removed battery-related attributes and added `in_zones` where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->