### PR TITLE
Document Supervisor API for Raspberry Pi firmware

### DIFF
--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -3014,6 +3014,55 @@ If running on a green board, changes one or more of its settings.
 
 </ApiEndpoint>
 
+<ApiEndpoint path="/os/boards/raspberrypi/firmware" method="get">
+
+Returns Raspberry Pi firmware information. Available on Raspberry Pi 4 / 5
+and Home Assistant Yellow when the OS Agent is at least version 1.9.0.
+The reported version covers the bundled firmware payload (bootloader EEPROM,
+and VL805 USB controller where present). Returns `404` if the OS Agent is
+older than 1.9.0 or the running board has no Raspberry Pi firmware interface.
+
+**Returned data:**
+
+| key              | type    | description                                                                                                |
+| ---------------- | ------- | ---------------------------------------------------------------------------------------------------------- |
+| current_version  | string  | The currently installed firmware version                                                                   |
+| latest_version   | string  | The latest firmware version bundled with the OS                                                            |
+| update_available | boolean | `true` if `latest_version` is newer than `current_version`                                                  |
+| update_blocked   | boolean | `true` if the current boot device or board configuration prevents the bundled updater from being applied   |
+| update_pending   | boolean | `true` if a firmware update has been applied but the system has not been rebooted yet                      |
+| blocked_reason   | string  | Blocked reason when `update_blocked` is `true`; `null` otherwise. See note below.                          |
+
+`blocked_reason` is currently always `unsupported_boot_device` whenever
+`update_blocked` is `true`. The underlying cause varies (for example, a
+USB/NVMe boot device, or a board without self-update enabled). More specific
+values may be introduced in the future.
+
+**Example response:**
+
+```json
+{
+  "current_version": "1765222194",
+  "latest_version": "1778498402",
+  "update_available": true,
+  "update_blocked": false,
+  "update_pending": false,
+  "blocked_reason": null
+}
+```
+
+</ApiEndpoint>
+
+<ApiEndpoint path="/os/boards/raspberrypi/firmware/update" method="post">
+
+Apply the bundled Raspberry Pi firmware update (bootloader EEPROM, and VL805
+where present). On success, Supervisor raises the `reboot_required` issue;
+a reboot is required to start running the new firmware. Returns `404` if the
+OS Agent is older than 1.9.0 or the running board has no Raspberry Pi firmware
+interface, and `400` if the update is blocked on this board / boot device.
+
+</ApiEndpoint>
+
 ### Resolution
 
 <ApiEndpoint path="/resolution/info" method="get">

--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -3020,18 +3020,19 @@ Returns Raspberry Pi firmware information. Available on Raspberry Pi 4 / 5
 and Home Assistant Yellow when the OS Agent is at least version 1.9.0.
 The reported version covers the bundled firmware payload (bootloader EEPROM,
 and VL805 USB controller where present). Returns `404` if the OS Agent is
-older than 1.9.0 or the running board has no Raspberry Pi firmware interface.
+older than 1.9.0, or `400` if the running board has no Raspberry Pi firmware
+interface.
 
 **Returned data:**
 
-| key              | type    | description                                                                                                |
-| ---------------- | ------- | ---------------------------------------------------------------------------------------------------------- |
-| current_version  | string  | The currently installed firmware version                                                                   |
-| latest_version   | string  | The latest firmware version bundled with the OS                                                            |
-| update_available | boolean | `true` if `latest_version` is newer than `current_version`                                                  |
-| update_blocked   | boolean | `true` if the current boot device or board configuration prevents the bundled updater from being applied   |
-| update_pending   | boolean | `true` if a firmware update has been applied but the system has not been rebooted yet                      |
-| blocked_reason   | string  | Blocked reason when `update_blocked` is `true`; `null` otherwise. See note below.                          |
+| key              | type           | description                                                                                              |
+| ---------------- | -------------- | -------------------------------------------------------------------------------------------------------- |
+| current_version  | string         | The currently installed firmware version                                                                 |
+| latest_version   | string         | The latest firmware version bundled with the OS                                                          |
+| update_available | boolean        | `true` if `latest_version` is newer than `current_version`                                               |
+| update_blocked   | boolean        | `true` if the current boot device or board configuration prevents the bundled updater from being applied |
+| update_pending   | boolean        | `true` if a firmware update has been applied but the system has not been rebooted yet                    |
+| blocked_reason   | string or null | Blocked reason when `update_blocked` is `true`; `null` otherwise. See note below.                        |
 
 `blocked_reason` is currently always `unsupported_boot_device` whenever
 `update_blocked` is `true`. The underlying cause varies (for example, a
@@ -3058,8 +3059,8 @@ values may be introduced in the future.
 Apply the bundled Raspberry Pi firmware update (bootloader EEPROM, and VL805
 where present). On success, Supervisor raises the `reboot_required` issue;
 a reboot is required to start running the new firmware. Returns `404` if the
-OS Agent is older than 1.9.0 or the running board has no Raspberry Pi firmware
-interface, and `400` if the update is blocked on this board / boot device.
+OS Agent is older than 1.9.0, or `400` if the running board has no Raspberry Pi
+firmware interface or the update is blocked on this board / boot device.
 
 </ApiEndpoint>
 


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Add docs for API added in home-assistant/supervisor#6886.


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: home-assistant/supervisor#6886


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added API docs for Raspberry Pi firmware management: a GET endpoint to report bundled firmware versions, update availability, block status (with reason), and pending-reboot state; and a POST endpoint to apply the bundled firmware update, including success behavior (reboot required) and documented 400/404 error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->