### PR TITLE
Document getEntitySuggestion for custom cards

### DIFF
--- a/blog/2026-05-27-custom-card-suggestions.md
+++ b/blog/2026-05-27-custom-card-suggestions.md
@@ -1,0 +1,28 @@
+---
+author: Paul Bottein
+authorURL: https://github.com/piitaya
+title: "Custom cards in the entity card picker"
+---
+
+As of Home Assistant 2026.6, custom cards can show up as suggestions in the card picker. When a user selects an entity, custom cards that opt in are listed under a **Community** section, below the built-in suggestions.
+
+To opt in, add a `getEntitySuggestion` function to your `window.customCards` entry. It receives the `hass` object and the selected entity id, and returns a suggestion (or `null` if the entity is not supported):
+
+```js
+window.customCards.push({
+  type: "my-card",
+  name: "My Card",
+  getEntitySuggestion: (hass, entityId) => {
+    if (entityId.split(".")[0] !== "light") {
+      return null;
+    }
+    return {
+      config: { type: "custom:my-card", entity: entityId },
+    };
+  },
+});
+```
+
+You can also return an array of suggestions to offer several variants, each with its own `label`.
+
+See the [custom card documentation](/docs/frontend/custom-ui/custom-card#suggesting-your-card-for-an-entity) for the full reference.

--- a/blog/2026-05-27-custom-card-suggestions.md
+++ b/blog/2026-05-27-custom-card-suggestions.md
@@ -1,7 +1,7 @@
 ---
 author: Paul Bottein
 authorURL: https://github.com/piitaya
-title: "Custom cards in the entity card picker"
+title: "Custom card suggestions in the card picker"
 ---
 
 As of Home Assistant 2026.6, custom cards can show up as suggestions in the card picker. When a user selects an entity, custom cards that opt in are listed under a **Community** section, below the built-in suggestions.
@@ -24,5 +24,7 @@ window.customCards.push({
 ```
 
 You can also return an array of suggestions to offer several variants, each with its own `label`.
+
+Only suggest your card when it makes sense for the entity. Check the domain, device class, or supported features with the `hass` object, and return `null` otherwise. Suggesting your card for every entity makes the picker noisy.
 
 See the [custom card documentation](/docs/frontend/custom-ui/custom-card#suggesting-your-card-for-an-entity) for the full reference.

--- a/docs/frontend/custom-ui/custom-card.md
+++ b/docs/frontend/custom-ui/custom-card.md
@@ -379,6 +379,8 @@ window.customCards.push({
 - `null` if the entity is not supported by your card.
 - A single suggestion, or an array of suggestions to offer several variants.
 
+Only return a suggestion when your card actually makes sense for that entity. Use the `hass` object to check its domain, device class, or supported features. Suggesting your card for every entity makes the picker noisy and leads users to the wrong card.
+
 Each suggestion is an object with:
 
 - `config` _(required)_: the card configuration to apply if the user picks the suggestion. It must include your `type` (with the `custom:` prefix).

--- a/docs/frontend/custom-ui/custom-card.md
+++ b/docs/frontend/custom-ui/custom-card.md
@@ -350,6 +350,62 @@ window.customCards.push({
 });
 ```
 
+### Suggesting your card for an entity
+
+_Available since Home Assistant 2026.6._
+
+When a user picks an entity in the card picker, Home Assistant shows a list of suggested cards for that entity. Your card can opt in to this list by defining a `getEntitySuggestion` function on its `window.customCards` entry. Suggested custom cards appear under a **Community** section, below the built-in suggestions.
+
+```js
+window.customCards.push({
+  type: "content-card-example",
+  name: "Content Card",
+  getEntitySuggestion: (hass, entityId) => {
+    // Return null if the entity is not supported
+    const domain = entityId.split(".")[0];
+    if (domain !== "light") {
+      return null;
+    }
+    // Return one suggestion
+    return {
+      config: { type: "custom:content-card-example", entity: entityId },
+    };
+  },
+});
+```
+
+`getEntitySuggestion(hass, entityId)` is called with the `hass` object and the selected entity id. It returns:
+
+- `null` if the entity is not supported by your card.
+- A single suggestion, or an array of suggestions to offer several variants.
+
+Each suggestion is an object with:
+
+- `config` _(required)_: the card configuration to apply if the user picks the suggestion. It must include your `type` (with the `custom:` prefix).
+- `label` _(optional)_: a short label describing the variant. The picker displays the card `name` followed by this label, so only set it when you return several suggestions.
+
+```js
+getEntitySuggestion: (hass, entityId) => {
+  if (entityId.split(".")[0] !== "light") {
+    return null;
+  }
+  return [
+    {
+      label: "Compact",
+      config: { type: "custom:content-card-example", entity: entityId },
+    },
+    {
+      label: "Detailed",
+      config: {
+        type: "custom:content-card-example",
+        entity: entityId,
+        details: true,
+      },
+    },
+  ];
+},
+```
+
 ### Using the built-in form editor
 While one way to configure a graphical editor is to supply a custom editor element, another option for cards with relatively simple configuration requirements is to use the built-in frontend form editor. This is done by defining a static `getConfigForm` function in your card class, that returns a form schema defining the shape of your configuration form. 
 


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Document `getEntitySuggestion`, which lets custom cards appear as suggestions in the entity card picker under a "Community" section. Adds a section to the custom card page and a short blog post.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [ ] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/frontend/pull/52228


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation and blog post guiding custom card developers on implementing entity-specific suggestions for the card picker. Developers can leverage the new `getEntitySuggestion` callback available in Home Assistant 2026.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->