### PR TITLE
Document async_address_reachability_diagnostics bluetooth API

### DIFF
--- a/docs/core/bluetooth/api.md
+++ b/docs/core/bluetooth/api.md
@@ -211,6 +211,23 @@ from homeassistant.components import bluetooth
 ble_device = bluetooth.async_ble_device_from_address(hass, "44:44:33:11:23:42", connectable=True)
 ```
 
+### Explaining why a device is unreachable
+
+When `async_ble_device_from_address` returns `None`, or a connection cannot be established, the `bluetooth.async_address_reachability_diagnostics` API returns a human readable string explaining why, suitable for embedding in an error or log message. Pass a `BluetoothReachabilityIntent` describing what you need from the device, since the relevant facts differ: a caller that only consumes advertisements does not care about connectable paths or connection slots, while a caller that wants to connect does.
+
+The string reports whether the address is in the connectable history, only seen via non-connectable advertisements, or has never been seen; which scanners currently see it, with their RSSI and slot allocations; and how many scanners are registered, scanning, and connectable. It also calls out the case where every scanner is paused because it is busy connecting, which means no advertisements can be received at all.
+
+The returned string is for humans only; its wording is not stable, so do not parse it.
+
+```python
+from homeassistant.components import bluetooth
+from homeassistant.components.bluetooth import BluetoothReachabilityIntent
+
+reason = bluetooth.async_address_reachability_diagnostics(
+    hass, "44:44:33:11:23:42", BluetoothReachabilityIntent.CONNECTION
+)
+```
+
 ### Fetching the latest `BluetoothServiceInfoBleak` for a device
 
 The latest advertisement and device data are available with the `bluetooth.async_last_service_info` API, which returns a `BluetoothServiceInfoBleak` from the scanner with the best RSSI of the requested connectable type.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Documents the new `bluetooth.async_address_reachability_diagnostics` API and the `BluetoothReachabilityIntent` enum, which explain why a Bluetooth device is unreachable (in connectable history vs advertisement only, which scanners see it, RSSI, slot allocations, and whether all scanners are paused connecting). Added in habluetooth 6.8.0 and exposed in home-assistant/core#172578.


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: home-assistant/core#172578 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new documentation section on diagnosing Bluetooth device unreachability, covering connectable history, advertisement types, scanner visibility and signal conditions, resource allocations, and scanner pause scenarios, with a Python usage example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->