### PR TITLE
Add detailed instructions for SSH debugging using boot-partition

### DIFF
--- a/docs/operating-system/debugging.md
+++ b/docs/operating-system/debugging.md
@@ -100,7 +100,7 @@ You will be logged in as `root` with the `/root` folder set as the working direc
 [Home Assistant OS] is a hypervisor for Docker.
 See the [Supervisor Architecture] documentation for information regarding the Supervisor.
 The Supervisor offers an API to manage the host and running the Docker containers.
-Home Assistant itself and all installed addons run in separate Docker containers.
+Home Assistant itself and all installed apps run in separate Docker containers.
 
 [Home Assistant OS]: https://github.com/home-assistant/operating-system
 [Supervisor Architecture]: /architecture_index.md

--- a/docs/operating-system/debugging.md
+++ b/docs/operating-system/debugging.md
@@ -13,21 +13,25 @@ This section is not for end users. End users should use the [SSH app (formerly k
 
 ## Enabling SSH access to the host
 
-:::info
-SSH access through the [SSH app] (on port 22 by default) only grants limited privileges, and you will be asked for a username and password when typing the 'login' command. Follow the steps below to enable a separate SSH access on port 22222 that works independently of the app and gives you direct access to the Home Assistant OS (the "host") with full privileges.
-:::
+SSH access through the [SSH app] (on port 22 by default) only grants limited privileges, and you will be asked for a username and password when typing the 'login' command.
+Follow the steps below to enable a separate SSH access on port 22222.
+It works independently of the app.
 
-The following guide uses the [`hassos-config`][hassos-config] script, which enables the SSH server (`dropbear`) on system startup.
+The following guide uses the [`/usr/sbin/hassos-config`][hassos-config] script, which enables the SSH server (`dropbear`) on system startup.
 Further information is provided at [Home Assistant Operating System configuration].
 
 :::warning
-Do not use methods 1 and 2 at the same time.
-Do not mix method 1 and 2 for setup and disable. 
+- This guide enables unconfined access to the Home Assistant OS (the "host") with full `root` privileges.
+- Unplugging power or SD card without a clean shutdown can damage your SD card!
+- Do not use methods 1 and 2 at the same time.
+- Do not mix method 1 and 2 for enabling and disabling SSH access.
 :::
 
-:::tip
-Make sure when you are copying the public key(s) to the root of the USB drive that you correctly name the file `authorized_keys` without a `.pub` file extension.
-:::
+Follow these rules:
+- Check the respective partition layout for [USB-Drive](#partition-layout-usb-drive) or [hassos-boot](#partition-layout-hassos-boot).
+- `authorized_keys` must use POSIX-standard newline control characters, i.e. `LF`, ASCII `\n` (not Windows (CR LF, `\r\n`), not macOS (CR, `\r`))
+- `authorized_keys` must only contain ASCII characters
+- `authorized_keys` must be ASCII-encoded (not `UTF-8`, not Windows `ISO_8859-1`).
 
 ### Method 1: USB Drive
 

--- a/docs/operating-system/debugging.md
+++ b/docs/operating-system/debugging.md
@@ -50,6 +50,24 @@ See [Example Workflow](#example-workflow) section below for a complete guide.
 
 Note that this method requires you to remove the file on the physical partition `hassos-boot`, if you want to disable the SSH server!
 
+#### Partition layout hassos-boot
+
+:::warning
+Changing, adding or removing anything other than `CONFIG` can result in physical damage to your device.
+Be aware, that _open & close_ can modify a file, e.g. when Auto-Save is on, which can mess with the encoding
+To be absolutely certain to not change anything else, follow the [Example Workflow](#example-workflow).
+:::
+
+```shell
+/ # Partition: hassos-boot
+├── ...
+├── cmdline.txt
+├── CONFIG
+│   └── authorized_keys
+├── config.txt
+└── ...
+```
+
 ### SSH access
 You should now be able to connect to your device as root over SSH on port 22222. On Mac/Linux, use:
 
@@ -68,7 +86,24 @@ You will be logged in as root with the `/root` folder set as the working directo
 
 1. Use a USB drive with a partition named `CONFIG` (case sensitive) formatted as FAT, ext4, or NTFS. Remove any existing `authorized_keys` file from the root of that partition. Using method 2, delete the file `/CONFIG/authorized_keys` on the partition `hassos-boot`, while keeping `CONFIG`.
 
-2. When the Home Assistant OS device is rebooted with a present `CONFIG` without `authorized_keys`, any existing SSH public keys will be removed and SSH access on port 22222 will be disabled.
+2. When the Home Assistant OS device reboots with a present `CONFIG` without `authorized_keys`, any existing SSH public keys will be removed and SSH access on port 22222 will be disabled.
+
+### Disabling SSH access partition layout USB-Drive
+Remove `authorized_keys` from the partition `CONFIG`.
+```shell
+/ # Partition: CONFIG
+└──
+```
+### Disabling SSH access Partition layout hassos-boot
+Only remove `authorized_keys` from the partition `hassos-boot`.
+Keep `CONFIG`.
+Do not touch any other files.
+```shell
+/ # Partition: hassos-boot
+├── CONFIG
+│   └──
+└── ...
+```
 
 ## Checking the logs
 

--- a/docs/operating-system/debugging.md
+++ b/docs/operating-system/debugging.md
@@ -138,15 +138,25 @@ docker logs homeassistant
 docker exec -it homeassistant /bin/bash
 ```
 
+[github-instructions]: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent
 [windows-keys]: https://docs.digitalocean.com/products/droplets/how-to/add-ssh-keys/create-with-putty/
 
 ## Generating SSH Keys
 
-Windows instructions on how to generate and use private/public keys with Putty are found [here][windows-keys]. Instead of the droplet instructions, add the public key as per above instructions.
+Create a separate key named `id_hassos` for Home Assistant.
+Creating SSH keys is as simple as running `ssh-keygen` or `PuTTYgen` on your local machine and following prompts.
+Generating an asymmetric key creates 2 files:
 
-Alternative instructions for Mac, Windows and Linux can be found [here](https://docs.github.com/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent). Follow the steps under *Generating a new SSH key* (the other sections are not applicable to Home Assistant and can be ignored).
+1. `id_XYZ`: This is your private decryption key, which you should _never_ export or upload.
+2. `id_XYZ.pub`: This is your public encryption key, which others use.
 
-Make sure to copy the ***public*** key of the SSH key pair you just created. By default, the public key file is named `id_ed25519.pub` (in case of the Ed25519 elliptic curve algorithm) or `id_rsa.pub` (in case of the older RSA algorithm), i.e. it should have a `.pub` filename suffix. It is saved to the same folder as the private key (which is named `id_ed25519` or `id_rsa` by default).
+This means `authorized_keys` are only _public_ keys `id_XYZ.pub`, _never_ private keys.
+Key filenames are inconsequential and only identify the correct key.
+
+Generate keys on your local machine and add them to your `authorized_keys` file.
+- [`ssh-keygen`][github-instructions] (Linux, WSL, Git for Windows)
+- [`PuTTYgen`][windows-keys]
+- [inbrowser.app](https://inbrowser.app/tools/ssh-key-generator/) (Discouraged, only use if you cannot generate keys on your local machine)
 
 ## Example Workflow
 

--- a/docs/operating-system/debugging.md
+++ b/docs/operating-system/debugging.md
@@ -8,6 +8,8 @@ This section is not for end users. End users should use the [SSH app (formerly k
 :::
 
 [SSH app]: https://github.com/home-assistant/addons/tree/master/ssh
+[Home Assistant Operating System configuration]: /docs/operating-system/configuration
+[hassos-config]: https://github.com/home-assistant/operating-system/blob/dev/buildroot-external/rootfs-overlay/usr/sbin/hassos-config
 
 ## Enabling SSH access to the host
 
@@ -15,16 +17,40 @@ This section is not for end users. End users should use the [SSH app (formerly k
 SSH access through the [SSH app] (on port 22 by default) only grants limited privileges, and you will be asked for a username and password when typing the 'login' command. Follow the steps below to enable a separate SSH access on port 22222 that works independently of the app and gives you direct access to the Home Assistant OS (the "host") with full privileges.
 :::
 
-1. Use a USB drive with a partition named `CONFIG` (case sensitive) formatted as FAT, ext4, or NTFS. Create an `authorized_keys` text file (without a file extension) containing your public key(s), one per line, and place it in the root of the USB drive's `CONFIG` partition. The file must use POSIX-standard newline control characters (LF), not Windows ones (CR LF), and needs to be ASCII character encoded (i.e. mustn't contain any special characters in the comments).
+The following guide uses the [`hassos-config`][hassos-config] script, which enables the SSH server (`dropbear`) on system startup.
+Further information is provided at [Home Assistant Operating System configuration].
 
-   See [Generating SSH Keys](#generating-ssh-keys) section below if you need help generating keys.
-
-1. Connect the USB drive to your Home Assistant OS device and either explicitly import the drive's contents using the `ha os import` command (e.g. via SSH to the [SSH app] on port 22) or reboot the device leaving the drive attached, which automatically triggers the import.
+:::warning
+Do not use methods 1 and 2 at the same time.
+Do not mix method 1 and 2 for setup and disable. 
+:::
 
 :::tip
 Make sure when you are copying the public key(s) to the root of the USB drive that you correctly name the file `authorized_keys` without a `.pub` file extension.
 :::
 
+### Method 1: USB Drive
+
+1. Use a USB drive with a partition named `CONFIG` (case sensitive) formatted as FAT, ext4, or NTFS. Create an `authorized_keys` text file (without a file extension) containing your public key(s), one per line, and place it in the root of the USB drive's `CONFIG` partition. The file must use POSIX-standard newline control characters (LF), not Windows ones (CR LF), and needs to be ASCII character encoded (i.e. mustn't contain any special characters in the comments).
+
+   See [Generating SSH Keys](#generating-ssh-keys) section below if you need help generating keys.
+
+2. Connect the USB drive to your Home Assistant OS device and either explicitly import the drive's contents using the `ha os import` command (e.g. via SSH to the [SSH app] on port 22) or reboot the device leaving the drive attached, which automatically triggers the import.
+
+### Method 2: hassos-boot
+This method requires writing to the boot partition, e.g. by mounting the SD card.
+
+See [Example Workflow](#example-workflow) section below for a complete guide.
+
+1. Place the `authorized_keys` file at `/CONFIG/authorized_keys` in the mounted partition `hassos-boot`.
+   - The partition is auto-mounted at different locations dependending on your system (e.g. `/run/media/USER/hassos-boot` or `/mnt/hassos-boot`). 
+   - The file will ultimately be mounted at `/boot/CONFIG/authorized_keys`
+2. Eject the SD card, to prevent write faults.
+3. Insert and reboot the Home Assistant device.
+
+Note that this method requires you to remove the file on the physical partition `hassos-boot`, if you want to disable the SSH server!
+
+### SSH access
 You should now be able to connect to your device as root over SSH on port 22222. On Mac/Linux, use:
 
 ```shell
@@ -40,9 +66,9 @@ You will be logged in as root with the `/root` folder set as the working directo
 
 ## Disabling SSH access to the host
 
-1. Use a USB drive with a partition named `CONFIG` (case sensitive) formatted as FAT, ext4, or NTFS. Remove any existing `authorized_keys` file from the root of that partition.
+1. Use a USB drive with a partition named `CONFIG` (case sensitive) formatted as FAT, ext4, or NTFS. Remove any existing `authorized_keys` file from the root of that partition. Using method 2, delete the file `/CONFIG/authorized_keys` on the partition `hassos-boot`, while keeping `CONFIG`.
 
-1. When the Home Assistant OS device is rebooted with this drive inserted, any existing SSH public keys will be removed and SSH access on port 22222 will be disabled.
+2. When the Home Assistant OS device is rebooted with a present `CONFIG` without `authorized_keys`, any existing SSH public keys will be removed and SSH access on port 22222 will be disabled.
 
 ## Checking the logs
 
@@ -65,10 +91,59 @@ docker exec -it homeassistant /bin/bash
 
 [windows-keys]: https://docs.digitalocean.com/products/droplets/how-to/add-ssh-keys/create-with-putty/
 
-### Generating SSH Keys
+## Generating SSH Keys
 
 Windows instructions on how to generate and use private/public keys with Putty are found [here][windows-keys]. Instead of the droplet instructions, add the public key as per above instructions.
 
 Alternative instructions for Mac, Windows and Linux can be found [here](https://docs.github.com/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent). Follow the steps under *Generating a new SSH key* (the other sections are not applicable to Home Assistant and can be ignored).
 
 Make sure to copy the ***public*** key of the SSH key pair you just created. By default, the public key file is named `id_ed25519.pub` (in case of the Ed25519 elliptic curve algorithm) or `id_rsa.pub` (in case of the older RSA algorithm), i.e. it should have a `.pub` filename suffix. It is saved to the same folder as the private key (which is named `id_ed25519` or `id_rsa` by default).
+
+## Example Workflow
+
+The following commands show a complete example workflow to get the desired setup (Linux, WSL, etc.):
+
+```console
+/run/media/USER/hassos-boot
+├── CONFIG
+│   └── authorized_keys
+└── ...
+
+/home/USER/.ssh/
+├── config
+├── id_hassos
+├── id_hassos.pub
+└── ...
+```
+
+1. Example SSH Key Creation
+
+```shell
+# Prepare hassos-boot
+MOUNT_PATH="/run/media/${USER}/hassos-boot"
+sudo mount --label hassos-boot --mkdir "${MOUNT_PATH}"
+mkdir -p "${MOUNT_PATH}/CONFIG"
+
+# Prepare SSH-Key
+SSH_FILE="/home/${USER}/.ssh/id_hassos"
+ssh-keygen -t ed25519 -f ${SSH_FILE} -C "Home Assistant root@homeassistant.local"
+cat ${SSH_FILE}.pub | tee -a authorized_keys
+sudo cp authorized_keys ${MOUNT_PATH}/CONFIG
+
+# Unmount
+sudo umount ${MOUNT_PATH} # if target is busy, close all accessing processes, and cd out of the path.
+```
+
+2. Example SSH Config setup
+Optional: set `/home/${USER}/.ssh/config` to use an alias like `ssh homeassistant`.
+
+```ssh-config
+Host homeassistant
+   HostName 192.168.x.x
+   Port 22222
+   User root
+   IdentityFile ~/.ssh/id_hassos
+```
+
+Use `ssh homeassistant -D 1080` to instruct `DynamicForward 1080`, which also starts a SOCKS-proxy on `127.0.0.1:1080` during the connection.
+This can tunnel traffic directly onto the host (given the proxy is used).

--- a/docs/operating-system/debugging.md
+++ b/docs/operating-system/debugging.md
@@ -35,11 +35,21 @@ Follow these rules:
 
 ### Method 1: USB Drive
 
-1. Use a USB drive with a partition named `CONFIG` (case sensitive) formatted as FAT, ext4, or NTFS. Create an `authorized_keys` text file (without a file extension) containing your public key(s), one per line, and place it in the root of the USB drive's `CONFIG` partition. The file must use POSIX-standard newline control characters (LF), not Windows ones (CR LF), and needs to be ASCII character encoded (i.e. mustn't contain any special characters in the comments).
+1. Use a USB drive with a partition named `CONFIG` (case sensitive) formatted as FAT, ext4, or NTFS.
+2. See [Generating SSH Keys](#generating-ssh-keys) section below if you need help generating keys.
+3. Create an `authorized_keys` text file (without a file extension) containing your public key(s), one per line, and place it in the root of the USB drive's `CONFIG` partition.
+4. Connect the USB drive to your Home Assistant OS device
+   - Option 1: while up and running, explicitly import the drive's contents using the `ha os import` command (e.g. via SSH to the [SSH app] on port 22)
+   - Option 2: reboot the device leaving the drive attached, which automatically triggers the import.
 
-   See [Generating SSH Keys](#generating-ssh-keys) section below if you need help generating keys.
+#### Partition layout USB-Drive 
 
-2. Connect the USB drive to your Home Assistant OS device and either explicitly import the drive's contents using the `ha os import` command (e.g. via SSH to the [SSH app] on port 22) or reboot the device leaving the drive attached, which automatically triggers the import.
+Only `/authorized_keys` should be present.
+
+```shell
+/ # Partition: CONFIG
+└── authorized_keys
+```
 
 ### Method 2: hassos-boot
 This method requires writing to the boot partition, e.g. by mounting the SD card.
@@ -47,7 +57,7 @@ This method requires writing to the boot partition, e.g. by mounting the SD card
 See [Example Workflow](#example-workflow) section below for a complete guide.
 
 1. Place the `authorized_keys` file at `/CONFIG/authorized_keys` in the mounted partition `hassos-boot`.
-   - The partition is auto-mounted at different locations dependending on your system (e.g. `/run/media/USER/hassos-boot` or `/mnt/hassos-boot`). 
+   - The partition is auto-mounted at different locations depending on your system (e.g. `/run/media/USER/hassos-boot` or `/mnt/hassos-boot`). 
    - The file will ultimately be mounted at `/boot/CONFIG/authorized_keys`
 2. Eject the SD card, to prevent write faults.
 3. Insert and reboot the Home Assistant device.

--- a/docs/operating-system/debugging.md
+++ b/docs/operating-system/debugging.md
@@ -4,7 +4,10 @@ sidebar_label: Debugging
 ---
 
 :::info
-This section is not for end users. End users should use the [SSH app (formerly known as an add-on)] to SSH into Home Assistant. This is for **developers** of Home Assistant. Do not ask for support if you are using these options.
+This section is not for end users.
+End users should use the [SSH app (formerly known as an add-on)] to SSH into Home Assistant.
+This is for **developers** of Home Assistant.
+Do not ask for support if you are using these options.
 :::
 
 [SSH app]: https://github.com/home-assistant/addons/tree/master/ssh
@@ -13,7 +16,8 @@ This section is not for end users. End users should use the [SSH app (formerly k
 
 ## Enabling SSH access to the host
 
-SSH access through the [SSH app] (on port 22 by default) only grants limited privileges, and you will be asked for a username and password when typing the 'login' command.
+SSH access through the [SSH app] (on port 22 by default) only grants limited privileges.
+Here, you are asked for a username and password when typing the 'login' command.
 Follow the steps below to enable a separate SSH access on port 22222.
 It works independently of the app.
 
@@ -89,16 +93,23 @@ You should now be able to connect to your device as root over SSH on port 22222.
 ssh root@homeassistant.local -p 22222
 ```
 
-If you have an older installation or have changed your hostname, you may need to adjust the command above accordingly. You can alternatively use the device's IP address instead of the hostname.
+If you have an older installation or have changed your hostname, you may need to adjust the command above accordingly.
+You can alternatively use the device's IP address instead of the hostname.
 
-You will be logged in as root with the `/root` folder set as the working directory. [Home Assistant OS] is a hypervisor for Docker. See the [Supervisor Architecture] documentation for information regarding the Supervisor. The Supervisor offers an API to manage the host and running the Docker containers. Home Assistant itself and all installed addons run in separate Docker containers.
+You will be logged in as `root` with the `/root` folder set as the working directory.
+[Home Assistant OS] is a hypervisor for Docker.
+See the [Supervisor Architecture] documentation for information regarding the Supervisor.
+The Supervisor offers an API to manage the host and running the Docker containers.
+Home Assistant itself and all installed addons run in separate Docker containers.
 
 [Home Assistant OS]: https://github.com/home-assistant/operating-system
 [Supervisor Architecture]: /architecture_index.md
 
 ## Disabling SSH access to the host
 
-1. Use a USB drive with a partition named `CONFIG` (case sensitive) formatted as FAT, ext4, or NTFS. Remove any existing `authorized_keys` file from the root of that partition. Using method 2, delete the file `/CONFIG/authorized_keys` on the partition `hassos-boot`, while keeping `CONFIG`.
+1. Use a USB drive with a partition named `CONFIG` (case sensitive) formatted as FAT, ext4, or NTFS.
+Remove any existing `authorized_keys` file from the root of that partition.
+Using method 2, delete the file `/CONFIG/authorized_keys` on the partition `hassos-boot`, while keeping `CONFIG`.
 
 2. When the Home Assistant OS device reboots with a present `CONFIG` without `authorized_keys`, any existing SSH public keys will be removed and SSH access on port 22222 will be disabled.
 


### PR DESCRIPTION
I wanted to find out how the SSH server on port 22222 was actually spawned.
But the process of mounting a USB-Stick never worked for me.
In consequence, I wanted to change it on the boot partition/systemd-Unit level.
I found that my preference is already implemented.
As this documentation was quite frankly rather unclear to me, I propose an overhaul to this documentation.
It should allow most developers to get up and running much faster than fiddling on a headless instance with a USB-Stick.

This PR reworks the existing SSH debugging guide for port 22222.
It adds detailed instructions for method 2 (/boot/CONFIG) to setup the SSH server. 
It also details an example workflow to setup the debugging SSH session effortlessly.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

1. Adds the currently undocumented alternative, but less error-prone SSH activation method. It does not require USB-Stick mounting during the boot process (which requires headless mounting of often buggy hardware).
3. Adds an end-to-end example workflow to setup the required files, using the boot-CONFIG method, including SSH-client configuration.
4. Overhauls the documentation for improved clarity and structure with visual examples.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- Link to relevant existing code or pull request: 
1. [Debugging](https://developers.home-assistant.io/docs/operating-system/debugging/)
2. [`/usr/sbin/hassos-config`](https://github.com/home-assistant/operating-system/blob/dev/buildroot-external/rootfs-overlay/usr/sbin/hassos-config)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded and restructured SSH access guide with clear, step-by-step enable/disable procedures and separate method-specific flows.
  * Added prominent info/warning callouts outlining risks and safe usage rules.
  * Added a dedicated key-generation section with recommended key naming, platform links, concrete example workflows, sample layout illustrations, and explicit instructions for disabling access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->