### PR TITLE
Document _home-assistant._tcp instance discovery service

### DIFF
--- a/docs/api/instance_discovery.md
+++ b/docs/api/instance_discovery.md
@@ -25,7 +25,7 @@ The service is registered once the [`frontend`](https://www.home-assistant.io/in
 | `internal_url` | Internal/LAN URL, resolved via `get_url(..., allow_external=False)`. | `""` if unavailable |
 | `external_url` | External URL, resolved via `get_url(..., allow_internal=False)`. | `""` if unavailable |
 | `base_url` | Deprecated; kept for backward compatibility. Set to `external_url`, or `internal_url` if there is no external URL. | `""` if neither is available |
-| `requires_api_password` | Legacy flag. Always advertised as `True`. | `True` |
+| `requires_api_password` | Legacy flag, always advertised as `True`. The `api_password` authentication mechanism it referred to was [deprecated in 0.90](https://github.com/home-assistant/core/pull/21884) and [removed in 2024.7.0](https://github.com/home-assistant/core/pull/119976), so the flag is now meaningless. Clients should no longer parse it. | `True` |
 | `landingpage` | Present and set to `True` only on the record published by the [landing page](https://github.com/home-assistant/landingpage) before Core is set up. Absent on a running Core instance. | Not set |
 
 :::note

--- a/docs/api/instance_discovery.md
+++ b/docs/api/instance_discovery.md
@@ -21,7 +21,7 @@ The service is registered once the [`frontend`](https://www.home-assistant.io/in
 | --- | --- | --- |
 | `location_name` | Friendly instance name, from `hass.config.location_name`. | `Home` if no name is configured |
 | `uuid` | The instance ID (`core.uuid`); a stable, opaque 32-character hex identifier. Also reused as the host name (`<uuid>.local.`). | Generated on first run |
-| `version` | Home Assistant Core version. The landing page shown during initial setup, before Core is running, advertises the same service with the sentinel version `0000.0.0`. | Current Core version |
+| `version` | [Home Assistant Core version](../versioning.md). Optional: Consumers should support missing version number if Core is not yet installed (e.g. landing page shown during initial setup). Currently the landing page advertises with the sentinel version `0000.0.0`. This is not a valid Home Assistant Core version it is merly used to work around limitations of the current Android app. | Current Core version |
 | `internal_url` | Internal/LAN URL, resolved via `get_url(..., allow_external=False)`. | `""` if unavailable |
 | `external_url` | External URL, resolved via `get_url(..., allow_internal=False)`. | `""` if unavailable |
 | `base_url` | Deprecated; kept for backward compatibility. Set to `external_url`, or `internal_url` if there is no external URL. | `""` if neither is available |

--- a/docs/api/instance_discovery.md
+++ b/docs/api/instance_discovery.md
@@ -21,7 +21,7 @@ The service is registered once the [`frontend`](https://www.home-assistant.io/in
 | --- | --- | --- |
 | `location_name` | Friendly instance name, from `hass.config.location_name`. | `Home` if no name is configured |
 | `uuid` | The instance ID (`core.uuid`); a stable, opaque 32-character hex identifier. Also reused as the host name (`<uuid>.local.`). | Generated on first run |
-| `version` | [Home Assistant Core version](../versioning.md). Optional: Consumers should support missing version number if Core is not yet installed (e.g. landing page shown during initial setup). Currently the landing page advertises with the sentinel version `0000.0.0`. This is not a valid Home Assistant Core version it is merly used to work around limitations of the current Android app. | Current Core version |
+| `version` | [Home Assistant Core version](../versioning.md). Optional: Clients should treat optional as version currently not known. It typically means Core is not yet installed (e.g. landing page shown during initial setup). Currently the landing page advertises with the sentinel version `0000.0.0`. This is not a valid Home Assistant Core version it is merly used to work around limitations of the current Android app. | Current Core version |
 | `internal_url` | Internal/LAN URL, resolved via `get_url(..., allow_external=False)`. | `""` if unavailable |
 | `external_url` | External URL, resolved via `get_url(..., allow_internal=False)`. | `""` if unavailable |
 | `base_url` | Deprecated; kept for backward compatibility. Set to `external_url`, or `internal_url` if there is no external URL. | `""` if neither is available |

--- a/docs/api/instance_discovery.md
+++ b/docs/api/instance_discovery.md
@@ -28,4 +28,8 @@ The service is registered once the [`frontend`](https://www.home-assistant.io/in
 | `requires_api_password` | Legacy flag. Always advertised as `True`. | `True` |
 | `landingpage` | Present and set to `True` only on the record published by the [landing page](https://github.com/home-assistant/landingpage) before Core is set up. Absent on a running Core instance. | Not set |
 
+:::note
+
 A TXT property value may be at most 230 bytes (`key=value` is capped at 255). Any value exceeding this is suppressed (replaced with an empty string) so it does not break advertisement.
+
+:::

--- a/docs/api/instance_discovery.md
+++ b/docs/api/instance_discovery.md
@@ -1,0 +1,31 @@
+---
+title: "Instance discovery"
+---
+
+Home Assistant advertises itself on the local network as the `_home-assistant._tcp.local.` mDNS/Zeroconf service. Clients (for example the companion apps) can browse for this service to discover instances without asking the user for an address.
+
+The service is registered once the [`frontend`](https://www.home-assistant.io/integrations/frontend/) integration has been set up (or on start), so that the HTTP server is up and reachable when the record is published.
+
+## Service record
+
+| Field | Value |
+| --- | --- |
+| Service type | `_home-assistant._tcp.local.` |
+| Instance name | `<location_name>.<service type>`. The `location_name` has `.` replaced with a space and is truncated to fit the 63-byte DNS label limit. On a name collision, Zeroconf appends a suffix (`allow_name_change`). |
+| Host (server) | `<uuid>.local.`, where `<uuid>` is the instance ID. |
+| Port | The HTTP server port (`8123` by default). |
+
+## TXT properties
+
+| Property | Meaning | Default |
+| --- | --- | --- |
+| `location_name` | Friendly instance name, from `hass.config.location_name`. | `Home` if no name is configured |
+| `uuid` | The instance ID (`core.uuid`); a stable, opaque 32-character hex identifier. Also reused as the host name (`<uuid>.local.`). | Generated on first run |
+| `version` | Home Assistant Core version. The landing page shown during initial setup, before Core is running, advertises the same service with the sentinel version `0000.0.0`. | Current Core version |
+| `internal_url` | Internal/LAN URL, resolved via `get_url(..., allow_external=False)`. | `""` if unavailable |
+| `external_url` | External URL, resolved via `get_url(..., allow_internal=False)`. | `""` if unavailable |
+| `base_url` | Deprecated; kept for backward compatibility. Set to `external_url`, or `internal_url` if there is no external URL. | `""` if neither is available |
+| `requires_api_password` | Legacy flag. Always advertised as `True`. | `True` |
+| `landingpage` | Present and set to `True` only on the record published by the [landing page](https://github.com/home-assistant/landingpage) before Core is set up. Absent on a running Core instance. | Not set |
+
+A TXT property value may be at most 230 bytes (`key=value` is capped at 255). Any value exceeding this is suppressed (replaced with an empty string) so it does not break advertisement.

--- a/docs/api/instance_discovery.md
+++ b/docs/api/instance_discovery.md
@@ -21,7 +21,7 @@ The service is registered once the [`frontend`](https://www.home-assistant.io/in
 | --- | --- | --- |
 | `location_name` | Friendly instance name, from `hass.config.location_name`. | `Home` if no name is configured |
 | `uuid` | The instance ID (`core.uuid`); a stable, opaque 32-character hex identifier. Also reused as the host name (`<uuid>.local.`). | Generated on first run |
-| `version` | [Home Assistant Core version](../versioning.md). Optional: Clients should treat optional as version currently not known. It typically means Core is not yet installed (e.g. landing page shown during initial setup). Currently the landing page advertises with the sentinel version `0000.0.0`. This is not a valid Home Assistant Core version it is merly used to work around limitations of the current Android app. | Current Core version |
+| `version` | [Home Assistant Core version](../versioning.md). Optional: Clients should treat optional as version currently not known. It typically means Core is not yet installed (e.g. landing page shown during initial setup). Currently the landing page advertises with the sentinel version `0000.0.0`. This is not a valid Home Assistant Core version, but is merely used to work around limitations of the current Android app. | Current Core version |
 | `internal_url` | Internal/LAN URL, resolved via `get_url(..., allow_external=False)`. | `""` if unavailable |
 | `external_url` | External URL, resolved via `get_url(..., allow_internal=False)`. | `""` if unavailable |
 | `base_url` | Deprecated; kept for backward compatibility. Set to `external_url`, or `internal_url` if there is no external URL. | `""` if neither is available |

--- a/sidebars.js
+++ b/sidebars.js
@@ -298,7 +298,7 @@ module.exports = {
     {
       type: "category",
       label: "External APIs",
-      items: ["api/websocket", "api/rest"],
+      items: ["api/websocket", "api/rest", "api/instance_discovery"],
     },
     {
       type: "category",


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Add a page describing the mDNS/Zeroconf service Home Assistant advertises about itself, including the service record and TXT properties, so client/app developers know the discovery payload.

This came up during working on improving the announcement on the landing page and with the App team. The current PR keeps things rather minimal. There are many nitty gritty details (e.g. what addresses are announced, how `internal_url` is built by default etc.) which we could document, but it also probably gets stale quickly. 

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [ ] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide on instance discovery via mDNS/Zeroconf describing when the service is registered, advertised service fields, TXT properties (location name, UUID, version sentinel, internal/external URLs and legacy fields) and TXT size limits/behavior when values exceed the limit.
  * Updated site navigation to add the instance discovery guide under Core → External APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->