### PR TITLE
Revise FCM push notification setup steps

### DIFF
--- a/docs/android/tips/fcm_push_notification.md
+++ b/docs/android/tips/fcm_push_notification.md
@@ -14,17 +14,20 @@ If you want your own FCM setup for push notifications, follow these steps:
 1. **Create a Firebase project**  
    Go to the [Firebase Console](https://console.firebase.google.com) and create a new Firebase project.
 
-2. **Add Android apps to the Firebase project**  
+2. **Create a default Firestore database**
+   In the Firebase Console, enable the Cloud Firestore API and create a default Firestore database.
+
+3. **Add Android apps to the Firebase project**  
    Add the following package names as Android apps in your Firebase project:
    - `io.homeassistant.companion.android`
    - `io.homeassistant.companion.android.debug`
    - `io.homeassistant.companion.android.minimal`
    - `io.homeassistant.companion.android.minimal.debug`
 
-3. **Deploy the push notification service**  
+4. **Deploy the push notification service**  
    Visit the [mobile-apps-fcm-push repository](https://github.com/home-assistant/mobile-apps-fcm-push) and deploy the service to your Firebase project.
 
-4. **Set the push notification URL**  
+5. **Set the push notification URL**  
    Once you have the `androidV1` URL for the deployed service, add it to your `${GRADLE_USER_HOME}/gradle.properties` file. For example:
 
    ```properties
@@ -37,7 +40,7 @@ If you want your own FCM setup for push notifications, follow these steps:
    homeAssistantAndroidRateLimitUrl=https://mydomain.cloudfunctions.net/checkRateLimits
    ```
 
-5. **Download and place the `google-services.json` File**  
+6. **Download and place the `google-services.json` File**  
    Download the `google-services.json` file from your Firebase project and place it in the following folders:
    - `/app`
    - `/automotive`


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The instructions for setting up FCM for Android development currently result in errors for a missing Firestore database. This commit adds an instruction to create a Firestore database when setting up FCM push notifications.


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Android FCM push notification setup guide with clarified instructions and improved step organization.
  * Added explicit step for creating a default Firestore database in the setup process.
  * Re-organized subsequent steps to follow the new Firestore configuration step in correct order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->