### PR TITLE
Fix broken anchor links in the documentation

### DIFF
--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -19,7 +19,7 @@ Return overview information about installed apps.
 
 | key          | type | description                                        |
 | ------------ | ---- | -------------------------------------------------- |
-| addons       | list | A list of [Addon models](api/supervisor/models.md#addon)           |
+| addons       | list | A list of [Addon models](api/supervisor/models.md#app-formerly-known-as-an-add-on)           |
 
 **Example response:**
 
@@ -3074,7 +3074,7 @@ firmware interface or the update is blocked on this board / boot device.
 | -------- | ---------- | ------------------------------------------------ |
 | unsupported | list | A list of reasons why an installation is marked as unsupported (container, dbus, docker_configuration, docker_version, lxc, network_manager, os, privileged, systemd) |
 | unhealthy | list | A list of reasons why an installation is marked as unhealthy (docker, supervisor, privileged, setup) |
-| issues | list | A list of [Issue models](api/supervisor/models.md#issues) |
+| issues | list | A list of [Issue models](api/supervisor/models.md#issue) |
 | suggestions | list | A list of [Suggestion models](api/supervisor/models.md#suggestion) actions |
 | checks | list | A list of [Check models](api/supervisor/models.md#check) |
 

--- a/docs/apps/communication.md
+++ b/docs/apps/communication.md
@@ -63,5 +63,5 @@ MQTT_PASSWORD=$(bashio::services mqtt "password")
 [core-api]: /api/rest.md
 [core-websocket]: /api/websocket.md
 [supervisor-api]: /api/supervisor/endpoints.md
-[supervisor-addon-api]: /api/supervisor/endpoints.md#addons
+[supervisor-addon-api]: /api/supervisor/endpoints.md#apps
 [supervisor-services-api]: /api/supervisor/endpoints.md#service

--- a/docs/apps/presentation.md
+++ b/docs/apps/presentation.md
@@ -138,12 +138,12 @@ Ingress allows users to access the app web interface via the Home Assistant UI. 
 
 Here are the requirements of Ingress:
 - Ingress must be enabled. Set `ingress: true` in [`config.yaml`](/docs/apps/configuration#optional-configuration-options).
-- Your server may run on port 8099. If it does not run on 8099, you must set `ingress_port: PORT_NUMBER` in [`config.yaml`](/docs/apps/configuration#app-config) to match your configuration.
+- Your server may run on port 8099. If it does not run on 8099, you must set `ingress_port: PORT_NUMBER` in [`config.yaml`](/docs/apps/configuration#app-configuration) to match your configuration.
 - Only connections from `172.30.32.2` must be allowed. You should deny access to all other IP addresses within your app server. 
 - Users are previously authenticated via Home Assistant. Authentication is not required. 
 
 :::tip
-Configuration of path and port information may be queried via [apps info API endpoint](/docs/api/supervisor/endpoints/#addons). If the Home Assistant URL is required by your addon, Ingress adds a request header `X-Ingress-Path` which may be filtered to obtain the base URL. 
+Configuration of path and port information may be queried via [apps info API endpoint](/docs/api/supervisor/endpoints/#apps). If the Home Assistant URL is required by your addon, Ingress adds a request header `X-Ingress-Path` which may be filtered to obtain the base URL. 
 :::
 
 Ingress API gateway supports the following:

--- a/docs/core/entity/media-player.md
+++ b/docs/core/entity/media-player.md
@@ -94,7 +94,7 @@ The state of a media player is defined by using values in the `MediaPlayerState`
 
 :::note
 
-It is common that media players can't be controlled when in a standby state. If Home Assistant can turn on the device using another protocol or method, it should be shown as `off` even if the main channel used to control the device is currently unavailable. If Home Assistant has no way to turn on the device, it should be shown as `unavailable`. See [entity-unavailable Exceptions](/docs/core/integration-quality-scale/rules/entity-unavailable.md#Exceptions) for more details.
+It is common that media players can't be controlled when in a standby state. If Home Assistant can turn on the device using another protocol or method, it should be shown as `off` even if the main channel used to control the device is currently unavailable. If Home Assistant has no way to turn on the device, it should be shown as `unavailable`. See [entity-unavailable Exceptions](/docs/core/integration-quality-scale/rules/entity-unavailable.md#exceptions) for more details.
 
 :::
 

--- a/docs/dev_101_services.md
+++ b/docs/dev_101_services.md
@@ -143,7 +143,7 @@ set_speed:
 ```
 
 :::info
-The name and description of the service actions are set in our [translations](/docs/internationalization/core#services) and not in the service action description. Each service action and service action field must have a matching translation defined. Description placeholders allow you to exclude elements like URLs from translations.
+The name and description of the service actions are set in our [translations](/docs/internationalization/core#service-actions) and not in the service action description. Each service action and service action field must have a matching translation defined. Description placeholders allow you to exclude elements like URLs from translations.
 
 ```python
 ...

--- a/docs/intent_conversation_api.md
+++ b/docs/intent_conversation_api.md
@@ -85,7 +85,7 @@ The following properties are available in the `"response"` object:
 | Name            | Type       | Description                                                                               |
 | --------------- | ---------- | ----------------------------------------------------------------------------------------- |
 | `response_type` | string     | One of `action_done`, `query_answer`, or `error` (see [response types](#response-types)). |
-| `data`          | dictionary | Relevant data for each [response type](#response_types).                                  |
+| `data`          | dictionary | Relevant data for each [response type](#response-types).                                  |
 | `language`      | string     | The language of the intent and response.                                                  |
 | `speech`        | dictionary | Optional. Response text to speak to the user (see [speech](#speech)).                     |
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Several in-page anchor links were broken because the headings they point to were renamed or re-slugged over time. This was confirmed by running a local `docusaurus build`, which reports broken anchors, and verifying each corrected anchor exists in the generated HTML. A rebuild after these changes confirms all eight no longer warn.

Fixes:

- `core/entity/media-player.md`: `entity-unavailable#Exceptions` -> `#exceptions` (anchors are lowercase).
- `intent_conversation_api.md`: `#response_types` -> `#response-types`.
- `apps/presentation.md`: `apps/configuration#app-config` -> `#app-configuration`.
- `apps/presentation.md` and `apps/communication.md`: `api/supervisor/endpoints#addons` -> `#apps` (the section was renamed to "Apps").
- `dev_101_services.md`: `internationalization/core#services` -> `#service-actions`.
- `api/supervisor/endpoints.md`: `api/supervisor/models#addon` -> `#app-formerly-known-as-an-add-on`, and `#issues` -> `#issue`.

Not included (they are different fixes, not a renamed-heading link update):

- `api/rest#get-apiconfig` and `api/rest#post-apiservices...`: the `<ApiEndpoint>` component does not generate heading IDs, so there is no valid anchor to link to. This needs a component-level change.
- `core/bluetooth/bluetooth_fetching_data#activebluetoothcoordinator`: the anchor actually exists via an explicit `<a id>` tag; the build's broken-anchor checker does not detect raw HTML anchors, so this is a false positive.
- Broken anchors originating from older blog posts.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [x] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed internal documentation cross-reference links across multiple documentation files to ensure correct navigation to referenced sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->