### PR TITLE
Update outdated content in the permissions documentation

### DIFF
--- a/docs/auth_permissions.md
+++ b/docs/auth_permissions.md
@@ -2,10 +2,6 @@
 title: "Permissions"
 ---
 
-:::info
-This is an experimental feature that is not enabled or enforced yet
-:::
-
 Permissions limit the things a user has access to or can control. Permissions are attached to groups, of which a user can be a member. The combined permissions of all groups a user is a member of decides what a user can and cannot see or control.
 
 Permissions do not apply to the user that is flagged as "owner". This user will always have access to everything.
@@ -113,7 +109,7 @@ To check a permission, you will need to have access to the user object. Once you
 
 ```python
 from homeassistant.exceptions import Unauthorized
-from homeassistant.permissions.const import POLICY_READ, POLICY_CONTROL, POLICY_EDIT
+from homeassistant.auth.permissions.const import POLICY_READ, POLICY_CONTROL, POLICY_EDIT
 
 # Raise error if user is not an admin
 if not user.is_admin:
@@ -145,9 +141,6 @@ await hass.services.async_call(
 When you detect an unauthorized action, you should raise the `homeassistant.exceptions.Unauthorized` exception. This exception will cancel the current action and notifies the user that their action is unauthorized.
 
 The `Unauthorized` exception has various parameters, to identify the permission check that failed. All fields are optional.
-
-| # Not all actions have an ID (like adding config entry)
-| # We then use this fallback to know what category was unauth
 
 | Parameter | Description
 | --------- | -----------
@@ -205,19 +198,21 @@ async def async_setup(hass, config):
 
 #### Checking admin permission
 
-Starting Home Assistant 0.90, there is a special decorator to help protect
-service actions that require admin access.
+There is a special helper to protect service actions that require admin
+access.
 
 ```python
-# New in Home Assistant 0.90
+from homeassistant.helpers.service import async_register_admin_service
+
+
 async def handle_admin_service(call):
     """Handle a service action call."""
     # Do admin action
 
 
 async def async_setup(hass, config):
-    hass.helpers.service.async_register_admin_service(
-        DOMAIN, "my_service", handle_admin_service, vol.Schema({})
+    async_register_admin_service(
+        hass, DOMAIN, "my_service", handle_admin_service, vol.Schema({})
     )
     return True
 ```


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

The permissions documentation contained several outdated and incorrect bits. This updates them, validated against the current Home Assistant Core codebase (2026.7):

- Removed the "experimental feature that is not enabled or enforced yet" banner. The permission system is both enabled and enforced today: the read-only group ships with `READ_ONLY_POLICY` (`{entities: {all: {read: True}}}`), and `user.permissions.check_entity(...)` is called in the enforcement paths (`homeassistant/helpers/service.py` and `homeassistant/components/websocket_api/commands.py`).
- Fixed the import path `homeassistant.permissions.const` -> `homeassistant.auth.permissions.const` (the former does not exist; the constants live under `homeassistant/auth/permissions/const.py`).
- Removed an orphaned, broken table fragment (two stray comment lines that rendered as an empty table). The information is already covered by the `perm_category` row of the parameters table just below it.
- Modernized the admin service registration example: the `hass.helpers` accessor has been removed from Core, so it now imports `async_register_admin_service` directly and calls it with `hass` as the first argument (matching real usage such as `homeassistant/helpers/reload.py`). Also dropped the obsolete "Home Assistant 0.90" version notes and corrected "decorator" to "helper".

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [x] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request:
