### PR TITLE
Add type hints to component setup examples

### DIFF
--- a/docs/creating_component_index.md
+++ b/docs/creating_component_index.md
@@ -23,10 +23,13 @@ Create a file `homeassistant/components/hello_state/__init__.py` with one of the
 - Sync component:
 
 ```python
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
 DOMAIN = "hello_state"
 
 
-def setup(hass, config):
+def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     hass.states.set("hello_state.world", "Paulus")
 
     # Return boolean to indicate that initialization was successful.
@@ -36,10 +39,13 @@ def setup(hass, config):
 - And if you prefer an async component:
 
 ```python
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
 DOMAIN = "hello_state"
 
 
-async def async_setup(hass, config):
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     hass.states.async_set("hello_state.world", "Paulus")
 
     # Return boolean to indicate that initialization was successful.

--- a/docs/dev_101_events.md
+++ b/docs/dev_101_events.md
@@ -15,10 +15,13 @@ To fire an event, you have to interact with the event bus. The event bus is avai
 Example component that will fire an event when loaded. Note that custom event names are prefixed with the component name.
 
 ```python
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
 DOMAIN = "example_component"
 
 
-def setup(hass, config):
+def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up is called when Home Assistant is loading our component."""
 
     # Fire event example_component_my_cool_event with event data answer=42
@@ -33,15 +36,18 @@ def setup(hass, config):
 Most of the times you'll not be firing events but instead listen to events. For example, the state change of an entity is broadcasted as an event.
 
 ```python
+from homeassistant.core import Event, HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
 DOMAIN = "example_component"
 
 
-def setup(hass, config):
+def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up is called when Home Assistant is loading our component."""
     count = 0
 
     # Listener to handle fired events
-    def handle_event(event):
+    def handle_event(event: Event) -> None:
         nonlocal count
         count += 1
         print(f"Answer {count} is: {event.data.get('answer')}")

--- a/docs/dev_101_states.md
+++ b/docs/dev_101_states.md
@@ -25,12 +25,15 @@ https://developers.home-assistant.io/docs/dev_101_states
 """
 import logging
 
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "hello_state"
 
 
-def setup(hass, config):
+def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Setup the Hello State component. """
     _LOGGER.info("The 'hello state' component is ready!")
 
@@ -68,6 +71,9 @@ The next step is the introduction of configuration options. A user can pass conf
 ```python
 import logging
 
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "hello_state"
@@ -76,7 +82,7 @@ CONF_TEXT = "text"
 DEFAULT_TEXT = "No text!"
 
 
-def setup(hass, config):
+def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Hello State component. """
     # Get the text from the configuration. Use DEFAULT_TEXT if no name is provided.
     text = config[DOMAIN].get(CONF_TEXT, DEFAULT_TEXT)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Home Assistant Core is thoroughly type hinted, but several documentation examples still show untyped function signatures. This adds type hints to the component `setup` / `async_setup` examples in the foundational integration docs, so the examples model the style we expect in Core.

- `creating_component_index.md`: the sync and async setup examples.
- `dev_101_events.md`: both setup examples (the event listener nested in the second example is typed too).
- `dev_101_states.md`: both setup examples.

Each signature becomes `def setup(hass: HomeAssistant, config: ConfigType) -> bool:` (and the `async` variant), with the matching imports added. The signatures were verified against real Core integrations (`sun`, `hassio`, `ads`, `aqualogic`), `ConfigType` from `homeassistant/helpers/typing.py`, and the `Event` listener type from `homeassistant/core.py`.

This is a focused first pass. Follow-up PRs can type the remaining examples (the `async_setup_entry` platform signatures, and other handlers/callbacks).

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request:
