### PR TITLE
Note ADR-0007 YAML config structure in YAML configuration docs

### DIFF
--- a/docs/core/integration/yaml_configuration.md
+++ b/docs/core/integration/yaml_configuration.md
@@ -22,6 +22,12 @@ If a component defines a variable `CONFIG_SCHEMA`, the config object that is pas
 
 ### PLATFORM_SCHEMA
 
+:::info
+
+The platform-key configuration structure described below (configuration listed under an entity component domain, such as `switch`) is the existing mechanism for entity components. New integrations must not use it. Per [ADR-0007](https://github.com/home-assistant/architecture/blob/master/adr/0007-integration-config-yaml-structure.md), all YAML configuration for an integration, if present, must be placed under the integration's own domain key, with platforms loaded via `discovery.async_load_platform`. YAML configuration in platform sections of existing integrations is frozen until the integration is refactored.
+
+:::
+
 If a component defines a variable `PLATFORM_SCHEMA`, the component will be treated as an entity component. The configuration of entity components is a list of platform configurations.
 
 Home Assistant will gather all platform configurations for this component. It will do so by looking for configuration entries under the domain of the component (ie `light`) but also under any entry of domain + extra text.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

The "YAML configuration" page illustrates the `PLATFORM_SCHEMA` mechanism using the platform-key configuration structure (configuration listed under an entity component domain, such as `switch:` with `- platform: ...`). That structure is exactly what [ADR-0007](https://github.com/home-assistant/architecture/blob/master/adr/0007-integration-config-yaml-structure.md) froze for new integrations, but the page only referenced ADR-0010 (config flow) and gave no hint that this structure is legacy.

This adds a short note under the `PLATFORM_SCHEMA` heading clarifying that new integrations must place YAML configuration under the integration's own domain key (loading platforms via `discovery.async_load_platform`), and that platform-section configuration in existing integrations is frozen until refactored. The existing example is left intact, since it still correctly demonstrates how platform-config gathering works.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Clarified YAML configuration guidelines for integration development and platform loading requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->