### PR TITLE
Use ConfigEntry.runtime_data in data fetching examples

### DIFF
--- a/docs/core/entity.md
+++ b/docs/core/entity.md
@@ -331,7 +331,7 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Example sensor based on a config entry."""
-    device: ExampleDevice = hass.data[DOMAIN][entry.entry_id]
+    device: ExampleDevice = entry.runtime_data
     async_add_entities(
         ExampleSensorEntity(device, description)
         for description in SENSORS

--- a/docs/integration_fetching_data.md
+++ b/docs/integration_fetching_data.md
@@ -46,15 +46,13 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 
-from .const import DOMAIN
-
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Config entry example."""
-    # assuming API object stored here by __init__.py
-    my_api = hass.data[DOMAIN][config_entry.entry_id]
+    # assuming API object stored as runtime_data by __init__.py
+    my_api = config_entry.runtime_data
     coordinator = MyCoordinator(hass, config_entry, my_api)
 
     # Fetch initial data so we have data when entities subscribe


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

The [`runtime-data` quality scale rule](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/runtime-data) states that config entry integrations must store runtime data in `ConfigEntry.runtime_data`, not in `hass.data`. Two example snippets still used the older `hass.data[DOMAIN][entry.entry_id]` pattern in a config-entry context:

- `integration_fetching_data.md`: the `DataUpdateCoordinator` example now reads `my_api = config_entry.runtime_data` (and the now-unused `from .const import DOMAIN` import is removed).
- `core/entity.md`: the entity-description `async_setup_entry` example now reads `device: ExampleDevice = entry.runtime_data`.

This matches the rule's own example (`entry.runtime_data = client`).

Note: `creating_component_code_review.md` also mentions `hass.data[DOMAIN]`, but that page covers legacy YAML components that have no config entry (so `runtime_data` does not apply there); it is intentionally left unchanged.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [x] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated integration setup examples to clarify the recommended approach for accessing configuration data during asynchronous initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->