### PR TITLE
Remove stale advanced mode reference from registering resources docs

### DIFF
--- a/docs/frontend/custom-ui/registering-resources.md
+++ b/docs/frontend/custom-ui/registering-resources.md
@@ -12,14 +12,6 @@ The next step is to register these resources with the Home Assistant interface. 
 
 [![Open your Home Assistant instance and show your resources.](https://my.home-assistant.io/badges/lovelace_resources.svg)](https://my.home-assistant.io/redirect/lovelace_dashboards/) (Note: Once redirected, click the three dots menu in the top-right.)
 
-:::note
-
-This area is only available when the active user's profile has "advanced mode" enabled.
-
-:::
-
-![Screenshot of the Advanced Mode selector found on the Profile page](/img/en/frontend/frontend-profile-advanced-mode.png)
-
 Alternatively, you can also register the resource by adding it to the `resources` section of `lovelace` in the configuration:
 
 ```yaml


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

The registering resources documentation stated that the Resources area is only available with the user profile's "advanced mode" enabled, and showed a screenshot of the Advanced Mode selector. Advanced mode has since been removed from the frontend, so both are stale (and also used skill-implying framing), as reported in #3172.

This removes the outdated "advanced mode" note and the Advanced Mode screenshot. The surrounding text already describes how to reach the Resources page (via the three-dots menu), so it now reflects the current behaviour.

Note: this leaves `/img/en/frontend/frontend-profile-advanced-mode.png` orphaned; happy to drop the asset too if preferred.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [x] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.

  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #3172
- Link to relevant existing code or pull request:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Simplified custom UI resource registration documentation by removing the Advanced Mode prerequisite note and screenshot, providing a more streamlined path to registration instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->