### PR TITLE
Reword "advanced" terminology in services developer docs

### DIFF
--- a/docs/dev_101_services.md
+++ b/docs/dev_101_services.md
@@ -110,9 +110,6 @@ set_speed:
     speed:
       # Whether or not field is required (default = false)
       required: true
-      # Advanced fields are only shown when the advanced mode is enabled for the user
-      # (default = false)
-      advanced: true
       # Example value that can be passed for this field
       example: "low"
       # The default field value
@@ -128,9 +125,9 @@ set_speed:
             - "medium"
             - "high"
     # Fields can be grouped in collapsible sections, this is useful to initially hide
-    # advanced fields and to group related fields. Note that the collapsible section
+    # less commonly used fields and to group related fields. Note that the collapsible section
     # only affect presentation to the user, service action data will not be nested.
-    advanced_fields:
+    additional_fields:
       # Whether or not the section is initially collapsed (default = false)
       collapsed: true
       # Input fields in this section
@@ -163,9 +160,9 @@ Input fields can be visually grouped in sections. Grouping input fields by secti
 only how the inputs are displayed to the user, and not how service action data is structured.
 
 In the [service action description example](#service-action-description-example), the `speed_pct`
-input field is inside an initially collapsed section `advanced_fields`.
+input field is inside an initially collapsed section `additional_fields`.
 The service action data for the service in the example is `{"speed_pct": 50}`, not
-`{"advanced_fields": {"speed_pct": 50}}`.
+`{"additional_fields": {"speed_pct": 50}}`.
 
 ### Filtering service action fields
 
@@ -231,7 +228,7 @@ The following example shows how to provide icons for the `turn_on` and `turn_off
 
 In addition, icons can optionally be specified for collapsible sections.
 
-The following example shows how to provide an icon for the `advanced_options` section:
+The following example shows how to provide an icon for the `additional_options` section:
 
 ```json
 {
@@ -239,7 +236,7 @@ The following example shows how to provide an icon for the `advanced_options` se
     "start_brewing": {
       "service": "mdi:flask",
       "sections": {
-        "advanced_options": "mdi:test-tube"
+        "additional_options": "mdi:test-tube"
       }
     }
   }
@@ -313,7 +310,7 @@ async def custom_set_sleep_timer(entity, service_call):
 
 ## Response data
 
-Actions may respond to an action call with data for powering more advanced automations. There are some additional implementation requirements:
+Actions may respond to an action call with data for powering more complex automations. There are some additional implementation requirements:
 
 - Response data must be a `dict` and serializable in JSON [`homeassistant.util.json.JsonObjectType`](https://github.com/home-assistant/core/blob/dev/homeassistant/util/json.py) in order to interoperate with other parts of the system, such as the frontend.
 - Errors must be raised as exceptions just like any other service action call as

--- a/docs/internationalization/core.md
+++ b/docs/internationalization/core.md
@@ -208,8 +208,8 @@ Set description placeholders when the [service action is registered](/docs/dev_1
         }
       },
       "sections": {
-        "advanced_fields": {
-          "name": "Advanced options"
+        "additional_fields": {
+          "name": "Additional options"
         }
       }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Reworks the "advanced" terminology in the services developer docs, as requested in #3165.

Since advanced mode has been removed from the frontend, the field-level `advanced:` option no longer has any effect (it is still accepted by the `services.yaml` schema, but no core integration uses it). For hiding less commonly used options from the default view, collapsible sections are the documented mechanism. This PR therefore:

- Drops the `advanced:` field (and its now-inaccurate "only shown when advanced mode is enabled" comment) from the `services.yaml` example.
- Rewords "initially hide advanced fields" -> "initially hide less commonly used fields".
- Rewords "powering more advanced automations" -> "powering more complex automations".
- Renames the example collapsible section keys so they no longer model the pattern being removed: `advanced_fields` -> `additional_fields` and `advanced_options` -> `additional_options`, kept consistent between `dev_101_services.md` and the matching `strings.json` translation example in `internationalization/core.md` (display name "Advanced options" -> "Additional options").

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.

  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #3165
- Link to relevant existing code or pull request:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated service action configuration examples to use revised field grouping terminology throughout integration development documentation, improving consistency across sections.
  * Enhanced internationalization documentation examples with updated naming conventions to align with service action specifications.
  * Refined response data section documentation with clearer language for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->