### PR TITLE
Clarify media player state values are lowercase

### DIFF
--- a/docs/core/entity/media-player.md
+++ b/docs/core/entity/media-player.md
@@ -81,7 +81,7 @@ and are combined using the bitwise or (`|`) operator.
 
 ## States
 
-The state of a media player is defined by using values in the `MediaPlayerState` enum, and can take the following possible values.
+Setting the state should return an enum from `MediaPlayerState` in the `state` property. The resulting state value is the lowercase version of the enum member name (for example, `MediaPlayerState.PLAYING` results in the state `playing`).
 
 | Value       | Description                                                                                                         |
 |-------------|---------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

The media player entity "States" section introduced the state table with "... can take the following possible values" and then listed the uppercase `MediaPlayerState` enum member names. This misleads readers into thinking the actual state value is uppercase (for example `PAUSED`), when the state string is lowercase (`paused`), as reported in #2131.

This reframes the intro to match the convention used by the other entity docs (`vacuum`, `alarm-control-panel`): "Setting the state should return an enum from `MediaPlayerState` in the `state` property." It also adds an explicit note that the resulting state value is the lowercase version of the enum member name (for example, `MediaPlayerState.PLAYING` results in the state `playing`). The table itself is unchanged, keeping it consistent with the other entity pages.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.

  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #2131
- Link to relevant existing code or pull request:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated media player state documentation to clarify how the state property returns enum values in lowercase format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->