### PR TITLE
Fix incorrect examples in handling setup failures docs

### DIFF
--- a/docs/integration_setup_failures.md
+++ b/docs/integration_setup_failures.md
@@ -14,7 +14,7 @@ Raise the `ConfigEntryNotReady` exception from `async_setup_entry` in the integr
 
 ```python
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Setup the config entry for my device."""
+    """Set up the config entry for my device."""
     device = MyDevice(entry.data[CONF_HOST])
     try:
         await device.async_setup()
@@ -46,7 +46,7 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the platform."""
-    device = MyDevice(conf[CONF_HOST])
+    device = MyDevice(config[CONF_HOST])
     try:
         await device.async_setup()
     except ConnectionError as ex:
@@ -56,7 +56,7 @@ async def async_setup_platform(
 #### Handling logging of a retry
 
 Pass the error message to `PlatformNotReady` as the first argument. Home Assistant will log the retry once with a log level of
-`warning`, and subsequent retries will be logged at `debug` level. Suppose you do not set a message when raising `ConfigEntryNotReady`; in that case, Home Assistant will try to extract the reason from the exception that is the cause of `ConfigEntryNotReady` if it was propagated from another exception.
+`warning`, and subsequent retries will be logged at `debug` level. Suppose you do not set a message when raising `PlatformNotReady`; in that case, Home Assistant will try to extract the reason from the exception that is the cause of `PlatformNotReady` if it was propagated from another exception.
 
 The integration should not log any non-debug messages about the retry, and should instead rely on the logic built-in to `PlatformNotReady` to avoid spamming the logs.
 
@@ -74,7 +74,7 @@ The `reauth` flow will be started with the following context variables, which ar
 
 ```python
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Setup the config entry for my device."""
+    """Set up the config entry for my device."""
     device = MyDevice(entry.data[CONF_HOST])
     try:
         await device.async_setup()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Fixes two bugs and a grammar issue in the "Handling setup failures" examples:

- The `async_setup_platform` example referenced `conf[CONF_HOST]`, but the parameter is named `config`. Changed to `config[CONF_HOST]`.
- The `PlatformNotReady` section's "Handling logging of a retry" paragraph mistakenly referred to `ConfigEntryNotReady` (copy-paste from the `ConfigEntryNotReady` section above). Corrected to `PlatformNotReady`.
- Two docstrings used "Setup" as a verb; corrected to "Set up".

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.

  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated integration setup failure documentation with corrected examples and refined guidance for setup retries, credential expiration, and platform readiness scenarios. Clarified error handling explanations and improved documentation consistency for setup functions and integration setup best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->