### PR TITLE
Use ConfigEntry.runtime_data in Bluetooth fetching data examples

### DIFF
--- a/docs/core/bluetooth/bluetooth_fetching_data.md
+++ b/docs/core/bluetooth/bluetooth_fetching_data.md
@@ -67,7 +67,6 @@ from homeassistant.components.bluetooth import BluetoothScanningMode
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothProcessorCoordinator,
 )
-from .const import DOMAIN
 from homeassistant.const import Platform
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
@@ -76,19 +75,21 @@ from your_library import DataParser
 
 _LOGGER = logging.getLogger(__name__)
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+type ExampleConfigEntry = ConfigEntry[PassiveBluetoothProcessorCoordinator]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ExampleConfigEntry) -> bool:
     """Set up example BLE device from a config entry."""
     address = entry.unique_id
     data = DataParser()
-    coordinator = hass.data.setdefault(DOMAIN, {})[
-        entry.entry_id
-    ] = PassiveBluetoothProcessorCoordinator(
+    coordinator = PassiveBluetoothProcessorCoordinator(
         hass,
         _LOGGER,
         address=address,
         mode=BluetoothScanningMode.ACTIVE,
         update_method=data.update,
     )
+    entry.runtime_data = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(
         # only start after all platforms have had a chance to subscribe
@@ -100,19 +101,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 Example `sensor.py`:
 
 ```python
-from homeassistant import config_entries
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothDataProcessor,
     PassiveBluetoothDataUpdate,
     PassiveBluetoothEntityKey,
-    PassiveBluetoothProcessorCoordinator,
     PassiveBluetoothProcessorEntity,
 )
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
+from . import ExampleConfigEntry
 
 
 def sensor_update_to_bluetooth_data_update(parsed_data):
@@ -130,13 +129,11 @@ def sensor_update_to_bluetooth_data_update(parsed_data):
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: config_entries.ConfigEntry,
+    entry: ExampleConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the example BLE sensors."""
-    coordinator: PassiveBluetoothProcessorCoordinator = hass.data[DOMAIN][
-        entry.entry_id
-    ]
+    coordinator = entry.runtime_data
     processor = PassiveBluetoothDataProcessor(sensor_update_to_bluetooth_data_update)
     entry.async_on_unload(
         processor.async_add_entities_listener(
@@ -177,7 +174,6 @@ from homeassistant.components.bluetooth import (
     BluetoothServiceInfoBleak,
     async_ble_device_from_address,
 )
-from .const import DOMAIN
 from homeassistant.const import Platform
 
 from homeassistant.components.bluetooth.active_update_processor import (
@@ -189,7 +185,10 @@ from your_library import DataParser
 
 _LOGGER = logging.getLogger(__name__)
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+type ExampleConfigEntry = ConfigEntry[ActiveBluetoothProcessorCoordinator]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ExampleConfigEntry) -> bool:
     """Set up example BLE device from a config entry."""
     address = entry.unique_id
     assert address is not None
@@ -223,9 +222,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
         return await data.async_poll(connectable_device)
 
-    coordinator = hass.data.setdefault(DOMAIN, {})[
-        entry.entry_id
-    ] = ActiveBluetoothProcessorCoordinator(
+    coordinator = ActiveBluetoothProcessorCoordinator(
         hass,
         _LOGGER,
         address=address,
@@ -238,6 +235,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # if we need to poll it
         connectable=False,
     )
+    entry.runtime_data = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(
         # only start after all platforms have had a chance to subscribe


### PR DESCRIPTION
## Proposed change

The Bluetooth "Fetching Bluetooth data" examples still stored the coordinator in `hass.data[DOMAIN][entry.entry_id]` inside `async_setup_entry` and read it back in the platform. That predates the `runtime-data` quality-scale rule, which recommends storing per config entry runtime objects on a typed `ConfigEntry.runtime_data`.

This updates both processor coordinator examples (passive and active) and the shared `sensor.py` example to use a typed `ExampleConfigEntry = ConfigEntry[...Coordinator]` and `entry.runtime_data`, in line with the [runtime-data rule](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/runtime-data). The now unused `DOMAIN`, `config_entries`, and explicit coordinator imports are dropped along with it.

## Type of change

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [x] Remove stale or deprecated documentation

## Checklist

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request:
