### PR TITLE
Replace deprecated SUPPORT_ flag names with EntityFeature enums

### DIFF
--- a/docs/core/entity/climate.md
+++ b/docs/core/entity/climate.md
@@ -15,8 +15,8 @@ Properties should always only return information from memory and not do I/O (lik
 | ----------------------- | ----------------------------------- | ------------------------------------ | -------------------------------------------------------------------------- |
 | current_humidity        | `float \| None`      | `None`                               | The current humidity.                                                      |
 | current_temperature     | `float \| None`      | `None`                               | The current temperature.                                                   |
-| fan_mode                | `str \| None`        | **Required by SUPPORT_FAN_MODE**     | The current fan mode.                                                      |
-| fan_modes               | `list[str] \| None`  | **Required by SUPPORT_FAN_MODE**     | The list of available fan modes.                                           |
+| fan_mode                | `str \| None`        | **Required by ClimateEntityFeature.FAN_MODE**     | The current fan mode.                                                      |
+| fan_modes               | `list[str] \| None`  | **Required by ClimateEntityFeature.FAN_MODE**     | The list of available fan modes.                                           |
 | hvac_action             | `HVACAction \| None` | `None`                               | The current HVAC action (heating, cooling)                                 |
 | hvac_mode               | `HVACMode \| None`   | **Required**                         | The current operation (for example, heat, cool, idle). Used to determine `state`.  |
 | hvac_modes              | `list[HVACMode]`         | **Required**                         | List of available operation modes. See below.                              |
@@ -25,12 +25,12 @@ Properties should always only return information from memory and not do I/O (lik
 | min_humidity            | `float`                             | `DEFAULT_MIN_HUMIDITY` (value == 30) | The minimum humidity.                                                      |
 | min_temp                | `float`                             | `DEFAULT_MIN_TEMP` (value == 7 °C)   | The minimum temperature in `temperature_unit`.                             |
 | precision               | `float`                             | According to `temperature_unit`      | The precision of the temperature in the system. Defaults to tenths for TEMP_CELSIUS, whole number otherwise. |
-| preset_mode             | `str \| None`        | **Required by SUPPORT_PRESET_MODE**  | The current active preset.                                                 |
-| preset_modes            | `list[str] \| None`  | **Required by SUPPORT_PRESET_MODE**  | The available presets.                                                     |
-| swing_mode              | `str \| None`        | **Required by SUPPORT_SWING_MODE**   | The swing setting.                                                         |
-| swing_modes             | `list[str] \| None`  | **Required by SUPPORT_SWING_MODE**   | Returns the list of available swing modes, only vertical modes in the case horizontal swing is implemented. |
-| swing_horizontal_mode   | `str \| None`        | **Required by SUPPORT_SWING_HORIZONTAL_MODE**   | The horizontal swing setting.                                   |
-| swing_horizontal_modes  | `list[str] \| None`  | **Required by SUPPORT_SWING_HORIZONTAL_MODE**  | Returns the list of available horizontal swing modes.            |
+| preset_mode             | `str \| None`        | **Required by ClimateEntityFeature.PRESET_MODE**  | The current active preset.                                                 |
+| preset_modes            | `list[str] \| None`  | **Required by ClimateEntityFeature.PRESET_MODE**  | The available presets.                                                     |
+| swing_mode              | `str \| None`        | **Required by ClimateEntityFeature.SWING_MODE**   | The swing setting.                                                         |
+| swing_modes             | `list[str] \| None`  | **Required by ClimateEntityFeature.SWING_MODE**   | Returns the list of available swing modes, only vertical modes in the case horizontal swing is implemented. |
+| swing_horizontal_mode   | `str \| None`        | **Required by ClimateEntityFeature.SWING_HORIZONTAL_MODE**   | The horizontal swing setting.                                   |
+| swing_horizontal_modes  | `list[str] \| None`  | **Required by ClimateEntityFeature.SWING_HORIZONTAL_MODE**  | Returns the list of available horizontal swing modes.            |
 | target_humidity         | `float \| None`      | `None`                               | The target humidity the device is trying to reach.                         |
 | target_humidity_step    | `int \| None`        | `None`                               | The supported step size a target humidity can be increased or decreased in an action call targeting the device. |
 | target_temperature      | `float \| None`      | `None`                               | The temperature currently set to be reached.                               |

--- a/docs/core/entity/cover.md
+++ b/docs/core/entity/cover.md
@@ -70,7 +70,7 @@ and are combined using the bitwise or (`|`) operator.
 
 ### Open cover
 
-Only implement this method if the flag `SUPPORT_OPEN` is set.
+Only implement this method if the flag `CoverEntityFeature.OPEN` is set.
 
 ```python
 class MyCover(CoverEntity):
@@ -85,7 +85,7 @@ class MyCover(CoverEntity):
 
 ### Close cover
 
-Only implement this method if the flag `SUPPORT_CLOSE` is set.
+Only implement this method if the flag `CoverEntityFeature.CLOSE` is set.
 
 ```python
 class MyCover(CoverEntity):
@@ -100,7 +100,7 @@ class MyCover(CoverEntity):
 
 ### Set cover position
 
-Only implement this method if the flag `SUPPORT_SET_POSITION` is set.
+Only implement this method if the flag `CoverEntityFeature.SET_POSITION` is set.
 
 ```python
 class MyCover(CoverEntity):
@@ -115,7 +115,7 @@ class MyCover(CoverEntity):
 
 ### Stop cover
 
-Only implement this method if the flag `SUPPORT_STOP` is set.
+Only implement this method if the flag `CoverEntityFeature.STOP` is set.
 
 ```python
 class MyCover(CoverEntity):
@@ -130,7 +130,7 @@ class MyCover(CoverEntity):
 
 ### Open cover tilt
 
-Only implement this method if the flag `SUPPORT_OPEN_TILT` is set.
+Only implement this method if the flag `CoverEntityFeature.OPEN_TILT` is set.
 
 ```python
 class MyCover(CoverEntity):
@@ -145,7 +145,7 @@ class MyCover(CoverEntity):
 
 ### Close cover tilt
 
-Only implement this method if the flag `SUPPORT_CLOSE_TILT` is set.
+Only implement this method if the flag `CoverEntityFeature.CLOSE_TILT` is set.
 
 ```python
 class MyCover(CoverEntity):
@@ -160,7 +160,7 @@ class MyCover(CoverEntity):
 
 ### Set cover tilt position
 
-Only implement this method if the flag `SUPPORT_SET_TILT_POSITION` is set.
+Only implement this method if the flag `CoverEntityFeature.SET_TILT_POSITION` is set.
 
 ```python
 class MyCover(CoverEntity):
@@ -175,7 +175,7 @@ class MyCover(CoverEntity):
 
 ### Stop cover tilt
 
-Only implement this method if the flag `SUPPORT_STOP_TILT` is set.
+Only implement this method if the flag `CoverEntityFeature.STOP_TILT` is set.
 
 ```python
 class MyCover(CoverEntity):

--- a/docs/core/entity/humidifier.md
+++ b/docs/core/entity/humidifier.md
@@ -14,13 +14,13 @@ Properties should always only return information from memory and not do I/O (lik
 | Name                    | Type                                           | Default                               | Description                                        |
 | ----------------------- | ---------------------------------------------- | ------------------------------------- | -------------------------------------------------- |
 | action                  | `HumidifierAction \| None`      | `None`                                | Returns the current status of the device.          |
-| available_modes         | `list[str] \| None`             | **Required by MODES**                 | The available modes. Requires `SUPPORT_MODES`.     |
+| available_modes         | `list[str] \| None`             | **Required by MODES**                 | The available modes. Requires `HumidifierEntityFeature.MODES`.     |
 | current_humidity        | `float \| None`                   | `None`                                | The current humidity measured by the device.       |
 | device_class            | `HumidifierDeviceClass \| None` | `None`                                | Type of hygrostat                                  |
 | is_on                   | `bool \| None`                  | `None`                                | Whether the device is on or off.                   |
 | max_humidity            | `float`                                          | `DEFAULT_MAX_HUMIDITY` (value == 100) | The maximum humidity.                              |
 | min_humidity            | `float`                                          | `DEFAULT_MIN_HUMIDITY` (value == 0)   | The minimum humidity.                              |
-| mode                    | `str \| None`                   | **Required**                          | The current active mode. Requires `SUPPORT_MODES`. |
+| mode                    | `str \| None`                   | **Required**                          | The current active mode. Requires `HumidifierEntityFeature.MODES`. |
 | target_humidity         | `float \| None`                   | `None`                                | The target humidity the device is trying to reach. |
 | target_humidity_step    | `float \| None`                   | `None`                                | The supported step size a target humidity can be increased or decreased. |
 

--- a/docs/core/entity/lock.md
+++ b/docs/core/entity/lock.md
@@ -73,7 +73,7 @@ class MyLock(LockEntity):
 
 ### Open
 
-Only implement this method if the flag `SUPPORT_OPEN` is set.
+Only implement this method if the flag `LockEntityFeature.OPEN` is set.
 
 ```python
 class MyLock(LockEntity):

--- a/docs/core/entity/media-player.md
+++ b/docs/core/entity/media-player.md
@@ -329,7 +329,7 @@ class MyMediaPlayer(MediaPlayerEntity):
 
 ### Grouping player entities together
 
-Optional. If your player has support for grouping player entities together for synchronous playback (indicated by `SUPPORT_GROUPING`) one join and one unjoin method needs to be defined.
+Optional. If your player has support for grouping player entities together for synchronous playback (indicated by `MediaPlayerEntityFeature.GROUPING`) one join and one unjoin method needs to be defined.
 
 ```python
 class MyMediaPlayer(MediaPlayerEntity):

--- a/docs/core/entity/remote.md
+++ b/docs/core/entity/remote.md
@@ -89,7 +89,7 @@ class MyRemote(RemoteEntity):
 
 ### Learn command
 
-Only implement this method if the flag `SUPPORT_LEARN_COMMAND` is set.
+Only implement this method if the flag `RemoteEntityFeature.LEARN_COMMAND` is set.
 
 ```python
 class MyRemote(RemoteEntity):
@@ -103,7 +103,7 @@ class MyRemote(RemoteEntity):
 
 ### Delete command
 
-Only implement this method if the flag `SUPPORT_DELETE_COMMAND` is set.
+Only implement this method if the flag `RemoteEntityFeature.DELETE_COMMAND` is set.
 
 ```python
 class MyRemote(RemoteEntity):

--- a/docs/core/entity/valve.md
+++ b/docs/core/entity/valve.md
@@ -53,7 +53,7 @@ and are combined using the bitwise or (`|`) operator.
 
 ### Open valve
 
-Only implement this method if the flag `SUPPORT_OPEN` is set. For valves that
+Only implement this method if the flag `ValveEntityFeature.OPEN` is set. For valves that
 can set position, this method should be left unimplemented and only `set_valve_position` is required.
 
 ```python
@@ -69,7 +69,7 @@ class MyValve(ValveEntity):
 
 ### Close valve
 
-Only implement this method if the flag `SUPPORT_CLOSE` is set. For valves that
+Only implement this method if the flag `ValveEntityFeature.CLOSE` is set. For valves that
 can set position, this method should be left unimplemented and only `set_valve_position` is required.
 
 ```python
@@ -85,7 +85,7 @@ class MyValve(ValveEntity):
 
 ### Set valve position
 
-Only implement this method if the flag `SUPPORT_SET_POSITION` is set. This method must be implemented in valves that can set position.
+Only implement this method if the flag `ValveEntityFeature.SET_POSITION` is set. This method must be implemented in valves that can set position.
 
 ```python
 class MyValve(ValveEntity):
@@ -100,7 +100,7 @@ class MyValve(ValveEntity):
 
 ### Stop valve
 
-Only implement this method if the flag `SUPPORT_STOP` is set.
+Only implement this method if the flag `ValveEntityFeature.STOP` is set.
 
 ```python
 class MyValve(ValveEntity):


### PR DESCRIPTION
## Proposed change

Several entity documentation pages still referred to the old `SUPPORT_*` flag constants (such as `SUPPORT_OPEN`, `SUPPORT_FAN_MODE`, `SUPPORT_GROUPING`) when describing which methods or properties are required for a feature. These constants have been removed from core and replaced by the `*EntityFeature` enums, which the same pages already use in their supported features tables.

This updates the prose and table references on the cover, valve, climate, remote, lock, humidifier, and media player pages to use the matching `*EntityFeature` enum member names, so the documentation is consistent with itself and with core.

The light page is intentionally left out: its remaining `SUPPORT_*` references sit inside a description of the legacy color mode deduction (including `SUPPORT_WHITE_VALUE`), which is a separate stale documentation concern.

## Type of change

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [x] Remove stale or deprecated documentation

## Checklist

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request:
