### PR TITLE
Remove stale color mode deduction from light docs

### DIFF
--- a/docs/core/entity/light.md
+++ b/docs/core/entity/light.md
@@ -27,27 +27,11 @@ A light entity controls the brightness, hue and saturation color value, white va
 
 ## Color modes
 
-New integrations must implement both `color_mode` and `supported_color_modes`. If an integration is upgraded to support color mode, both `color_mode` and `supported_color_modes` should be implemented.
+A light must implement both `color_mode` and `supported_color_modes`. Supported color modes are defined by using values in the `ColorMode` enum, and `color_mode` must be set to one of the modes listed in `supported_color_modes`.
 
-Supported color modes are defined by using values in the `ColorMode` enum.
+Setting `supported_color_modes` is required. A light that does not set it will raise an error when its state is written.
 
-If a light does not implement the `supported_color_modes`, the `LightEntity` will attempt deduce it based on deprecated flags in the `supported_features` property:
-
- - Start with an empty set
- - If `SUPPORT_COLOR_TEMP` is set, add `ColorMode.COLOR_TEMP`
- - If `SUPPORT_COLOR` is set, add `ColorMode.HS`
- - If `SUPPORT_WHITE_VALUE` is set, add `ColorMode.RGBW`
- - If `SUPPORT_BRIGHTNESS` is set and no color modes have yet been added, add `ColorMode.BRIGHTNESS`
- - If no color modes have yet been added, add `ColorMode.ONOFF`
-
-If a light does not implement the `color_mode`, the `LightEntity` will attempt to deduce it based on which of the properties are set and which are `None`:
-
-- If `supported_color_modes` includes `ColorMode.RGBW` and `white_value` and `hs_color` are both not None: `ColorMode.RGBW`
-- Else if `supported_color_modes` includes `ColorMode.HS` and `hs_color` is not None: `ColorMode.HS`
-- Else if `supported_color_modes` includes `ColorMode.COLOR_TEMP` and `color_temp` is not None: `ColorMode.COLOR_TEMP`
-- Else if `supported_color_modes` includes `ColorMode.BRIGHTNESS` and `brightness` is not None: `ColorMode.BRIGHTNESS`
-- Else if `supported_color_modes` includes `ColorMode.ONOFF`: `ColorMode.ONOFF`
-- Else: ColorMode.UNKNOWN
+The available color modes are:
 
 | Value | Description
 |----------|-----------------------


### PR DESCRIPTION
## Proposed change

The light color modes documentation still described two fallback behaviors that no longer exist in core:

- Deducing `supported_color_modes` from the deprecated `SUPPORT_*` flags (including `SUPPORT_WHITE_VALUE`).
- Deducing `color_mode` from which properties are set, referencing the removed `white_value` property.

In current core, `supported_color_modes` is mandatory and raises an error when it is not set, `color_mode` is simply the value the integration sets, and `white_value` has been removed entirely. The fallback text also contradicted the section's own opening statement that both properties must be implemented.

This removes both stale deduction lists and replaces them with an accurate statement: a light must implement both `color_mode` and `supported_color_modes`, and `color_mode` must be one of the supported modes.

## Type of change

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [x] Remove stale or deprecated documentation

## Checklist

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/blob/dev/homeassistant/components/light/__init__.py#L1035-L1047
