### PR TITLE
Replace removed temperature unit constants with UnitOfTemperature

### DIFF
--- a/docs/core/entity/climate.md
+++ b/docs/core/entity/climate.md
@@ -24,7 +24,7 @@ Properties should always only return information from memory and not do I/O (lik
 | max_temp                | `float`                             | `DEFAULT_MAX_TEMP` (value == 35 °C)  | The maximum temperature in `temperature_unit`.                             |
 | min_humidity            | `float`                             | `DEFAULT_MIN_HUMIDITY` (value == 30) | The minimum humidity.                                                      |
 | min_temp                | `float`                             | `DEFAULT_MIN_TEMP` (value == 7 °C)   | The minimum temperature in `temperature_unit`.                             |
-| precision               | `float`                             | According to `temperature_unit`      | The precision of the temperature in the system. Defaults to tenths for TEMP_CELSIUS, whole number otherwise. |
+| precision               | `float`                             | According to `temperature_unit`      | The precision of the temperature in the system. Defaults to tenths for `UnitOfTemperature.CELSIUS`, whole number otherwise. |
 | preset_mode             | `str \| None`        | **Required by SUPPORT_PRESET_MODE**  | The current active preset.                                                 |
 | preset_modes            | `list[str] \| None`  | **Required by SUPPORT_PRESET_MODE**  | The available presets.                                                     |
 | swing_mode              | `str \| None`        | **Required by SUPPORT_SWING_MODE**   | The swing setting.                                                         |
@@ -37,7 +37,7 @@ Properties should always only return information from memory and not do I/O (lik
 | target_temperature_high | `float \| None`      | **Required by TARGET_TEMPERATURE_RANGE** | The upper bound target temperature                                     |
 | target_temperature_low  | `float \| None`      | **Required by TARGET_TEMPERATURE_RANGE** | The lower bound target temperature                                     |
 | target_temperature_step | `float \| None`      | `None`                               | The supported step size a target temperature can be increased or decreased |
-| temperature_unit        | <code>str</code>                    | **Required**                         | The unit of temperature measurement for the system (`TEMP_CELSIUS` or `TEMP_FAHRENHEIT`).                    |
+| temperature_unit        | <code>str</code>                    | **Required**                         | The unit of temperature measurement for the system (`UnitOfTemperature.CELSIUS` or `UnitOfTemperature.FAHRENHEIT`).                    |
 
 ### HVAC modes
 

--- a/docs/core/entity/water-heater.md
+++ b/docs/core/entity/water-heater.md
@@ -20,7 +20,7 @@ Properties should always only return information from memory and not do I/O (lik
 | `target_temperature_high` | `float` | `None`    | Upper bound of the temperature we are trying to reach.
 | `target_temperature_low` | `float`  | `None`    | Lower bound of the temperature we are trying to reach.
 | `target_temperature_step` | `float`  | `None`    | The supported step size a target temperature can be increased or decreased.
-| `temperature_unit`    | `str`       | `NotImplementedError` | One of `TEMP_CELSIUS`, `TEMP_FAHRENHEIT`, or `TEMP_KELVIN`.
+| `temperature_unit`    | `str`       | `NotImplementedError` | One of `UnitOfTemperature.CELSIUS`, `UnitOfTemperature.FAHRENHEIT`, or `UnitOfTemperature.KELVIN`.
 | `current_operation`   | `string`    | `None`    | The current operation mode.
 | `operation_list`      | `List[str]` | `None`    | List of possible operation modes.
 | `supported_features`  | `List[str]` | `NotImplementedError` | List of supported features.


### PR DESCRIPTION
## Proposed change

The climate and water heater entity pages still referred to the `TEMP_CELSIUS`, `TEMP_FAHRENHEIT`, and `TEMP_KELVIN` constants for the `temperature_unit` property. These constants have been removed from core and replaced by the `UnitOfTemperature` enum.

This updates both pages to use `UnitOfTemperature.CELSIUS`, `UnitOfTemperature.FAHRENHEIT`, and `UnitOfTemperature.KELVIN`.

## Type of change

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [x] Remove stale or deprecated documentation

## Checklist

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/blob/dev/homeassistant/const.py#L558-L563


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Climate entity documentation to reflect current temperature unit naming conventions and clarify default precision behavior across different temperature unit types.
  * Updated Water Heater entity documentation with accurate temperature unit property references, including all supported unit options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->