### PR TITLE
Modernize typing syntax in entity and platform doc examples

### DIFF
--- a/docs/core/entity/conversation.md
+++ b/docs/core/entity/conversation.md
@@ -66,7 +66,7 @@ A `ConversationInput` object contains the following data:
 | ---- | ---- | -----------
 | `text` | `str` | User input
 | `context` | `Context` | HA context to attach to actions in HA
-| `conversation_id` | `Optional[str]` | Can be used to track a multi-turn conversation. Return None if not supported
+| `conversation_id` | `str \| None` | Can be used to track a multi-turn conversation. Return None if not supported
 | `language` | `str` | Language of the text. If user did not provide one, it's set to the HA configured language.
 | `continue_conversation` | `bool` | If the agent expects the user to respond. If not set, it's assumed to be False.
 

--- a/docs/core/entity/fan.md
+++ b/docs/core/entity/fan.md
@@ -108,7 +108,7 @@ named_speed = percentage_to_ordered_list_item(ORDERED_NAMED_FAN_SPEEDS, 23)
 ...
 
     @property
-    def percentage(self) -> Optional[int]:
+    def percentage(self) -> int | None:
         """Return the current speed percentage."""
         return ordered_list_item_to_percentage(ORDERED_NAMED_FAN_SPEEDS, current_speed)
 
@@ -133,7 +133,7 @@ value_in_range = math.ceil(percentage_to_ranged_value(SPEED_RANGE, 50))
 ...
 
     @property
-    def percentage(self) -> Optional[int]:
+    def percentage(self) -> int | None:
         """Return the current speed percentage."""
         return ranged_value_to_percentage(SPEED_RANGE, current_speed)
 
@@ -152,10 +152,22 @@ Only implement this method if the flag `FanEntityFeature.TURN_ON` is set.
 class FanEntity(ToggleEntity):
     # Implement one of these methods.
 
-    def turn_on(self, speed: Optional[str] = None, percentage: Optional[int] = None, preset_mode: Optional[str] = None, **kwargs: Any) -> None:
+    def turn_on(
+        self,
+        speed: str | None = None,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
         """Turn on the fan."""
 
-    async def async_turn_on(self, speed: Optional[str] = None, percentage: Optional[int] = None, preset_mode: Optional[str] = None, **kwargs: Any) -> None:
+    async def async_turn_on(
+        self,
+        speed: str | None = None,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
         """Turn on the fan."""
 ```
 

--- a/docs/core/platform/reproduce_state.md
+++ b/docs/core/platform/reproduce_state.md
@@ -14,12 +14,13 @@ If you prefer to go the manual route, create a new file in your integration fold
 
 ```python
 import asyncio
-from typing import Iterable, Optional
+from collections.abc import Iterable
+
 from homeassistant.core import Context, HomeAssistant, State
 
 
 async def async_reproduce_states(
-    hass: HomeAssistant, states: Iterable[State], context: Optional[Context] = None
+    hass: HomeAssistant, states: Iterable[State], context: Context | None = None
 ) -> None:
     """Reproduce component states."""
     # TODO reproduce states


### PR DESCRIPTION
## Proposed change

A few entity and platform documentation examples still used the legacy typing syntax (`Optional[...]` and `typing.Iterable`). This updates them to the modern syntax that Home Assistant uses: PEP 604 unions (`X | None`) and `collections.abc` for the abstract base classes.

- `fan.md`: `percentage` properties and the `turn_on` / `async_turn_on` signatures (the latter split to one argument per line).
- `conversation.md`: the `conversation_id` type in the `ConversationInput` table.
- `reproduce_state.md`: the import line and the `context` parameter.

## Type of change

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated type annotations across core entity and platform documentation to use modern Python typing syntax (e.g., `str | None` instead of `Optional[str]`).
  * Reformatted code examples and method signatures for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->