### PR TITLE
Document contributing LLM tools via the llm integration platform

### DIFF
--- a/docs/core/llm/index.md
+++ b/docs/core/llm/index.md
@@ -11,6 +11,32 @@ Home Assistant has a built-in API which exposes the Assist API to LLMs. This API
 
 The Assist API is equivalent to the capabilities and exposed entities that are also accessible to the built-in conversation agent. No administrative tasks can be performed.
 
+## Contributing tools
+
+Integrations can contribute tools to an LLM API without owning a full API. The `llm` integration discovers an `<integration>/llm.py` platform that exposes an `async_get_tools` hook. The platform is imported lazily and queried only when an LLM request needs its tools.
+
+`async_get_tools` is a callback that is evaluated for each request with the request's `LLMContext`. It returns the tools to expose, together with an optional prompt fragment that travels with those tools. Because it runs per request, it can return a different set of tools depending on the context, such as the assistant or device making the request.
+
+```python
+# example_integration/llm.py
+from homeassistant.components import llm
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.llm import LLMContext
+
+
+@callback
+def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> llm.LLMTools:
+    """Return the tools to expose to the LLM."""
+    return llm.LLMTools(
+        tools=[MyTool()],
+        prompt="Use MyTool to ...",  # Optional prompt fragment
+    )
+```
+
+The hook is only called once the `llm` integration is set up, so the platform does not need to depend on `llm` itself.
+
+See [Tools](#tools) for how to implement the `Tool` objects returned by the platform.
+
 ## Supporting LLM APIs
 
 The LLM API needs to be integrated in two places in your integration. Users need to be able to configure which APIs should be used, and the tools offered by the APIs should be passed to the LLM when interacting with it.


### PR DESCRIPTION
## Proposed change

Documents the new `llm` integration's tool platform. Adds a "Contributing tools" section to the LLM API page explaining how an integration ships an `<integration>/llm.py` platform exposing an `async_get_tools(hass, llm_context)` hook, which the `llm` integration loads lazily and queries per request to contribute tools (and an optional prompt fragment) to an LLM API.

## Type of change

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: home-assistant/core#174253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added guide for third-party integrations to contribute tool functionality to the LLM API without requiring full API ownership
  * Includes example code demonstrating tool contribution patterns and dynamic tool set configuration based on request context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->