### PR TITLE
Add blog post for frontend component updates in 2026.7

### DIFF
--- a/blog/2026-06-23-frontend-component-updates-2026.7.md
+++ b/blog/2026-06-23-frontend-component-updates-2026.7.md
@@ -1,0 +1,124 @@
+---
+author: Jan-Philipp Benecke
+authorURL: https://github.com/jpbede
+authorImageURL: https://avatars.githubusercontent.com/u/3989428?s=96&v=4
+title: "Frontend component updates in 2026.7"
+---
+
+## Component updates
+
+### Component sizes use Web Awesome names
+
+`ha-button`, `ha-button-toggle-group`, and `ha-slider` now use the short Web Awesome size names.
+
+For `ha-button`, use:
+
+```html
+<ha-button size="s">Save</ha-button>
+```
+
+Supported values are `xs`, `s`, `m`, `l`, and `xl`.
+
+For `ha-button-toggle-group`, use `s` or `m`:
+
+```html
+<ha-button-toggle-group size="s" .buttons=${buttons}></ha-button-toggle-group>
+```
+
+`ha-slider` uses `s` or `m`.
+
+If your custom card or editor still uses `small`, `medium`, or `large` on these components, migrate them to short values like `s`, `m`, or `l`.
+
+### Virtualized lists
+
+We added two list components for large data sets:
+
+- `ha-list-virtualized`
+- `ha-list-selectable-virtualized`
+
+Use these when a picker or dialog can render enough rows to affect scrolling or initial render time. The virtualized list renders only the visible rows while keeping the roving-tabindex keyboard navigation from `ha-list-base`.
+
+Rows expose accessibility metadata with `aria-setsize` and `aria-posinset`, so assistive technologies still get the full list position even though only part of the list is in the DOM.
+
+```ts
+import "../../../components/list/ha-list-virtualized";
+import type { HaListVirtualizedItem } from "../../../components/list/ha-list-virtualized";
+```
+
+For selectable lists, render `ha-list-item-option` rows and keep selection state in the consumer. This keeps filtering and off-screen selections predictable.
+
+## Context and editor infrastructure
+
+### Dirty state tracking
+
+Dialogs and editors now have shared dirty-state infrastructure:
+
+- `DirtyStateProviderMixin`
+- `dirtyStateContext`
+- `isDirtyState`
+- `isEffectiveDirtyState`
+
+Use `DirtyStateProviderMixin` for new dialogs or editors that need to block scrim close, enable Save only after edits, or coordinate dirty state with child components.
+
+```ts
+class MyDialog extends DirtyStateProviderMixin<MyState>()(LitElement) {
+  public openDialog() {
+    this._initDirtyTracking({ type: "shallow" }, this._state);
+  }
+
+  private _stateChanged(state: MyState) {
+    this._updateDirtyState(state);
+  }
+}
+```
+
+`isDirtyState` is the raw comparison and is usually right for enabling Save. `isEffectiveDirtyState` can ignore equivalent config output, for example when an editor normalizes an explicit default back to the same effective config.
+
+### Related context
+
+Pages and editors can now publish related context for nearby pickers:
+
+- `relatedContext`
+- `fireRelatedContext`
+- `fireEntityRelatedContext`
+
+When a card editor, badge editor, automation trace page, or similar surface knows the current entity, device, or area, it can provide that context. Entity pickers and add-element searches can then prioritize related entities, devices, and areas.
+
+```ts
+fireEntityRelatedContext(this, "light.kitchen");
+```
+
+Clear the context with `undefined` when the editor no longer has a related item.
+
+### Narrow viewport context
+
+`narrowViewportContext` exposes whether the main Home Assistant viewport is in the narrow layout.
+
+Components that only need narrow-layout state can consume this context instead of receiving `narrow` through several layers of properties.
+
+```ts
+@consume({ context: narrowViewportContext, subscribe: true })
+private _narrow!: boolean;
+```
+
+## Lovelace updates
+
+### Strategy regeneration control
+
+Lovelace strategies can now avoid unnecessary regeneration.
+
+Strategies may declare `registryDependencies` to use the default reference-change check for only the registries they depend on:
+
+```ts
+static registryDependencies = ["entities", "areas"] as const;
+```
+
+For custom logic, implement `shouldRegenerate()`:
+
+```ts
+static shouldRegenerate(config, oldHomeAssistant, newHomeAssistant) {
+  return oldHomeAssistant.entities !== newHomeAssistant.entities;
+}
+```
+
+If neither is provided, strategies keep the previous default behavior and regenerate on changes to entities, devices, areas, or floors.

--- a/blog/2026-06-23-frontend-component-updates-2026.7.md
+++ b/blog/2026-06-23-frontend-component-updates-2026.7.md
@@ -40,12 +40,7 @@ Use these when a picker or dialog can render enough rows to affect scrolling or 
 
 Rows expose accessibility metadata with `aria-setsize` and `aria-posinset`, so assistive technologies still get the full list position even though only part of the list is in the DOM.
 
-```ts
-import "../../../components/list/ha-list-virtualized";
-import type { HaListVirtualizedItem } from "../../../components/list/ha-list-virtualized";
-```
-
-For selectable lists, render `ha-list-item-option` rows and keep selection state in the consumer. This keeps filtering and off-screen selections predictable.
+For selectable lists, render `ha-list-item-option` rows.
 
 ## Context and editor infrastructure
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
As Wendelin isn't around this release, I'm going to add a blog post for him. This PR adds the frontend 2026.7 developers blog post covering migration-relevant changes for custom cards, Lovelace strategy authors, and frontend contributors.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for frontend component updates including renamed size values for buttons, toggles, and sliders.
  * Documented new virtualized list components with accessibility position metadata and selectable item rows.
  * Added guidance on dirty-state tracking infrastructure for dialogs and editors.
  * Documented new context APIs for entity, device, and area relationships.
  * Added information on consuming narrow-layout state and Lovelace strategy regeneration control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->