### PR TITLE
Document reference_extra field on Issue and Suggestion supervisor API models

### DIFF
--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -3089,8 +3089,9 @@ firmware interface or the update is blocked on this board / boot device.
       "uuid": "A89924620F9A11EBBDC3C403FC2CA371",
       "type": "free_space",
       "context": "system",
-      "reference": null
-     }
+      "reference": null,
+      "reference_extra": null
+    }
   ],
   "suggestions": [
     {
@@ -3098,6 +3099,7 @@ firmware interface or the update is blocked on this board / boot device.
       "type": "clear_backups",
       "context": "system",
       "reference": null,
+      "reference_extra": null,
       "auto": false
     }
   ],
@@ -3144,6 +3146,7 @@ Get suggestions that would fix an issue if applied.
       "type": "clear_backups",
       "context": "system",
       "reference": null,
+      "reference_extra": null,
       "auto": false
     }
   ]

--- a/docs/api/supervisor/models.md
+++ b/docs/api/supervisor/models.md
@@ -234,22 +234,24 @@ The `content` key of a backup object contains the following keys:
 
 ## Issue
 
-| key       | type        | description                                         |
-| ----------| ----------- | --------------------------------------------------- |
-| uuid      | str         | A generated uuid as issue ID                        |
-| type      | str         | Type of the issue                                   |
-| context   | str         | In which context the issue occurs                   |
-| reference | str or null | Depend on the Context, a reference to another Model |
+| key             | type                | description                                                                                  |
+| --------------- | ------------------- | -------------------------------------------------------------------------------------------- |
+| uuid            | str                 | A generated uuid as issue ID                                                                 |
+| type            | str                 | Type of the issue                                                                            |
+| context         | str                 | In which context the issue occurs                                                            |
+| reference       | str or null         | Depends on the context; a reference to another model (e.g. an app slug)                      |
+| reference_extra | dict or null        | Additional context-specific metadata about the issue (e.g. which port is in conflict)        |
 
 ## Suggestion
 
-| key       | type        | description                                         |
-| ----------| ----------- | --------------------------------------------------- |
-| uuid      | str         | A generated uuid as suggestion ID                   |
-| type      | str         | Type of the suggestion                              |
-| context   | str         | In which context the suggestion occurs              |
-| reference | str or null | Depend on the Context, a reference to another Model |
-| auto      | bool        | True if the suggested fix will be auto-applied      |
+| key             | type                | description                                                                                  |
+| --------------- | ------------------- | -------------------------------------------------------------------------------------------- |
+| uuid            | str                 | A generated uuid as suggestion ID                                                            |
+| type            | str                 | Type of the suggestion                                                                       |
+| context         | str                 | In which context the suggestion occurs                                                       |
+| reference       | str or null         | Depends on the context; a reference to another model (e.g. an app slug)                      |
+| reference_extra | dict or null        | Additional context-specific metadata about the suggestion (e.g. which port to clear)         |
+| auto            | bool                | True if the suggested fix will be auto-applied                                               |
 
 ## Check
 


### PR DESCRIPTION
## Proposed change

Documents the `reference_extra` field added to the `Issue` and `Suggestion` models in the Supervisor API. This field carries additional context-specific metadata about an issue or suggestion (for example, which port is in conflict for an `app_port_conflict` issue).

Updated:
- `docs/api/supervisor/models.md` — added `reference_extra` to the Issue and Suggestion model tables
- `docs/api/supervisor/endpoints.md` — updated example JSON responses for `/resolution/info` and `/resolution/issue/<issue>/suggestions` to include `reference_extra`

## Type of change

- [x] Document existing features within Home Assistant

## Checklist

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: home-assistant/supervisor#6916

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API examples to include an additional `reference_extra` field in resolution responses.
  * Added documentation for the new Issue model details, including `reference_extra`.
  * Refreshed the Suggestion model description and field list to match the latest API output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->