### PR TITLE
Document Rust requirement for macOS development setup

### DIFF
--- a/docs/development_environment.mdx
+++ b/docs/development_environment.mdx
@@ -166,6 +166,12 @@ Install [Homebrew](https://brew.sh/), then use that to install the dependencies:
 brew install python3 autoconf ffmpeg cmake make
 ```
 
+Some Python dependencies of Home Assistant, such as `cryptography` and `orjson`, contain extensions written in Rust. If no prebuilt wheel is available for your Python version and platform, pip builds them from source, which requires a [Rust toolchain](https://www.rust-lang.org/tools/install). If the `script/setup` script below fails because `rustc` or `cargo` is missing, install Rust as well:
+
+```shell
+brew install rust
+```
+
 If you encounter build issues with `cryptography` when running the `script/setup` script below, check the cryptography documentation for [installation instructions](https://cryptography.io/en/latest/installation/#building-cryptography-on-macos).
 
 ### Setup Local Repository


### PR DESCRIPTION
## Proposed change

The macOS setup instructions list the Homebrew packages needed for local development, but `script/setup` can fail if no Rust toolchain is installed: several Python dependencies of Home Assistant (such as `cryptography`, `orjson`, and `pydantic-core`) contain Rust extensions, and pip needs `rustc`/`cargo` to build them from source whenever no prebuilt wheel is available for the current Python version and platform.

This adds a short note to the "Developing on macOS" section explaining when Rust is needed and how to install it via Homebrew.

## Type of change

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] The documentation follows the [Home Assistant documentation standards](https://developers.home-assistant.io/docs/documenting/standards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated macOS development setup instructions to include an extra Rust installation step.
  * Clarified what to do if setup fails because `rustc` or `cargo` are missing.
  * Added guidance for installing Rust with Homebrew when required by native dependency builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->