### PR TITLE
Update modbus-connection links to new documentation site

### DIFF
--- a/blog/2026-07-05-modernizing-modbus.md
+++ b/blog/2026-07-05-modernizing-modbus.md
@@ -16,7 +16,7 @@ The new [`modbus_connection`](https://github.com/home-assistant/core/tree/dev/ho
 
 ## A standalone library
 
-The connection abstraction underneath `modbus_connection` lives in [`modbus-connection`](https://github.com/home-assistant-libs/modbus-connection), a new library we designed for this purpose and published on PyPI. It is not bound to Home Assistant and can be used standalone in any Python project. It presents a common, backend-neutral interface, so device library authors write against one API regardless of the underlying Modbus implementation, and it ships a device-modelling framework and a `pytest` plugin to make building and testing a device library straightforward.
+The connection abstraction underneath `modbus_connection` lives in [`modbus-connection`](https://home-assistant-libs.github.io/modbus-connection/), a new library we designed for this purpose and published on PyPI. It is not bound to Home Assistant and can be used standalone in any Python project. It presents a common, backend-neutral interface, so device library authors write against one API regardless of the underlying Modbus implementation, and it ships a device-modelling framework and a `pytest` plugin to make building and testing a device library straightforward.
 
 This keeps concerns where they belong. A device library is a normal PyPI package that knows how to talk to a specific device, and a consuming integration in Home Assistant wires that library up to a shared connection and exposes entities. Both can be developed and tested independently.
 

--- a/docs/modbus/introduction.md
+++ b/docs/modbus/introduction.md
@@ -76,7 +76,7 @@ You do not need to catch `ConnectionNotReady`. Because it is a `ConfigEntryNotRe
 
 ## Writing Modbus libraries
 
-We require each integration to implement a library that handles the device-specific communication. To help build these libraries, we maintain [`modbus-connection`](https://github.com/home-assistant-libs/modbus-connection), a Python package. See its [documentation](https://home-assistant-libs.github.io/modbus-connection/) for details.
+We require each integration to implement a library that handles the device-specific communication. To help build these libraries, we maintain [`modbus-connection`](https://home-assistant-libs.github.io/modbus-connection/), a Python package.
 
 `modbus-connection` provides:
 

--- a/docs/modbus/introduction.md
+++ b/docs/modbus/introduction.md
@@ -76,7 +76,7 @@ You do not need to catch `ConnectionNotReady`. Because it is a `ConfigEntryNotRe
 
 ## Writing Modbus libraries
 
-We require each integration to implement a library that handles the device-specific communication. To help build these libraries, we maintain [`modbus-connection`](https://github.com/home-assistant-libs/modbus-connection), a Python package published on [PyPI](https://pypi.org/project/modbus-connection/).
+We require each integration to implement a library that handles the device-specific communication. To help build these libraries, we maintain [`modbus-connection`](https://github.com/home-assistant-libs/modbus-connection), a Python package published on [PyPI](https://home-assistant-libs.github.io/modbus-connection/).
 
 `modbus-connection` provides:
 

--- a/docs/modbus/introduction.md
+++ b/docs/modbus/introduction.md
@@ -76,7 +76,7 @@ You do not need to catch `ConnectionNotReady`. Because it is a `ConfigEntryNotRe
 
 ## Writing Modbus libraries
 
-We require each integration to implement a library that handles the device-specific communication. To help build these libraries, we maintain [`modbus-connection`](https://github.com/home-assistant-libs/modbus-connection), a Python package published on [PyPI](https://home-assistant-libs.github.io/modbus-connection/).
+We require each integration to implement a library that handles the device-specific communication. To help build these libraries, we maintain [`modbus-connection`](https://github.com/home-assistant-libs/modbus-connection), a Python package. See its [documentation](https://home-assistant-libs.github.io/modbus-connection/) for details.
 
 `modbus-connection` provides:
 


### PR DESCRIPTION
## Proposed change

Updates the links for the `modbus-connection` Python package to point to its new documentation site at https://home-assistant-libs.github.io/modbus-connection/.

- `docs/modbus/introduction.md`: the `modbus-connection` reference now links to the documentation site (previously a PyPI link plus a separate GitHub-repo link; consolidated into a single documentation link).
- `blog/2026-07-05-modernizing-modbus.md`: the `modbus-connection` link now points to the documentation site instead of the GitHub repo.

## Type of change

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYzn1XUsgt4ppNpx3P28BX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Modbus-related links to point to the published library documentation site instead of the GitHub repository.
  * Improved guidance in the Modbus introduction and blog content by directing readers to the correct external reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->