### PR TITLE
Update LLM API docs to match current core and document MCP exposure

### DIFF
--- a/docs/core/llm/index.md
+++ b/docs/core/llm/index.md
@@ -309,7 +309,7 @@ You do not need to do anything special to make your API available over the [Mode
 
 Each API is reachable at its own Streamable HTTP endpoint, addressed by its API ID:
 
-```
+```text
 /api/mcp/<API ID>
 ```
 

--- a/docs/core/llm/index.md
+++ b/docs/core/llm/index.md
@@ -15,7 +15,7 @@ The Assist API is equivalent to the capabilities and exposed entities that are a
 
 Integrations can contribute tools to an LLM API without owning a full API. The `llm` integration discovers an `<integration>/llm.py` platform that exposes an `async_get_tools` hook. The platform is imported lazily and queried only when an LLM request needs its tools.
 
-`async_get_tools` is a callback that is evaluated for each request with the request's `LLMContext`. It returns the tools to expose, together with an optional prompt fragment that travels with those tools. Because it runs per request, it can return a different set of tools depending on the context, such as the assistant or device making the request.
+`async_get_tools` is a callback that is evaluated for each request with the request's `LLMContext` and the `api_id` of the API being assembled. It returns the tools to expose, together with an optional prompt fragment that travels with those tools, or `None` when the integration has nothing to contribute to that API. Because it runs per request, it can return a different set of tools depending on the context, such as the assistant or device making the request, or the selected API.
 
 ```python
 # example_integration/llm.py
@@ -25,7 +25,9 @@ from homeassistant.helpers.llm import LLMContext
 
 
 @callback
-def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> llm.LLMTools:
+def async_get_tools(
+    hass: HomeAssistant, llm_context: LLMContext, api_id: str
+) -> llm.LLMTools | None:
     """Return the tools to expose to the LLM."""
     return llm.LLMTools(
         tools=[MyTool()],
@@ -164,7 +166,7 @@ class MyConversationEntity(conversation.ConversationEntity):
 
 ## Creating your own API
 
-To create your own API, you need to create a class that inherits from `API` and implement the `async_get_tools` method. The `async_get_tools` method should return a list of `Tool` objects that represent the functionality that you want to expose to the LLM.
+To create your own API, you need to create a class that inherits from `API` and implement the `async_get_api_instance` method. It returns an `APIInstance` holding the list of `Tool` objects that represent the functionality you want to expose to the LLM, together with the prompt that tells the LLM how to use them.
 
 ### Tools
 
@@ -172,7 +174,8 @@ The `llm.Tool` class represents a tool that can be called by the LLM.
 
 ```python
 from homeassistant.core import HomeAssistant
-from homeassistant.helper import llm
+from homeassistant.helpers import llm
+from homeassistant.helpers.llm import LLMContext, ToolInput
 from homeassistant.util import dt as dt_util
 from homeassistant.util.json import JsonObjectType
 
@@ -181,7 +184,7 @@ class TimeTool(llm.Tool):
     """Tool to get the current time."""
 
     name = "GetTime"
-    description: "Returns the current time."
+    description = "Returns the current time."
 
     # Optional. A voluptuous schema of the input parameters.
     parameters = vol.Schema({
@@ -197,7 +200,7 @@ class TimeTool(llm.Tool):
         else:
             tzinfo = dt_util.DEFAULT_TIME_ZONE
 
-        return dt_util.now(tzinfo).isoformat()
+        return {"time": dt_util.now(tzinfo).isoformat()}
 ```
 
 The `llm.Tool` class has the following attributes:
@@ -212,7 +215,7 @@ The `llm.Tool` class has the following methods:
 
 #### `async_call`
 
-Perform the actual operation of the tool when called by the LLM. This must be an async method. Its arguments are `hass` and an instance of `llm.ToolInput`.
+Perform the actual operation of the tool when called by the LLM. This must be an async method. Its arguments are `hass`, an instance of `llm.ToolInput`, and the `llm.LLMContext` of the request.
 
 Response data must be a dict and serializable in JSON [`homeassistant.util.json.JsonObjectType`](https://github.com/home-assistant/core/blob/dev/homeassistant/util/json.py).
 
@@ -224,9 +227,17 @@ The `ToolInput` has following attributes:
 |-------------------|---------|---------------------------------------------------------------------------------------------------------|
 | `tool_name`       | string  | The name of the tool being called                                                                       |
 | `tool_args`       | dict    | The arguments provided by the LLM. The arguments are converted and validated using `parameters` schema. |
-| `platform`        | string  | The DOMAIN of the conversation agent using the tool                                                     |
-| `context`         | Context | The `homeassistant.core.Context` of the conversation                                                    |
-| `user_prompt`     | string  | The raw text input that initiated the tool call                                                         |
+| `id`              | string  | Unique identifier for the tool call. Defaults to a newly generated ULID.                                 |
+| `external`        | bool    | Whether the tool call is executed outside of Home Assistant (for example by the model provider). External tool calls are not dispatched to the API's tools. Defaults to `False`. |
+
+Context that is shared across all tools of a request (the conversation agent, the requesting device, etc.) is provided separately as the `llm.LLMContext` passed to `async_call`.
+
+The `LLMContext` has following attributes:
+
+| Name              | Type    | Description                                                                                             |
+|-------------------|---------|---------------------------------------------------------------------------------------------------------|
+| `platform`        | string  | The DOMAIN of the conversation agent handling the LLM request                                           |
+| `context`         | Context | The `homeassistant.core.Context` of the request                                                         |
 | `language`        | string  | The language of the conversation agent, or "*" for any language                                         |
 | `assistant`       | string  | The assistant name used to control exposed entities. Currently, only `conversation` is supported.        |
 | `device_id`       | string  | The device_id of the device the user used to initiate the conversation.                                 |
@@ -238,12 +249,13 @@ The API object allows creating API instances. An API Instance represents a colle
 ```python
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helper import llm
+from homeassistant.helpers import llm
+from homeassistant.helpers.llm import APIInstance, LLMContext
 from homeassistant.util import dt as dt_util
 from homeassistant.util.json import JsonObjectType
 
 
-class MyAPI(API):
+class MyAPI(llm.API):
     """My own API for LLMs."""
 
     async def async_get_api_instance(self, llm_context: LLMContext) -> APIInstance:
@@ -262,7 +274,11 @@ async def async_setup_api(hass: HomeAssistant, entry: ConfigEntry) -> None:
     # unregistered when the config entry is unloaded.
     unreg = llm.async_register_api(
         hass,
-        MyAPI(hass, f"my_unique_key-{entry.entry_id}", entry.title)
+        MyAPI(
+            hass=hass,
+            id=f"my_unique_key-{entry.entry_id}",
+            name=entry.title,
+        ),
     )
     entry.async_on_unload(unreg)
 ```
@@ -271,8 +287,11 @@ The `llm.API` class has the following attributes:
 
 | Name              | Type    | Description                                                                                             |
 |-------------------|---------|---------------------------------------------------------------------------------------------------------|
+| `hass`            | HomeAssistant | The Home Assistant instance. Required.                                                            |
 | `id`              | string  | A unique identifier for the API. Required.                                                              |
 | `name`            | string  | The name of the API. Required.                                                                          |
+
+All fields are keyword-only, so the API must be instantiated with keyword arguments.
 
 The `llm.APIInstance` class has the following attributes:
 
@@ -282,3 +301,18 @@ The `llm.APIInstance` class has the following attributes:
 | `api_prompt`      | string  | Instructions for LLM on how to use the LLM tools. Required.                                      |
 | `llm_context`    | LLMContext | The context of the tool call. Required.                                                                 |
 | `tools`           | list[Tool] | The tools that are available in this API. Required.                                                     |
+| `custom_serializer` | Callable | Optional function to convert voluptuous schemas (for example selectors) into the JSON schema the LLM expects. Defaults to `None`. |
+
+## Exposing an API over MCP
+
+You do not need to do anything special to make your API available over the [Model Context Protocol (MCP)](https://modelcontextprotocol.io). Once the user sets up the [MCP Server integration](https://www.home-assistant.io/integrations/mcp_server/), every registered LLM API is automatically served over MCP.
+
+Each API is reachable at its own Streamable HTTP endpoint, addressed by its API ID:
+
+```
+/api/mcp/<API ID>
+```
+
+For example, the built-in Assist API is available at `/api/mcp/assist`, and a custom API registered with `llm.async_register_api` is available at `/api/mcp/<your API ID>`.
+
+These per-API endpoints require an admin access token, except for the Assist API. The MCP Server integration also exposes a single configured API at `/api/mcp` for clients that do not target a specific API by ID.


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

The LLM API documentation had drifted from the current implementation in core. This brings it back in sync and documents how APIs are exposed over MCP:

- Update the `async_get_tools` platform hook signature: it now takes an `api_id` argument and may return `None` when an integration has nothing to contribute to that API.
- Rework the `ToolInput` table (now `tool_name`, `tool_args`, `id`, `external`) and document the separate `LLMContext`, which now carries the request context (`platform`, `context`, `language`, `assistant`, `device_id`) that used to live on `ToolInput`.
- Note that `async_call` also receives the `LLMContext`.
- Fix the API creation example: `API` is keyword-only, so it must be instantiated with keyword arguments; document the required `hass` field.
- Document `APIInstance.custom_serializer`.
- Fix the "Creating your own API" intro: the abstract method to implement is `async_get_api_instance`, not `async_get_tools`.
- Fix the `homeassistant.helper` → `homeassistant.helpers` import typo and the `description:` annotation typo in the `TimeTool` example, and make it return a dict to match the documented response contract.
- Add an "Exposing an API over MCP" section explaining that every registered LLM API is automatically served over MCP at `/api/mcp/<API ID>` once the MCP Server integration is set up.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request:
  - [`homeassistant/helpers/llm.py`](https://github.com/home-assistant/core/blob/dev/homeassistant/helpers/llm.py) (`ToolInput`, `LLMContext`, `API`, `APIInstance`)
  - [`homeassistant/components/llm/__init__.py`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/llm/__init__.py) (`async_get_tools` platform hook)
  - [`homeassistant/components/mcp_server/http.py`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/mcp_server/http.py) (`/api/mcp/<API ID>` endpoints)


---
_Generated by [Claude Code](https://claude.ai/code/session_019G7Kvra86vW53QgT8LmDq7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated LLM integration guidance to match newer per-request tool resolution behavior, including cases where an API provides no tools.
  * Revised API/tool contract examples, including the required inputs passed to tools and how API instances are created.
  * Updated tool response examples to use JSON-serializable return data.
  * Documented MCP exposure for each API, including `/api/mcp/<API ID>` and the `/api/mcp` catch-all behavior and access requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->