### PR TITLE
Fix outdated integration developer guides to match core

### DIFF
--- a/docs/core/integration/config_flow.md
+++ b/docs/core/integration/config_flow.md
@@ -288,7 +288,7 @@ class ExampleConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None):
         if user_input is not None:
             # TODO: process user input
-            self.async_set_unique_id(user_id)
+            await self.async_set_unique_id(user_id)
             self._abort_if_unique_id_mismatch()
             return self.async_update_reload_and_abort(
                 self._get_reconfigure_entry(),
@@ -366,7 +366,7 @@ class OAuth2FlowHandler(
 
     async def async_oauth_create_entry(self, data: dict) -> dict:
         """Create an oauth config entry or update existing entry for reauth."""
-        self.async_set_unique_id(user_id)
+        await self.async_set_unique_id(user_id)
         if self.source == SOURCE_REAUTH:
             self._abort_if_unique_id_mismatch()
             return self.async_update_reload_and_abort(

--- a/docs/core/platform/reproduce_state.md
+++ b/docs/core/platform/reproduce_state.md
@@ -14,12 +14,17 @@ If you prefer to go the manual route, create a new file in your integration fold
 
 ```python
 import asyncio
-from typing import Iterable, Optional
+from collections.abc import Iterable
+from typing import Any
 from homeassistant.core import Context, HomeAssistant, State
 
 
 async def async_reproduce_states(
-    hass: HomeAssistant, states: Iterable[State], context: Optional[Context] = None
+    hass: HomeAssistant,
+    states: Iterable[State],
+    *,
+    context: Context | None = None,
+    reproduce_options: dict[str, Any] | None = None,
 ) -> None:
     """Reproduce component states."""
     # TODO reproduce states

--- a/docs/integration_fetching_data.md
+++ b/docs/integration_fetching_data.md
@@ -32,10 +32,9 @@ When using the DataUpdateCoordinator, the data being polled is often expected to
 ```python
 """Example integration using DataUpdateCoordinator."""
 
+import asyncio
 from datetime import timedelta
 import logging
-
-import async_timeout
 
 from homeassistant.components.light import LightEntity
 from homeassistant.core import callback
@@ -111,7 +110,7 @@ class MyCoordinator(DataUpdateCoordinator):
         try:
             # Note: asyncio.TimeoutError and aiohttp.ClientError are already
             # handled by the data update coordinator.
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 # Grab active context variables to limit data required to be fetched from API
                 # Note: using context is not required if there is no need or ability to limit
                 # data retrieved from API.

--- a/docs/integration_listen_events.md
+++ b/docs/integration_listen_events.md
@@ -8,7 +8,7 @@ Your integration may need to take action when a specific event happens inside Ho
 
 Event helpers are available in the `homeassistant.helpers.event` namespace. These functions return a callable that cancels the listener.
 
-Sync versions of the below functions are also available without the `async_` prefix.
+Sync versions of many of these functions are also available without the `async_` prefix.
 
 ### Example
 
@@ -21,7 +21,7 @@ unsub()
 
 | Function                             | Use case
 | ------------------------------------ | --------------------------------------------------------------------------
-| `async_track_state_change`           | Track specific state changes
+| `async_track_state_change`           | Track specific state changes (deprecated, use `async_track_state_change_event`)
 | `async_track_state_change_event`     | Track specific state change events indexed by entity_id
 | `async_track_state_added_domain`     | Track state change events when an entity is added to domains
 | `async_track_state_removed_domain`   | Track state change events when an entity is removed from domains

--- a/docs/network_discovery.md
+++ b/docs/network_discovery.md
@@ -114,7 +114,7 @@ from homeassistant.components import ssdp
 ...
 
 entry.async_on_unload(
-    ssdp.async_register_callback(
+    await ssdp.async_register_callback(
         hass, _async_discovered_player, {"st": "urn:schemas-upnp-org:device:ZonePlayer:1"}
     )
 )
@@ -129,7 +129,7 @@ from homeassistant.const import MATCH_ALL
 ...
 
 entry.async_on_unload(
-    ssdp.async_register_callback(
+    await ssdp.async_register_callback(
         hass, _async_discovered_player, {"x-rincon-bootseq": MATCH_ALL}
     )
 )
@@ -207,20 +207,6 @@ for adapter in adapters:
 
 The USB integration discovers new USB devices at startup, when the integrations page is accessed, and when they are plugged in if the underlying system has support for `pyudev`.
 
-### Checking if a specific adapter is plugged in
-
-Call the `async_is_plugged_in` API to check if a specific adapter is on the system.
-
-```python
-from homeassistant.components import usb
-
-...
-
-if not usb.async_is_plugged_in(hass, {"serial_number": "A1234", "manufacturer": "xtech"}):
-   raise ConfigEntryNotReady("The USB device is missing")
-
-```
-
 ### Knowing when to look for new compatible USB devices
 
 Call the `async_register_scan_request_callback` API to request a callback when new compatible USB devices may be available.
@@ -233,9 +219,9 @@ from homeassistant.core import callback
 
 @callback
 def _async_check_for_usb() -> None:
-    """Check for new compatible bluetooth USB adapters."""
+    """Check for new compatible USB adapters."""
 
 entry.async_on_unload(
-    bluetooth.async_register_scan_request_callback(hass, _async_check_for_usb)
+    usb.async_register_scan_request_callback(hass, _async_check_for_usb)
 )
 ```


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Corrects outdated code examples in the integration developer guides so they match current Home Assistant Core:

- **core/platform/reproduce_state.md** — updated the `async_reproduce_states` signature: `context` is now keyword-only and the new `reproduce_options: dict[str, Any] | None = None` parameter is included (matches `switch/reproduce_state.py` and the scaffold template). Modernized the imports.
- **core/integration/config_flow.md** — added the missing `await` to `self.async_set_unique_id(user_id)` in the reconfigure and reauth OAuth examples (it is a coroutine).
- **integration_fetching_data.md** — replaced the banned third-party `async_timeout` library with the stdlib `asyncio.timeout`.
- **integration_listen_events.md** — softened the overbroad "Sync versions of the below functions are also available…" (several listed helpers have no sync counterpart) and marked `async_track_state_change` as deprecated in favor of `async_track_state_change_event`.
- **network_discovery.md** — removed the "Checking if a specific adapter is plugged in" section (`usb.async_is_plugged_in` no longer exists in core); fixed the scan-request example to call `usb.async_register_scan_request_callback` (was `bluetooth.…`); added the missing `await` to both `ssdp.async_register_callback(...)` calls (it is a coroutine returning the cancel callback).

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: [`switch/reproduce_state.py`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/switch/reproduce_state.py), [`ssdp/__init__.py`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/ssdp/__init__.py), [`usb/__init__.py`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/usb/__init__.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRizr1PuMrPu8Z16JChguS)_