### PR TITLE
Revise guidance on avoiding templates in YAML

### DIFF
--- a/docs/documenting/yaml-style-guide.md
+++ b/docs/documenting/yaml-style-guide.md
@@ -375,10 +375,6 @@ Home Assistant templates are powerful, but they can be really confusing or hard
 to understand. Therefore, the use of templates
 should be avoided if a pure YAML version is available.
 
-Additionally, the use of templates requires additional escaping in our
-documentation to avoid our website code to confuse it for the Liquid syntax.
-Avoiding templates in general removes the need of additional escaping.
-
 ```yaml
 # Good
 conditions:


### PR DESCRIPTION
## Proposed change

Delete advice to avoid the use of templates in Home Assistant documentation, because it's no longer problematic (fixed in https://github.com/home-assistant/home-assistant.io/pull/44508).

Related to #3033.

## Type of change

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [x] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the YAML style guide’s Templates section by removing an outdated clarification.
  * Improved readability by streamlining the guidance before the next YAML example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->