### PR TITLE
Document standard Button event types

### DIFF
--- a/docs/core/entity/event.md
+++ b/docs/core/entity/event.md
@@ -73,4 +73,21 @@ Some device classes define standard event types to ensure consistency across int
 
 - `DoorbellEventType.RING`: represents the standard "doorbell was pressed" event. **This event type is mandatory**.
 
+#### Button
+
+Approved in [architecture#1377](https://github.com/home-assistant/architecture/discussions/1377). Unlike `DoorbellEventType.RING`, none of these are mandatory: integrations map only the interactions their hardware can actually produce and omit the rest.
+
+- `ButtonEventType.PRESS_START`: the button was pressed down.
+- `ButtonEventType.PRESS_END`: the button was released after a brief press (the standard "click").
+- `ButtonEventType.LONG_PRESS_START`: the button was held past a threshold.
+- `ButtonEventType.LONG_PRESS_END`: the button was released after a long hold.
+- `ButtonEventType.MULTI_PRESS_ONGOING`: an intermediate press in a multi-press sequence was detected.
+- `ButtonEventType.MULTI_PRESS_END`: a multi-press sequence completed.
+
+`MULTI_PRESS_ONGOING` and `MULTI_PRESS_END` include a `multi_press_count` attribute in `event_data` with the number of presses.
+
+If a device only emits a single event per interaction, with no separate press and release, map it to the matching `_end` type (`PRESS_END` for short presses, `LONG_PRESS_END` for holds, and so on).
+
+For a button that reports a direction from a single source (for example an up/down paddle), prefer exposing separate entities per direction. A non-standard `direction` attribute is an accepted alternative when splitting into multiple entities isn't practical.
+
 Other non-standard event types are also allowed.

--- a/docs/core/entity/event.md
+++ b/docs/core/entity/event.md
@@ -75,7 +75,6 @@ Some device classes define standard event types to ensure consistency across int
 
 #### Button
 
-Approved in [architecture#1377](https://github.com/home-assistant/architecture/discussions/1377). Unlike `DoorbellEventType.RING`, none of these are mandatory: integrations map only the interactions their hardware can actually produce and omit the rest.
 
 - `ButtonEventType.PRESS_START`: the button was pressed down.
 - `ButtonEventType.PRESS_END`: the button was released after a brief press (the standard "click").


### PR DESCRIPTION
## Proposed change

Documents the standard `ButtonEventType` event types for the `event` entity's `BUTTON` device class, added to Home Assistant Core in home-assistant/core#177028 and approved in [architecture#1377](https://github.com/home-assistant/architecture/discussions/1377).

Adds a "Button" subsection to `docs/core/entity/event.md`, alongside the existing "Doorbell" subsection, covering:
- The six standard event types and their meaning.
- The `multi_press_count` event-data attribute.
- Guidance for single-event devices (map to the matching `_end` type).
- Guidance for directional buttons (prefer separate entities per direction; a non-standard `direction` attribute is an accepted alternative), per the proposal's note on directional buttons.

Part of https://github.com/home-assistant/core/issues/176682

## Type of change

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: home-assistant/core#177028


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a section documenting standard “Button” event types.
  - Covered press start/end, long-press start/end, and multi-press ongoing/end values.
  - Clarified the required/optional event fields, including multi-press count.
  - Included mapping guidance for devices that only emit end events and for directional inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->