### PR TITLE
Add blogpost about button event types

### DIFF
--- a/blog/2026-07-22-button-standard-event-types.md
+++ b/blog/2026-07-22-button-standard-event-types.md
@@ -23,7 +23,7 @@ The new `ButtonEventType` standard event types solve this by giving every button
 
 - `ButtonEventType.PRESS_START`: the button was pressed down.
 - `ButtonEventType.PRESS_END`: the button was released after a brief press (the standard "click").
-- `ButtonEventType.LONG_PRESS_START`: the button was held past a threshold.
+- `ButtonEventType.LONG_PRESS_START`: the button was held past a duration threshold.
 - `ButtonEventType.LONG_PRESS_END`: the button was released after a long hold.
 - `ButtonEventType.MULTI_PRESS_ONGOING`: an intermediate press in a multi-press sequence was detected.
 - `ButtonEventType.MULTI_PRESS_END`: a multi-press sequence completed.

--- a/blog/2026-07-22-button-standard-event-types.md
+++ b/blog/2026-07-22-button-standard-event-types.md
@@ -1,0 +1,75 @@
+---
+author: Abílio Costa
+authorURL: https://github.com/abmantis
+authorImageURL: https://avatars.githubusercontent.com/u/974569?v=4
+title: "Standard event types for button event entities"
+---
+
+Button event entities now have a set of standard event types, provided by the new `ButtonEventType` enum. Integrations that use `EventDeviceClass.BUTTON` should use these types instead of custom strings whenever the interaction maps to one of them.
+
+See the [architecture discussion](https://github.com/home-assistant/architecture/discussions/1377) for the full background.
+
+<!--truncate-->
+
+## Why
+
+Previously, each integration picked its own strings for button interactions — `single`, `click`, `hold`, `double_press`, and so on. This inconsistency made it impossible to build generic button automations that work across integrations, and prevented the frontend from offering meaningful trigger suggestions.
+
+The new `ButtonEventType` standard event types solve this by giving every button integration a shared vocabulary for the common interactions.
+
+## The event types
+
+`ButtonEventType` defines six standard event types:
+
+- `ButtonEventType.PRESS_START`: the button was pressed down.
+- `ButtonEventType.PRESS_END`: the button was released after a brief press (the standard "click").
+- `ButtonEventType.LONG_PRESS_START`: the button was held past a threshold.
+- `ButtonEventType.LONG_PRESS_END`: the button was released after a long hold.
+- `ButtonEventType.MULTI_PRESS_ONGOING`: an intermediate press in a multi-press sequence was detected.
+- `ButtonEventType.MULTI_PRESS_END`: a multi-press sequence completed.
+
+The `MULTI_PRESS_ONGOING` and `MULTI_PRESS_END` events include a `multi_press_count` attribute in their event data (the `ATTR_MULTI_PRESS_COUNT` constant) with the number of presses.
+
+**None of these are mandatory.** Unlike the doorbell `ring` event, there is no required type here. Each integration maps only the interactions its hardware can actually produce, and lists just those in `event_types`.
+
+## What to do
+
+Import `ButtonEventType` from `homeassistant.components.event` and include the types your device supports in the entity's `event_types`. Fire them as the interactions happen:
+
+```python
+from homeassistant.components.event import (
+    ATTR_MULTI_PRESS_COUNT,
+    ButtonEventType,
+    EventDeviceClass,
+    EventEntity,
+)
+
+
+class MyButtonEvent(EventEntity):
+
+    _attr_device_class = EventDeviceClass.BUTTON
+    _attr_event_types = [
+        ButtonEventType.PRESS_END,
+        ButtonEventType.LONG_PRESS_END,
+        ButtonEventType.MULTI_PRESS_END,
+    ]
+
+    @callback
+    def _async_handle_multi_press(self, count: int) -> None:
+        """Handle a completed multi-press sequence."""
+        self._trigger_event(
+            ButtonEventType.MULTI_PRESS_END,
+            {ATTR_MULTI_PRESS_COUNT: count},
+        )
+        self.async_write_ha_state()
+```
+
+### Single-event devices
+
+If a device only emits a single event per interaction, with no separate press and release, map it to the matching `_end` type (`PRESS_END` for short presses, `LONG_PRESS_END` for holds, and so on). This keeps the "button was pressed" trigger consistent across devices without synthesizing events the hardware never sends.
+
+## No migration required
+
+This change only adds the shared constants; nothing is deprecated and no integration is forced to migrate. Custom event types are still allowed alongside the standard ones. Adopt `ButtonEventType` when it fits your device.
+
+For full details, see the [event entity documentation](/docs/core/entity/event).


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Add blogpost for https://github.com/home-assistant/core/pull/177028/
Parent task: https://github.com/home-assistant/core/issues/176682


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [ ] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/177028/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide for standardized `ButtonEventType` interactions, including press, long-press, and multi-press event types.
  * Documented the `multi_press_count` attribute for multi-press scenarios.
  * Provided integration instructions for declaring supported `event_types` and firing events during interactions, including multi-press completion.
  * Clarified how single-event-per-interaction devices should map to the corresponding `_end` type.
  * Confirmed no migration is required; all event types remain optional.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->