### PR TITLE
Clarify documentation regarding Climate entity hvac_action

### DIFF
--- a/docs/core/entity/climate.md
+++ b/docs/core/entity/climate.md
@@ -44,7 +44,8 @@ Properties should always only return information from memory and not do I/O (lik
 The HVAC mode is the behaviour that the device is requested to perform.
 
 You are only allowed to use the built-in HVAC modes, provided by the `HVACMode`
-enum. For behaviour that is not covered by the HVAC modes, add a preset instead.
+enum.
+For device options which modify how one or more of the modes behave, add a preset.
 
 
 | Name                 | Description                                                         |
@@ -59,35 +60,21 @@ enum. For behaviour that is not covered by the HVAC modes, add a preset instead.
 
 ### HVAC action
 
-The HVAC action describes the _current_ action that the device is performing in order to fulfill the requested HVAC mode as determined by the device's thermostat, humidistat, and control algorithms.
-It should be determined based on information reported by the device if possible, or may be calculated if the behaviour of the device is well understood and predictable.
+The HVAC action describes the _current_ action that the device is performing in order to fulfill the requested HVAC mode and preset,
+as determined by the device's own control algorithms.
 
 You are only allowed to use the built-in HVAC actions provided by the `HVACAction` enum.
-If not enough information is available to determine the HVAC action then use the default (`None`).
 
-To help you understand when to use the different HVAC actions, here are some example situations:
+:::note
+It might not be possible to accurately determine the correct HVAC action unless the device reports additional information.
+For example:
 
-- **A thermostat with hysteresis is set to `HVACMode.HEAT`.**
-  When the temperature falls to 0.5°C below the target it starts calling for heat, and the action changes to `HVACAction.HEATING`.
-  When the temperature rises to 0.5°C above the target it stops calling for heat, and the action changes to `HVACAction.IDLE`.
-- **A smart TRV uses a PID algorithm to select between multiple valve positions.**
-  When the valve is closed, the action is `HVACAction.IDLE`.
-  When the valve is open at any position, the action is `HVACAction.HEATING`.
-- **A variable speed air conditioner is set to `HVACMode.COOL`.**
-  When the temperature rises above the target, the device increases speed.
-  When the temperature falls below the target, the device reduces speed.
-  The action remains `HVACAction.COOLING` throughout.
-  If temperature continues to stay below the target for an extended time, the device stops the compressor and fan.
-  The action changes to `HVACAction.IDLE`.
-- **A thermostat in a forced air system periodically circulates air.**
-  It is not currently calling for heating or cooling.
-  When the fan starts, the action changes to `HVACAction.FAN`. When the fan stops, the action changes to `HVACAction.IDLE`.
-- **A split heat pump is set to `HVACMode.HEAT`, and detects ice on the outdoor heat exchanger.**
-  It stops the indoor fan and reverses the direction of the refrigeration loop.
-  The action changes to `HVACAction.DEFROSTING`.
-  Defrosting completes, and the device restores the previous loop direction.
-  It does not start the indoor fan yet because the indoor heat exchanger is still cold.
-  The action changes to `HVACAction.PREHEATING`.
+- A thermostat with hysteresis has an ambiguous temperature range near the target temperature where it may be performing an action or may be idle.
+- A variable power device might continue to operate at a reduced power level after the target temperature is reached, rather than becoming idle.
+
+If the HVAC action cannot be accurately determined, use the default `None`.
+:::
+
 
 | Name                    | Description                                                                                                 |
 | ----------------------- | ----------------------------------------------------------------------------------------------------------- |

--- a/docs/core/entity/climate.md
+++ b/docs/core/entity/climate.md
@@ -72,7 +72,7 @@ For example:
 - A thermostat with hysteresis has an ambiguous temperature range near the target temperature where it may be performing an action or may be idle.
 - A variable power device might continue to operate at a reduced power level after the target temperature is reached, rather than becoming idle.
 
-If the HVAC action cannot be accurately determined, use the default `None`.
+For devices where the HVAC action cannot be accurately determined, use the default `None`.
 :::
 
 

--- a/docs/core/entity/climate.md
+++ b/docs/core/entity/climate.md
@@ -72,7 +72,7 @@ For example:
 - A thermostat with hysteresis has an ambiguous temperature range near the target temperature where it may be performing an action or may be idle.
 - A variable power device might continue to operate at a reduced power level after the target temperature is reached, rather than becoming idle.
 
-For devices where the HVAC action cannot be accurately determined, use the default `None`.
+For devices where the HVAC action cannot be accurately determined, do not implement `hvac_action`.
 :::
 
 

--- a/docs/core/entity/climate.md
+++ b/docs/core/entity/climate.md
@@ -17,9 +17,9 @@ Properties should always only return information from memory and not do I/O (lik
 | current_temperature     | `float \| None`      | `None`                               | The current temperature.                                                   |
 | fan_mode                | `str \| None`        | **Required by ClimateEntityFeature.FAN_MODE**     | The current fan mode.                                                      |
 | fan_modes               | `list[str] \| None`  | **Required by ClimateEntityFeature.FAN_MODE**     | The list of available fan modes.                                           |
-| hvac_action             | `HVACAction \| None` | `None`                               | The current HVAC action (heating, cooling)                                 |
-| hvac_mode               | `HVACMode \| None`   | **Required**                         | The current operation (for example, heat, cool, idle). Used to determine `state`.  |
-| hvac_modes              | `list[HVACMode]`         | **Required**                         | List of available operation modes. See below.                              |
+| hvac_action             | `HVACAction \| None` | `None`                               | The action currently being performed. See below.                                        |
+| hvac_mode               | `HVACMode \| None`   | **Required**                         | The selected operation mode. See below. Used to determine `state`.                      |
+| hvac_modes              | `list[HVACMode]`     | **Required**                         | List of available operation modes. See below.                                           |
 | max_humidity            | `float`                             | `DEFAULT_MAX_HUMIDITY` (value == 99) | The maximum humidity.                                                      |
 | max_temp                | `float`                             | `DEFAULT_MAX_TEMP` (value == 35 °C)  | The maximum temperature in `temperature_unit`.                             |
 | min_humidity            | `float`                             | `DEFAULT_MIN_HUMIDITY` (value == 30) | The minimum humidity.                                                      |
@@ -41,8 +41,10 @@ Properties should always only return information from memory and not do I/O (lik
 
 ### HVAC modes
 
+The HVAC mode is the behaviour that the device is requested to perform.
+
 You are only allowed to use the built-in HVAC modes, provided by the `HVACMode`
-enum. If you want another mode, add a preset instead.
+enum. For behaviour that is not covered by the HVAC modes, add a preset instead.
 
 
 | Name                 | Description                                                         |
@@ -57,18 +59,45 @@ enum. If you want another mode, add a preset instead.
 
 ### HVAC action
 
-The HVAC action describes the _current_ action. This is different from the mode, because if a device is set to heat, and the target temperature is already achieved, the device will not be actively heating anymore. It is only allowed to use the built-in HVAC actions, provided by the `HVACAction` enum.
+The HVAC action is reported by the device, and describes the _current_ action that the device is performing in order to fulfill the requested HVAC mode, as determined by the device's thermostat, humidistat, and control algorithms.
 
-| Name                    | Description           |
-| ----------------------- | --------------------- |
-| `HVACAction.OFF`        | Device is turned off. |
-| `HVACAction.PREHEATING` | Device is preheating. |
-| `HVACAction.HEATING`    | Device is heating.    |
-| `HVACAction.COOLING`    | Device is cooling.    |
-| `HVACAction.DRYING`     | Device is drying.     |
-| `HVACAction.FAN`        | Device has fan on.    |
-| `HVACAction.IDLE`       | Device is idle.       |
-| `HVACAction.DEFROSTING` | Device is defrosting. |
+You are only allowed to use the built-in HVAC actions provided by the `HVACAction` enum.
+If the device does not report enough information to determine the HVAC action then use the default (`None`).
+
+To help you understand when to use the different HVAC actions, here are some example situations:
+
+- **A thermostat with hysteresis is set to `HVACMode.HEAT`.**
+  When the temperature falls to 0.5°C below the target it starts calling for heat, and the action changes to `HVACAction.HEATING`.
+  When the temperature rises to 0.5°C above the target it stops calling for heat, and the action changes to `HVACAction.IDLE`.
+- **A smart TRV uses a PID algorithm to select between multiple valve positions.**
+  When the valve is closed, the action is `HVACAction.IDLE`.
+  When the valve is open at any position, the action is `HVACAction.HEATING`.
+- **A variable speed air conditioner is set to `HVACMode.COOL`.**
+  When the temperature rises above the target, the device increases speed.
+  When the temperature falls below the target, the device reduces speed.
+  The action remains `HVACAction.COOLING` throughout.
+  If temperature continues to stay below the target for an extended time, the device stops the compressor and fan.
+  The action changes to `HVACAction.IDLE`.
+- **A thermostat in a forced air system periodically circulates air.**
+  It is not currently calling for heating or cooling.
+  When the fan starts, the action changes to `HVACAction.FAN`. When the fan stops, the action changes to `HVACAction.IDLE`.
+- **A split heat pump is set to `HVACMode.HEAT`, and detects ice on the outdoor heat exchanger.**
+  It stops the indoor fan and reverses the direction of the refrigeration loop.
+  The action changes to `HVACAction.DEFROSTING`.
+  Defrosting completes, and the device restores the previous loop direction.
+  It does not start the indoor fan yet because the indoor heat exchanger is still cold.
+  The action changes to `HVACAction.PREHEATING`.
+
+| Name                    | Description                                                                                                 |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `HVACAction.OFF`        | HVAC mode is `HVACMode.OFF`. The device will not perform any action unless the mode is changed.             |
+| `HVACAction.PREHEATING` | The device heat source is running, but is not at operating temperature yet.                                 |
+| `HVACAction.HEATING`    | The device is adding heat to the space.                                                                     |
+| `HVACAction.COOLING`    | The device is removing heat from the space.                                                                 |
+| `HVACAction.DRYING`     | The device is removing moisture from the air in the space.                                                  |
+| `HVACAction.FAN`        | The device has fan on to circulate or ventilate air only.                                                   |
+| `HVACAction.IDLE`       | The device is not currently performing any action, but may start performing an action if conditions change. |
+| `HVACAction.DEFROSTING` | The device is removing built up ice.                                                                        |
 
 ### Presets
 

--- a/docs/core/entity/climate.md
+++ b/docs/core/entity/climate.md
@@ -59,10 +59,11 @@ enum. For behaviour that is not covered by the HVAC modes, add a preset instead.
 
 ### HVAC action
 
-The HVAC action is reported by the device, and describes the _current_ action that the device is performing in order to fulfill the requested HVAC mode, as determined by the device's thermostat, humidistat, and control algorithms.
+The HVAC action describes the _current_ action that the device is performing in order to fulfill the requested HVAC mode as determined by the device's thermostat, humidistat, and control algorithms.
+It should be determined based on information reported by the device if possible, or may be calculated if the behaviour of the device is well understood and predictable.
 
 You are only allowed to use the built-in HVAC actions provided by the `HVACAction` enum.
-If the device does not report enough information to determine the HVAC action then use the default (`None`).
+If not enough information is available to determine the HVAC action then use the default (`None`).
 
 To help you understand when to use the different HVAC actions, here are some example situations:
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The description of HVAC action contained an example which was not clearly labeled as an example, and that caused some confusion due to people thinking it was instructions on how the attribute should be implemented.

I've adjusted the wording to make it clear that the `hvac_action` is intended to represent the current action that the device is performing, as reported by the device, and according to the device's own control algorithms. An explicit instruction is added saying it should be left as `None` for devices which do not report enough information to determine the `hvac_action`.

To help integration implementors, I have added a series of example situations and described the expected `hvac_action` during those situations. This includes a thermostat with hysteresis (replacing the previous extremely simple thermostat example) along with several other types of devices.

I have clarified the wording in the descriptions of the enum values to avoid language/translation issues regarding the interpretation of the word "idle".


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

This PR is based on a discussion I had on Discord regarding some changes that had been made in the HACS "Midea Smart AC" (midea-ac-py) integration. See the discussion starting at https://discord.com/channels/330944238910963714/554842238073700352/1530292994782134362

What prompted this was that the integration began to calculate the HVAC Action by comparing the `target_temperature` and `current_temperature`, assuming the text "if a device is set to heat, and the target temperature is already achieved, the device will not be actively heating anymore." was prescriptive instructions on how to determine the `hvac_action` value. Additionally, there were some communication issues resulting from interpretation or translation of the word "idle" across language barriers. Discussion of this issue can be seen at https://github.com/mill1000/midea-ac-py/issues/449 and on some of the related PRs, although be warned that it got a bit argumentative at times.

LLM assistance was not used in this PR—any mistakes are my own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated guidance on HVAC action reporting to clarify when `hvac_action` should be omitted if it can’t be determined.
  - Refined distinctions between HVAC action, HVAC mode, and supported HVAC modes.
  - Reworded the HVAC modes section to reinforce using built-in `HVACMode` values and presets for out-of-scope behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->