### PR TITLE
Document shared frontend output locking

### DIFF
--- a/docs/frontend/development.md
+++ b/docs/frontend/development.md
@@ -216,7 +216,7 @@ Each dev server listens on its own port:
 | `yarn dev:gallery`      | 8100 | The [design gallery](/docs/frontend/design).                             |
 | `yarn test:e2e:app:dev` | 8095 | The stripped-down app used by the [end-to-end tests](#end-to-end-tests). |
 
-Development servers for different suites can run at the same time. Their startup phases are serialised while they regenerate shared files under `build/`, then each server uses a private snapshot of those files. A build or development server cannot start while another process owns the same suite's output directory. In particular, `yarn dev` and `yarn dev:serve` both own the app output under `hass_frontend/` and cannot run together.
+Only one supported build or development workflow can run at a time. If another workflow is active, the command exits without starting a second process and reports the commands to inspect or stop the active workflow.
 
 :::note
 When a coding agent is detected, `yarn dev:*` runs in the background automatically so it does not block the agent's session. Set `HA_DEV_BACKGROUND=0` to force the dev server to run in the foreground.
@@ -347,7 +347,7 @@ yarn build --stop          # stop a running background build
 Use `yarn build --modern` when packaging, bundle-size, or browser performance work only needs the modern `frontend_latest` bundle. Add `--background` to run the modern-only build as a managed background process.
 
 :::caution
-Production builds cannot run at the same time as `yarn dev` or `yarn dev:serve` because they all write the app output under `hass_frontend/`. Stop the running command with its corresponding `--stop` flag before starting another one. Other suites can keep running while a frontend build waits for its turn to regenerate shared files under `build/`.
+Production builds and development servers cannot run at the same time. Stop the active workflow with its corresponding `--stop` command before starting another one.
 :::
 
 To test it out inside Home Assistant, run the following command from the main Home Assistant repository:

--- a/docs/frontend/development.md
+++ b/docs/frontend/development.md
@@ -216,7 +216,7 @@ Each dev server listens on its own port:
 | `yarn dev:gallery`      | 8100 | The [design gallery](/docs/frontend/design).                             |
 | `yarn test:e2e:app:dev` | 8095 | The stripped-down app used by the [end-to-end tests](#end-to-end-tests). |
 
-Only one supported build or development workflow can run at a time. If another workflow is active, the command exits without starting a second process and reports the commands to inspect or stop the active workflow.
+These managed Yarn development workflows, together with `yarn build` and `yarn build --modern`, share one workflow lock. Starting the same development workflow again reports the running server and succeeds. Starting another managed workflow while one is active is blocked and reports the active workflow with the relevant status, logs, or stop command.
 
 :::note
 When a coding agent is detected, `yarn dev:*` runs in the background automatically so it does not block the agent's session. Set `HA_DEV_BACKGROUND=0` to force the dev server to run in the foreground.
@@ -347,7 +347,7 @@ yarn build --stop          # stop a running background build
 Use `yarn build --modern` when packaging, bundle-size, or browser performance work only needs the modern `frontend_latest` bundle. Add `--background` to run the modern-only build as a managed background process.
 
 :::caution
-Production builds and development servers cannot run at the same time. Stop the active workflow with its corresponding `--stop` command before starting another one.
+Managed production builds and development servers cannot run at the same time. Stop the active managed workflow with its corresponding `--stop` command before starting another one.
 :::
 
 To test it out inside Home Assistant, run the following command from the main Home Assistant repository:

--- a/docs/frontend/development.md
+++ b/docs/frontend/development.md
@@ -216,6 +216,8 @@ Each dev server listens on its own port:
 | `yarn dev:gallery`      | 8100 | The [design gallery](/docs/frontend/design).                             |
 | `yarn test:e2e:app:dev` | 8095 | The stripped-down app used by the [end-to-end tests](#end-to-end-tests). |
 
+Development servers for different suites can run at the same time. Their startup phases are serialised while they regenerate shared files under `build/`, then each server uses a private snapshot of those files. A build or development server cannot start while another process owns the same suite's output directory. In particular, `yarn dev` and `yarn dev:serve` both own the app output under `hass_frontend/` and cannot run together.
+
 :::note
 When a coding agent is detected, `yarn dev:*` runs in the background automatically so it does not block the agent's session. Set `HA_DEV_BACKGROUND=0` to force the dev server to run in the foreground.
 
@@ -345,7 +347,7 @@ yarn build --stop          # stop a running background build
 Use `yarn build --modern` when packaging, bundle-size, or browser performance work only needs the modern `frontend_latest` bundle. Add `--background` to run the modern-only build as a managed background process.
 
 :::caution
-Production builds cannot run at the same time as `yarn dev` or `yarn dev:serve`. These commands share generated files under `build/` and `hass_frontend/`. Stop the running command with its corresponding `--stop` flag before starting another one.
+Production builds cannot run at the same time as `yarn dev` or `yarn dev:serve` because they all write the app output under `hass_frontend/`. Stop the running command with its corresponding `--stop` flag before starting another one. Other suites can keep running while a frontend build waits for its turn to regenerate shared files under `build/`.
 :::
 
 To test it out inside Home Assistant, run the following command from the main Home Assistant repository:

--- a/docs/frontend/development.md
+++ b/docs/frontend/development.md
@@ -347,7 +347,7 @@ yarn build --stop          # stop a running background build
 Use `yarn build --modern` when packaging, bundle-size, or browser performance work only needs the modern `frontend_latest` bundle. Add `--background` to run the modern-only build as a managed background process.
 
 :::caution
-Managed production builds and development servers cannot run at the same time. Stop the active managed workflow with its corresponding `--stop` command before starting another one.
+A managed production build cannot run at the same time as a managed development server. Before starting a different managed workflow, stop the active workflow with its corresponding `--stop` command.
 :::
 
 To test it out inside Home Assistant, run the following command from the main Home Assistant repository:


### PR DESCRIPTION
## Summary

- document shared locking for managed frontend Yarn workflows
- clarify that conflicting managed workflows report the active workflow and relevant lifecycle command
- document same-suite development starts as idempotent

Documents the locking behaviour introduced by home-assistant/frontend#53396.

Stacked on #3275.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented workflow locking for managed development servers and production builds.
  * Clarified behavior when rerunning an existing workflow or starting another active workflow.
  * Updated build warnings to cover conflicts across all managed workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->