### PR TITLE
Document support for translated release notes messages in update entities

### DIFF
--- a/blog/2026-08-04-update-release-notes-messages.md
+++ b/blog/2026-08-04-update-release-notes-messages.md
@@ -1,0 +1,93 @@
+---
+author: Jan-Philipp Benecke
+authorURL: https://github.com/jpbede
+authorImageURL: https://avatars.githubusercontent.com/u/3989428?s=96&v=4
+title: "Translated release notes messages for update entities"
+---
+
+Update entities can now provide translated alert messages that Home Assistant shows before the full release notes. Integrations can use these messages for static update guidance, such as warning users not to interrupt a firmware update or explaining that battery powered devices may need to be woken up before an update can start.
+
+Previously, integrations that needed this kind of guidance often built `<ha-alert>` markup directly inside `release_notes()` or `async_release_notes()`. That duplicated wording across integrations, kept the text in English, and mixed static guidance with the actual release notes returned by the device or service.
+
+You can now use `release_notes_messages` for this guidance. Shared messages are available for common cases, and integration-specific messages can be defined with `UpdateReleaseNotesMessage`.
+
+<!--truncate-->
+
+## Shared messages
+
+For common update guidance, use the predefined messages exported by the update platform:
+
+```python
+from homeassistant.components.update import (
+    RELEASE_NOTES_MESSAGE_BATTERY_POWERED,
+    RELEASE_NOTES_MESSAGE_DO_NOT_INTERRUPT,
+    UpdateEntity,
+)
+
+
+class MyFirmwareUpdate(UpdateEntity):
+    _attr_release_notes_messages = (
+        RELEASE_NOTES_MESSAGE_BATTERY_POWERED,
+        RELEASE_NOTES_MESSAGE_DO_NOT_INTERRUPT,
+    )
+```
+
+These messages are translated by the update platform and rendered before the release notes returned by `release_notes()` or `async_release_notes()`.
+
+## Entity description support
+
+For static update entities, messages can also be defined on `UpdateEntityDescription`:
+
+```python
+from homeassistant.components.update import (
+    RELEASE_NOTES_MESSAGE_DO_NOT_INTERRUPT,
+    UpdateEntityDescription,
+)
+
+UPDATE_DESCRIPTION = UpdateEntityDescription(
+    key="firmware",
+    release_notes_messages=(RELEASE_NOTES_MESSAGE_DO_NOT_INTERRUPT,),
+)
+```
+
+## Integration-specific messages
+
+Integrations can define their own translated messages when the guidance is specific to the integration:
+
+```python
+from homeassistant.components.update import (
+    UpdateReleaseNotesMessage,
+    UpdateReleaseNotesMessageSeverity,
+)
+
+from .const import DOMAIN
+
+RELEASE_NOTES_MESSAGE_NON_MAIN_NET_UPDATE_SOURCE = UpdateReleaseNotesMessage(
+    translation_domain=DOMAIN,
+    translation_key="non_main_net_update_source",
+    severity=UpdateReleaseNotesMessageSeverity.WARNING,
+)
+```
+
+The translation lives in the integration's `strings.json` under `entity.update.release_notes_messages`:
+
+```json
+{
+  "entity": {
+    "update": {
+      "release_notes_messages": {
+        "non_main_net_update_source": "This update is not provided by the device's main update source. Only install it if you trust the source."
+      }
+    }
+  }
+}
+```
+
+Messages support `translation_placeholders` for values such as documentation URLs.
+
+## Rendering
+
+Home Assistant renders each message as an `<ha-alert>` before the release notes and returns the same markdown/html string over the existing `update/release_notes` websocket command.
+Integrations should return only the actual release notes from `release_notes()` or `async_release_notes()` and put static guidance in `release_notes_messages`.
+
+See the [update entity developer documentation](/docs/core/entity/update#release-notes-messages) for details.

--- a/blog/2026-08-04-update-release-notes-messages.md
+++ b/blog/2026-08-04-update-release-notes-messages.md
@@ -5,7 +5,7 @@ authorImageURL: https://avatars.githubusercontent.com/u/3989428?s=96&v=4
 title: "Translated release notes messages for update entities"
 ---
 
-Update entities can now provide translated alert messages that Home Assistant shows before the full release notes. Integrations can use these messages for static update guidance, such as warning users not to interrupt a firmware update or explaining that battery powered devices may need to be woken up before an update can start.
+Update entities can now provide translated alert messages that Home Assistant shows before the full release notes. Integrations can use these messages for static update guidance, such as warning users not to interrupt a firmware update or explaining that battery-powered devices may need to be woken up before an update can start.
 
 Previously, integrations that needed this kind of guidance often built `<ha-alert>` markup directly inside `release_notes()` or `async_release_notes()`. That duplicated wording across integrations, kept the text in English, and mixed static guidance with the actual release notes returned by the device or service.
 

--- a/docs/core/entity/update.md
+++ b/docs/core/entity/update.md
@@ -30,6 +30,7 @@ Properties should always only return information from memory and not do I/O (lik
 | latest_version | str | `None` | The latest version of the software available.
 | release_summary | str | `None` | Summary of the release notes or changelog. This is not suitable for long changelogs but merely suitable for a short excerpt update description of max 255 characters.
 | release_url | str | `None` | URL to the full release notes of the latest version available.
+| release_notes_messages | tuple[UpdateReleaseNotesMessage, ...] | `()` | Translated alert messages shown before the full release notes. This is for static update guidance, not for translating the release notes themselves.
 | title | str | `None` | Title of the software. This helps to differentiate between the device or entity name versus the title of the software installed.
 | update_percentage | int, float | `None` | Update installation progress. Can either return a number to indicate the progress from 0 to 100% or None.
 
@@ -122,6 +123,79 @@ class MyUpdate(UpdateEntity):
         """Return the release notes."""
         return "Lorem ipsum"
 ```
+
+#### Release notes messages
+
+Use `release_notes_messages` when the update needs static guidance shown before the release notes, for example that a battery powered device may need to be woken up or that power must not be removed during installation. Home Assistant renders these messages as alerts before the value returned by `release_notes()` or `async_release_notes()`.
+
+This is only for guidance that accompanies release notes. The release notes themselves should still be returned by `release_notes()` or `async_release_notes()`.
+
+For shared update guidance, use the predefined messages exported by the update platform:
+
+```python
+from homeassistant.components.update import (
+    RELEASE_NOTES_MESSAGE_BATTERY_POWERED,
+    RELEASE_NOTES_MESSAGE_DO_NOT_INTERRUPT,
+    UpdateEntity,
+)
+
+
+class MyUpdate(UpdateEntity):
+    _attr_release_notes_messages = (
+        RELEASE_NOTES_MESSAGE_BATTERY_POWERED,
+        RELEASE_NOTES_MESSAGE_DO_NOT_INTERRUPT,
+    )
+```
+
+For static cases, `UpdateEntityDescription` also accepts `release_notes_messages`:
+
+```python
+from homeassistant.components.update import (
+    RELEASE_NOTES_MESSAGE_DO_NOT_INTERRUPT,
+    UpdateEntityDescription,
+)
+
+UPDATE_DESCRIPTION = UpdateEntityDescription(
+    key="firmware",
+    release_notes_messages=(RELEASE_NOTES_MESSAGE_DO_NOT_INTERRUPT,),
+)
+```
+
+Integrations can define their own translated messages with `UpdateReleaseNotesMessage`:
+
+```python
+from homeassistant.components.update import (
+    UpdateReleaseNotesMessage,
+    UpdateReleaseNotesMessageSeverity,
+)
+
+from .const import DOMAIN
+
+RELEASE_NOTES_MESSAGE_NETWORK_RELIABILITY = UpdateReleaseNotesMessage(
+    translation_domain=DOMAIN,
+    translation_key="network_reliability",
+    severity=UpdateReleaseNotesMessageSeverity.WARNING,
+    translation_placeholders={
+        "zha_docs_network_reliability": ZHA_DOCS_NETWORK_RELIABILITY,
+    },
+)
+```
+
+Integration-specific messages are translated from the integration's `strings.json` under `entity.update.release_notes_messages`:
+
+```json
+{
+  "entity": {
+    "update": {
+      "release_notes_messages": {
+        "network_reliability": "If you are having issues updating a specific device, make sure that you have eliminated [common environmental issues]({zha_docs_network_reliability}) that could affect network reliability. OTA updates require a reliable network."
+      }
+    }
+  }
+}
+```
+
+By default, messages render as informational alerts. Set `severity` to `UpdateReleaseNotesMessageSeverity.WARNING` or `UpdateReleaseNotesMessageSeverity.ERROR` when the message needs stronger emphasis.
 
 ### Available device classes
 

--- a/docs/core/entity/update.md
+++ b/docs/core/entity/update.md
@@ -126,7 +126,7 @@ class MyUpdate(UpdateEntity):
 
 #### Release notes messages
 
-Use `release_notes_messages` when the update needs static guidance shown before the release notes, for example that a battery powered device may need to be woken up or that power must not be removed during installation. Home Assistant renders these messages as alerts before the value returned by `release_notes()` or `async_release_notes()`.
+Use `release_notes_messages` when the update needs static guidance shown before the release notes, for example that a battery-powered device may need to be woken up or that power must not be removed during installation. Home Assistant renders these messages as alerts before the value returned by `release_notes()` or `async_release_notes()`.
 
 This is only for guidance that accompanies release notes. The release notes themselves should still be returned by `release_notes()` or `async_release_notes()`.
 
@@ -176,7 +176,10 @@ RELEASE_NOTES_MESSAGE_NETWORK_RELIABILITY = UpdateReleaseNotesMessage(
     translation_key="network_reliability",
     severity=UpdateReleaseNotesMessageSeverity.WARNING,
     translation_placeholders={
-        "zha_docs_network_reliability": ZHA_DOCS_NETWORK_RELIABILITY,
+        "zha_docs_network_reliability": (
+            "https://www.home-assistant.io/integrations/zha/"
+            "#zigbee-interference-avoidance-and-network-rangecoverage-optimization"
+        ),
     },
 )
 ```


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Update entity documentation and blog post for new translateable release notes messages from https://github.com/home-assistant/core/pull/178125

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/178125


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Documented translated guidance messages displayed before update release notes.
  - Added guidance for predefined and integration-specific messages, severity levels, translation placeholders, rendering behavior, and websocket output.
  - Documented configuration of `release_notes_messages` for update entities.
  - Clarified that static guidance should remain separate from release-note methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->