### PR TITLE
Clarify that quality scale update is not fully automated

### DIFF
--- a/docs/documenting/create-page.md
+++ b/docs/documenting/create-page.md
@@ -75,7 +75,7 @@ The following keys are available for the integration page file header:
   - `zwave`: Products connect through Z-Wave.
 - `ha_mqtt`: Set to `true` if the integration supports discovery via MQTT, omit otherwise.
 - `ha_platforms`: This entry lists all implemented [platforms](/docs/creating_platform_index).
-- `ha_quality_scale`: The integration's rating on the [quality scale](https://www.home-assistant.io/docs/quality_scale/) (such as bronze, silver, gold, platinum, or internal). For new integrations, set this to `bronze`. This field is automatically updated when the integration's quality level changes in Core. You don't need to update this manually in the documentation.
+- `ha_quality_scale`: The integration's rating on the [quality scale](https://www.home-assistant.io/docs/quality_scale/) (such as bronze, silver, gold, platinum, or internal). For new integrations, set this to `bronze`. This field is updated during documentation syncs from the Core codebase. You normally do not need to update it manually in the documentation.
 - `ha_release`: The Home Assistant release when the integration was included.
   - If the current release is 2025.8, make `ha_release` 2025.9.
   - For the October release, as in '2025.10', quote it with `' '`, otherwise the zero won't be displayed.


### PR DESCRIPTION
## Proposed change

The development docs incorrectly state the quality score in docs is automatically updated **when the quality changes in Core**. Clarify it isn't updated immediately.

When it happened in 2025-2026:

- 2026-07-01 - Franck: <https://github.com/home-assistant/home-assistant.io/commit/837da912c3847c86edae0ca5a76661c5bb009111>
- 2026-01-28 - Franck: <https://github.com/home-assistant/home-assistant.io/commit/e0944d3cb155139af23dd5b9698ff86233b6e575>
- 2025-11-05 - Franck: <https://github.com/home-assistant/home-assistant.io/commit/9d69329a92e5fefcf78c65f7811834ef84197063>
- 2025-07-01 - tronikos: <https://github.com/home-assistant/home-assistant.io/commit/878cea027d9b98ab38b3504ae6440a38edc47ab1>
- 2025-05-26 - Franck: <https://github.com/home-assistant/home-assistant.io/commit/c0263c51bd93c80147f42e932d541b4921a0aff7>
- 2025-02-26 - Franck: <https://github.com/home-assistant/home-assistant.io/commit/cb6c735dd55dc89ec8f57ba0f53e84d5457ca4fa>
- 2025-02-05 - Franck: <https://github.com/home-assistant/home-assistant.io/commit/09b78b22541ef889bed85216a3f736f49b7678c7>

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the `ha_quality_scale` field is synchronized from the Core codebase and typically does not require manual documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->