### PR TITLE
Adapt config entry migration

### DIFF
--- a/blog/2026-09-03-Use-config-entry-exc-in-migration.md
+++ b/blog/2026-09-03-Use-config-entry-exc-in-migration.md
@@ -1,0 +1,40 @@
+---
+author: G Johansson
+authorURL: https://github.com/gjohansson-ST
+authorImageURL: https://avatars.githubusercontent.com/u/62932417?v=4
+authorTwitter: GJohansson
+title: "Deprecating config entry listener with reloading methods in config flow"
+---
+
+Integration migration method can now raise config entry exceptions instead of only being limited to return `False`. This is useful to provide more context and additionally being translatable.
+
+Additionally by raising `ConfigEntryNotReady` it will automatically try again later (same as during setup).
+
+More info in the [config flow documentation](/docs/core/integration/config_flow#handle-returns-raise-exceptions-in-migrations).
+
+```python
+# Example migration function which raises if client has issue
+async def async_migrate_entry(hass, config_entry: ConfigEntry):
+    """Migrate old entry."""
+    _LOGGER.debug("Migrating configuration from version %s.%s", config_entry.version, config_entry.minor_version)
+
+    if config_entry.version == 1:
+        
+        try:
+            new_info = await client.get_info()
+        except SomeException:
+            raise ConfigEntryNotReady(
+                translation_key="key",
+                translation_domain=DOMAIN,
+            ) from exc
+        new_data = {**config_entry.data, "some_data": new_info["some_data"]}
+        pass
+
+        hass.config_entries.async_update_entry(
+            config_entry, data=new_data, version=2
+        )
+
+    _LOGGER.debug("Migration to configuration version %s.%s successful", config_entry.version, config_entry.minor_version)
+
+    return True
+```

--- a/blog/2026-09-03-Use-config-entry-exc-in-migration.md
+++ b/blog/2026-09-03-Use-config-entry-exc-in-migration.md
@@ -3,12 +3,13 @@ author: G Johansson
 authorURL: https://github.com/gjohansson-ST
 authorImageURL: https://avatars.githubusercontent.com/u/62932417?v=4
 authorTwitter: GJohansson
-title: "Deprecating config entry listener with reloading methods in config flow"
+title: "Use Config Entry exceptions in integration migration method"
 ---
 
-Integration migration method can now raise config entry exceptions instead of only being limited to return `False`. This is useful to provide more context and additionally being translatable.
+Integration migration method can now raise config entry exceptions instead of only being limited to return `False`. This is preferred over only returning `False` to provide more context and being translatable.
 
-Additionally by raising `ConfigEntryNotReady` it will automatically try again later (same as during setup).
+For integrations collecting information from other services during migration, 
+by raising `ConfigEntryNotReady` it will automatically try again later (same as during setup) which can help for timeouts or other exceptions when it can be useful to just wait a bit and try again.
 
 More info in the [config flow documentation](/docs/core/integration/config_flow#handle-returns-raise-exceptions-in-migrations).
 

--- a/docs/core/integration/config_flow.md
+++ b/docs/core/integration/config_flow.md
@@ -236,6 +236,22 @@ Each config entry has a version assigned to it, made up of a major and a minor v
 
 Migration can be handled programmatically by implementing function `async_migrate_entry` in your integration's `__init__.py` file. The function should return `True` if migration is successful.
 
+### Handle returns, raise exceptions in migrations
+
+| Returns / Raises | Description |
+| return `True`               | Migration successful, setup continues                            |
+| return `False`              | Migration not successful, setup stops with config entry state `migration_error` |
+| raise `ConfigEntryNotReady` | Migration not successful, setup stops and will retry later                          |
+| raise `Exception`           | Migration not successful, setup stops with config entry state `migration_error` |
+
+:::note
+By raising `ConfigEntryNotReady` (if a retry is wanted) or `HomeAssistantError` instead of returning `False`, you can provide more context to the user by using the translations provided by using those exceptions.
+:::
+
+:::tip
+Config entry state `migration_error` is non-recoverable, if the user can do something to fix the problem, use a repair which can reload the integration once the user has acted on it. Otherwise the user needs to restart Home Assistant to try again.
+:::
+
 If minor versions differ but major versions are the same, integration setup will be allowed to continue even if the integration does not implement `async_migrate_entry`. This means a minor version bump is backwards compatible unlike a major version bump which causes the integration to fail setup if the user downgrades Home Assistant Core without restoring their configuration from backup.
 
 To set a new version, add `VERSION` and/or `MINOR_VERSION` to your config flow class:

--- a/docs/core/integration/config_flow.md
+++ b/docs/core/integration/config_flow.md
@@ -239,6 +239,7 @@ Migration can be handled programmatically by implementing function `async_migrat
 ### Handle returns, raise exceptions in migrations
 
 | Returns / Raises | Description |
+| ---------------- | ----------- |
 | return `True`               | Migration successful, setup continues                            |
 | return `False`              | Migration not successful, setup stops with config entry state `migration_error` |
 | raise `ConfigEntryNotReady` | Migration not successful, setup stops and will retry later                          |


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Adapt config entry migration to https://github.com/home-assistant/core/pull/175349 and https://github.com/home-assistant/core/pull/182054

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [ ] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/175349


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Documented how migration outcomes affect setup, including continuation, failure, and automatic retries.
  - Added guidance on using configuration entry exceptions for clearer user-facing errors and translated messages.
  - Explained when to create repairs for non-recoverable migration errors and how repairs can retry migrations.
  - Added examples covering connection failures, authentication failures, data updates, and repair flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->