### PR TITLE
Document status on CalendarEvent

### DIFF
--- a/docs/core/entity/calendar.md
+++ b/docs/core/entity/calendar.md
@@ -202,18 +202,13 @@ A `CalendarEvent` represents an individual event on a calendar.
 | uid | string | `None` | A unique identifier for the event (required for mutations) |
 | recurrence_id | string | `None` | An optional identifier for a specific instance of a recurring event (required for mutations of recurring events) |
 | rrule |  string | `None` | A recurrence rule string, for example, `FREQ=DAILY` |
-| status | `CalendarEventStatus` | `None` | The rfc5545 status of the event, one of `confirmed`, `tentative`, or `cancelled`. Leave unset when the calendar does not report a status, which is not the same as a confirmed event. |
+| status | `CalendarEventStatus` | `None` | The status of the event, either `confirmed` or `tentative`. Leave unset when the calendar does not report a status, which is not the same as a confirmed event. |
 
 ### Event status
 
-The `status` of an event is the rfc5545 `STATUS` property. An integration reports the status its calendar reports, and leaves it unset when the calendar does not provide one. An unset status is not the same as a confirmed event, so consumers should not treat it as one.
+The `status` of an event is a subset of the rfc5545 `STATUS` property. An integration reports the status its calendar reports, and leaves it unset when the calendar does not provide one. An unset status is not the same as a confirmed event, so consumers should not treat it as one.
 
-An integration does not hide events because of their status. Whether a cancelled event is shown, hidden, or styled differently is a presentation decision, and it belongs to the consumer rather than to the integration.
-
-Calendar systems differ in what a cancelled event means, which affects what an integration is able to report:
-
-- In rfc5545, `CANCELLED` describes the status of an event rather than its removal, so a calendar can keep the event and report that status. CalDAV and iCalendar sources commonly do, and those events are reported with a status of `cancelled`.
-- In the Google Calendar API, `cancelled` marks an event as deleted. `gcal_sync` drops those events when it builds the timeline, so the integration only reports `confirmed` or `tentative`.
+A calendar entity does not return cancelled events, so `cancelled` is not part of the supported set. Where a source keeps cancelled events instead of deleting them, the integration filters them out rather than reporting them with a status.
 
 ## Color management
 

--- a/docs/core/entity/calendar.md
+++ b/docs/core/entity/calendar.md
@@ -212,8 +212,8 @@ An integration does not hide events because of their status. Whether a cancelled
 
 Calendar systems differ in what a cancelled event means, which affects what an integration is able to report:
 
-- Under rfc5545 a cancelled event stays in the calendar, so CalDAV and iCalendar sources report it with a status of `cancelled`.
-- The Google Calendar API uses `cancelled` to mean deleted, and such events are already dropped before they reach the integration, which therefore only reports `confirmed` or `tentative`.
+- In rfc5545, `CANCELLED` describes the status of an event rather than its removal, so a calendar can keep the event and report that status. CalDAV and iCalendar sources commonly do, and those events are reported with a status of `cancelled`.
+- In the Google Calendar API, `cancelled` marks an event as deleted. `gcal_sync` drops those events when it builds the timeline, so the integration only reports `confirmed` or `tentative`.
 
 ## Color management
 

--- a/docs/core/entity/calendar.md
+++ b/docs/core/entity/calendar.md
@@ -202,6 +202,7 @@ A `CalendarEvent` represents an individual event on a calendar.
 | uid | string | `None` | A unique identifier for the event (required for mutations) |
 | recurrence_id | string | `None` | An optional identifier for a specific instance of a recurring event (required for mutations of recurring events) |
 | rrule |  string | `None` | A recurrence rule string, for example, `FREQ=DAILY` |
+| status | `CalendarEventStatus` | `None` | The rfc5545 status of the event, one of `confirmed`, `tentative`, or `cancelled`. Leave unset when the calendar does not report a status, which is not the same as a confirmed event. |
 
 ## Color management
 

--- a/docs/core/entity/calendar.md
+++ b/docs/core/entity/calendar.md
@@ -208,7 +208,7 @@ A `CalendarEvent` represents an individual event on a calendar.
 
 The `status` of an event is a subset of the rfc5545 `STATUS` property. An integration reports the status its calendar reports, and leaves it unset when the calendar does not provide one. An unset status is not the same as a confirmed event, so consumers should not treat it as one.
 
-A calendar entity does not return cancelled events, so `cancelled` is not part of the supported set. Where a source keeps cancelled events instead of deleting them, the integration filters them out rather than reporting them with a status.
+A calendar entity does not return cancelled events, so `cancelled` is not part of the supported set.
 
 ## Color management
 

--- a/docs/core/entity/calendar.md
+++ b/docs/core/entity/calendar.md
@@ -204,6 +204,17 @@ A `CalendarEvent` represents an individual event on a calendar.
 | rrule |  string | `None` | A recurrence rule string, for example, `FREQ=DAILY` |
 | status | `CalendarEventStatus` | `None` | The rfc5545 status of the event, one of `confirmed`, `tentative`, or `cancelled`. Leave unset when the calendar does not report a status, which is not the same as a confirmed event. |
 
+### Event status
+
+The `status` of an event is the rfc5545 `STATUS` property. An integration reports the status its calendar reports, and leaves it unset when the calendar does not provide one. An unset status is not the same as a confirmed event, so consumers should not treat it as one.
+
+An integration does not hide events because of their status. Whether a cancelled event is shown, hidden, or styled differently is a presentation decision, and it belongs to the consumer rather than to the integration.
+
+Calendar systems differ in what a cancelled event means, which affects what an integration is able to report:
+
+- Under rfc5545 a cancelled event stays in the calendar, so CalDAV and iCalendar sources report it with a status of `cancelled`.
+- The Google Calendar API uses `cancelled` to mean deleted, and such events are already dropped before they reach the integration, which therefore only reports `confirmed` or `tentative`.
+
 ## Color management
 
 Calendar entities can optionally provide a default color for display in the frontend by setting `initial_color` to a hex color string (e.g., `"#16a765"`). This color is automatically stored in entity registry options when the entity is first added and can be customized by users through the entity settings UI.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Document the `status` field added to `CalendarEvent`. It carries the RFC 5545 event status, so an integration can report whether an event is confirmed, tentative, or cancelled.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [X] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [X] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [X] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/179312


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

- Documented the optional calendar event status field.
- Listed supported statuses: confirmed and tentative.
- Clarified that an unset status indicates the source does not provide one and does not imply confirmation.
- Explained that cancelled events are not supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->