### PR TITLE
Document per-mount disk usage in the Supervisor API

### DIFF
--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -2042,12 +2042,17 @@ directories appears at 2, and every level below that needs one more.
 
 When a mount lists children, an `other` child carries whatever the walk did not
 attribute to a directory: files directly at the mount root, reserved space, and
-entries that could not be read. It is left out when that remainder is not
-positive, so the children of a node always sum to its own `used_bytes`.
+entries that could not be read. When that remainder is positive, the children of
+a node sum exactly to its own `used_bytes`. If the filesystem changes while it
+is being walked, the directory totals can exceed `used_bytes`; in that case
+`other` is left out.
 
-Requesting usage for a mount which does not exist returns a `404`. Requesting it
-for a mount which is not active returns a `400`, as does a mount which cannot be
-read or which does not answer within 60 seconds.
+Requesting usage for a mount which does not exist returns a `404`. A `400` is
+returned for a mount which is not active, is no longer actually mounted even
+though its unit still reports active, cannot be read, or whose usage probe has
+not completed within 60 seconds. The probe keeps running after that timeout, so
+retrying the request joins the probe already underway instead of starting a new
+one.
 
 **Example response:**
 

--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -2025,58 +2025,106 @@ Shutdown the host
 <ApiEndpoint path="/host/disks/<disk>/usage" method="get">
 Get detailed disk usage information in bytes.
 
-The only supported `disk` for now is "default". It will return usage info for the data disk.
+`disk` selects what is measured. Use `default` for the data disk, or the name of a
+mount to measure that mount. `default` always addresses the data disk, so a mount
+of that name cannot be reached through this endpoint.
 
-Supports an optional `max_depth` query param. Defaults to 1
+Supports an optional `max_depth` query param, which controls how far the breakdown
+goes. It defaults to 1 for the data disk and 0 for a mount.
+
+The data disk reports its known top-level paths as children, and `max_depth`
+controls how far the breakdown continues inside them.
+
+A mount has no such fixed layer, so it is measured by walking its directories, and
+a directory is only listed while more than one level of depth remains. A
+`max_depth` of 0 or 1 therefore returns totals only, the first level of
+directories appears at 2, and every level below that needs one more.
+
+When a mount lists children, an `other` child carries whatever the walk did not
+attribute to a directory: files directly at the mount root, reserved space, and
+entries that could not be read. It is left out when that remainder is not
+positive, so the children of a node always sum to its own `used_bytes`.
+
+Requesting usage for a mount which does not exist returns a `404`. Requesting it
+for a mount which is not active returns a `400`, as does a mount which cannot be
+read or which does not answer within 60 seconds.
 
 **Example response:**
 
 ```json
 {
   "id": "root",
-  "label": "Default",
-  "total_space": 503312781312,
-  "used_space": 430245011456,
+  "label": "Root",
+  "total_bytes": 503312781312,
+  "used_bytes": 430245011456,
   "children": [
     {
       "id": "system",
       "label": "System",
-      "used_space": 75660903137
+      "used_bytes": 75660903137
     },
     {
       "id": "addons_data",
       "label": "Addons data",
-      "used_space": 42349200762
+      "used_bytes": 42349200762
     },
     {
       "id": "addons_config",
       "label": "Addons configuration",
-      "used_space": 5283318814
+      "used_bytes": 5283318814
     },
     {
       "id": "media",
       "label": "Media",
-      "used_space": 476680019
+      "used_bytes": 476680019
     },
     {
       "id": "share",
       "label": "Share",
-      "used_space": 37477206419
+      "used_bytes": 37477206419
     },
     {
       "id": "backup",
       "label": "Backup",
-      "used_space": 268350699520
+      "used_bytes": 268350699520
     },
     {
       "id": "ssl",
       "label": "SSL",
-      "used_space": 202912633
+      "used_bytes": 202912633
     },
     {
       "id": "homeassistant",
       "label": "Home assistant",
-      "used_space": 444090152
+      "used_bytes": 444090152
+    }
+  ]
+}
+```
+
+**Example response for a mount**, requested with `max_depth=2`:
+
+```json
+{
+  "id": "media_nas",
+  "label": "media_nas",
+  "total_bytes": 2000398934016,
+  "used_bytes": 1240247081779,
+  "children": [
+    {
+      "id": "music",
+      "label": "music",
+      "used_bytes": 402653184000
+    },
+    {
+      "id": "movies",
+      "label": "movies",
+      "used_bytes": 800000000000
+    },
+    {
+      "id": "other",
+      "label": "Other",
+      "used_bytes": 37593897779
     }
   ]
 }

--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -2044,8 +2044,9 @@ When a mount lists children, an `other` child carries whatever the walk did not
 attribute to a directory: files directly at the mount root, reserved space, and
 entries that could not be read. When that remainder is positive, the children of
 a node sum exactly to its own `used_bytes`. If the filesystem changes while it
-is being walked, the directory totals can exceed `used_bytes`; in that case
-`other` is left out.
+is being walked, the directory totals can disagree with `used_bytes`; in that
+case the breakdown is left out entirely and only the totals are reported, so
+the children never sum past their parent.
 
 Requesting usage for a mount which does not exist returns a `404`. A `400` is
 returned for a mount which is not active, is no longer actually mounted even


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Document the parameterized `/host/disks/<disk>/usage` endpoint from home-assistant/supervisor#7146: querying a mount by name, the depth semantics for mounts (totals at `max_depth` 0–1, breakdown from 2), the `other` remainder child and its children-sum-to-`used_bytes` invariant, the error cases, and a mount example. Two pre-existing defects in the existing example are fixed alongside: the response fields are `total_bytes`/`used_bytes` (the example said `total_space`/`used_space`) and the root label is `"Root"` (the example said `"Default"`).

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [ ] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: home-assistant/supervisor#7146


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated disk usage API documentation to support named mounts alongside the default disk.
  * Clarified `max_depth` behavior, remainder handling, timeout and error conditions.
  * Documented behavior when filesystem walks are inconsistent, including totals-only responses.
  * Updated response field names to `total_bytes` and `used_bytes`.
  * Added an example response for mounted disks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->