### PR TITLE
Update docs for new default port 80 on Home Assistant OS

### DIFF
--- a/docs/api/instance_discovery.md
+++ b/docs/api/instance_discovery.md
@@ -13,7 +13,7 @@ The service is registered once the [`frontend`](https://www.home-assistant.io/in
 | Service type | `_home-assistant._tcp.local.` |
 | Instance name | `<location_name>.<service type>`. The `location_name` has `.` replaced with a space and is truncated to fit the 63-byte DNS label limit. On a name collision, Zeroconf appends a suffix (`allow_name_change`). |
 | Host (server) | `<uuid>.local.`, where `<uuid>` is the instance ID. |
-| Port | The HTTP server port (`8123` by default). |
+| Port | The HTTP server port. By default `80` on Home Assistant OS installations and `8123` otherwise, unless changed via the `SETUP_PORT` environment variable. |
 
 ## TXT properties
 

--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -3,7 +3,7 @@ title: "REST API"
 ---
 import ApiEndpoint from '@site/static/js/api_endpoint.jsx'
 
-Home Assistant provides a RESTful API on the same port as the web frontend (default port is port 8123).
+Home Assistant provides a RESTful API on the same port as the web frontend. The default port is 80 on Home Assistant OS installations and 8123 otherwise, unless the port is changed via the `SETUP_PORT` environment variable.
 
 If you are not using the [`frontend`](https://www.home-assistant.io/integrations/frontend/) in your setup then you need to add the [`api` integration](https://www.home-assistant.io/integrations/api/) to your `configuration.yaml` file.
 

--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -1202,7 +1202,7 @@ Returns information about the Home Assistant core
   "ip_address": "172.0.0.15",
   "image": "homeassistant/home-assistant",
   "boot": true,
-  "port": 8123,
+  "port": 80,
   "ssl": false,
   "watchdog": true,
   "wait_boot": 800,

--- a/docs/auth_api.md
+++ b/docs/auth_api.md
@@ -48,7 +48,7 @@ Optionally you can also include a `state` parameter, this will be added to the r
 http://your-instance.com/auth/authorize?
     client_id=https%3A%2F%2Fhass-auth-demo.glitch.me&
     redirect_uri=https%3A%2F%2Fhass-auth-demo.glitch.me%2Fauth_callback&
-    state=http%3A%2F%2Fhomeassistant.local%3A8123
+    state=http%3A%2F%2Fhomeassistant.local
 ```
 
 The user will navigate to this link and be presented with instructions to log in and authorize your application. Once authorized, the user will be redirected back to the passed-in redirect URI with the authorization code and state as part of the query parameters. Example:
@@ -56,7 +56,7 @@ The user will navigate to this link and be presented with instructions to log in
 ```txt
 https://hass-auth-demo.glitch.me/auth_callback?
     code=12345&
-    state=http%3A%2F%2Fhomeassistant.local%3A8123
+    state=http%3A%2F%2Fhomeassistant.local
 ```
 
 This authorization code can be exchanged for tokens by sending it to the token endpoint (see next section).

--- a/docs/frontend/development.md
+++ b/docs/frontend/development.md
@@ -107,7 +107,7 @@ yarn dev:serve
 You can change the Home Assistant url the frontend connects to by passing the `-c` option. This will also work for existing production core instances. It does not need to be a development version hosted locally. However, if you change the value for this option you will need to logout from your development frontend before it actually switches to the new value. For example:
 
 ```shell
-yarn dev:serve -c https://homeassistant.local:8123
+yarn dev:serve -c http://homeassistant.local
 ```
 
 You can change the port the frontend is served on by passing the `-p` option. Note that if you are running from a devcontainer, you will need to setup
@@ -175,10 +175,10 @@ Run this command to start the development server:
 
 ```shell
 nvm use
-yarn dev:serve --fetch-translations -c https://homeassistant.local:8123
+yarn dev:serve --fetch-translations -c http://homeassistant.local
 ```
 
-You may need to replace `https://homeassistant.local:8123` with your local Home Assistant url.
+You may need to replace `http://homeassistant.local` with your local Home Assistant url. `http://homeassistant.local` assumes a Home Assistant OS installation using the default port 80; older installations and other installation types typically use port 8123 (e.g. `http://homeassistant.local:8123`).
 
 ### Managing the dev server in the background
 

--- a/docs/supervisor/development.md
+++ b/docs/supervisor/development.md
@@ -80,11 +80,11 @@ The instructions here is for development of the `hassio` integration, we're goin
 
 To configure Home Assistant Core to connect to a remote supervisor, set the following environment variables when starting Home Assistant:
 
-- `SUPERVISOR`: Set to the IP of the machine running Home Assistant and port 80 (the API proxy add-on)
+- `SUPERVISOR`: Set to the IP of the machine running Home Assistant and port 8880 (the API proxy add-on)
 - `SUPERVISOR_TOKEN`: Set this to the token that you found [Supervisor API Access](#supervisor-api-access)
 
 ```shell
-SUPERVISOR=192.168.1.100:80 SUPERVISOR_TOKEN=abcdefghj1234 hass
+SUPERVISOR=192.168.1.100:8880 SUPERVISOR_TOKEN=abcdefghj1234 hass
 ```
 
 Your local Home Assistant installation will now connect to a remote Home Assistant instance.


### PR DESCRIPTION
## Proposed change

Home Assistant OS installations now serve the web frontend and API on port 80 by default (previously 8123). This updates the developer documentation accordingly:

- **REST API** (`docs/api/rest.md`): document that the default port is 80 on Home Assistant OS installations and 8123 otherwise, unless changed via the `SETUP_PORT` environment variable.
- **Instance discovery** (`docs/api/instance_discovery.md`): same hint for the advertised HTTP server port in the Zeroconf service record.
- **Supervisor API** (`docs/api/supervisor/endpoints.md`): the `/core/info` example response now shows `"port": 80`.
- **Auth API** (`docs/auth_api.md`): example `state` values now use the port-less `http://homeassistant.local` URL.
- **Frontend development** (`docs/frontend/development.md`): `yarn dev:serve -c` examples now use `http://homeassistant.local`, with a note that other installation types typically use port 8123.
- **Supervisor development** (`docs/supervisor/development.md`): the Remote API proxy add-on now publishes port 8880 by default to avoid conflicting with the frontend on port 80 (see home-assistant/addons-development#229).

Fixes https://github.com/home-assistant/developers.home-assistant/issues/3078

## Type of change

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Checklist

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] The documentation follows the [Home Assistant documentation text standards](https://developers.home-assistant.io/docs/documenting/yaml-style-guide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation to clarify default ports for Home Assistant OS and other installations.
  - Documented that the configured port can be overridden with `SETUP_PORT`.
  - Refreshed authorization and frontend development examples to use the current default URLs.
  - Updated Supervisor development instructions to use port `8880` for remote connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->