### PR TITLE
Document asking Modbus for a shared unit

### DIFF
--- a/blog/2026-07-05-modernizing-modbus.md
+++ b/blog/2026-07-05-modernizing-modbus.md
@@ -4,10 +4,6 @@ authorURL: https://github.com/balloob
 title: "Modernizing Modbus in Home Assistant"
 ---
 
-:::info Update — July 16, 2026
-We are re-evaluating the Home Assistant side of the approach described in this post. The foundation is unchanged: everything will still be built around the [`modbus-connection`](https://home-assistant-libs.github.io/modbus-connection/) PyPI package, and device libraries built on it remain the right investment. What we are rethinking is how connections surface inside Home Assistant itself, where we want to focus on being able to produce a better user experience. If you are working on a device integration, hold off on wiring it up to the `modbus_connection` integration described below — we will share the updated approach here soon.
-:::
-
 Modbus is everywhere in the modern home: solar inverters, energy meters, heat pumps, and all kinds of industrial equipment that has found its way indoors. Home Assistant has long supported these devices through the YAML-based `modbus` integration, where users hand-write register maps in their configuration. That integration is not going anywhere, and existing setups keep working. But hand-writing register maps puts the burden of understanding a device's protocol on every user, and it does not fit the config-flow, UI-first direction the rest of Home Assistant has taken.
 
 So we are adding a new way to use Modbus: an integration-based approach, where a device integration owns the device-specific knowledge and the user simply picks their device in the UI, the same as any other integration.
@@ -16,11 +12,13 @@ So we are adding a new way to use Modbus: an integration-based approach, where a
 
 A Modbus connection is a single, exclusive resource: only one party can talk on the bus at a time. A serial (RS-485) bus, or a TCP-to-serial gateway, can carry many devices at once, sometimes from different manufacturers. If two integrations each open their own connection to the same bus, they fight over it, and historically Home Assistant did not support sharing a bus between integrations at all.
 
-The new [`modbus_connection`](https://github.com/home-assistant/core/tree/dev/homeassistant/components/modbus_connection) integration solves this by making a connection something device integrations route through rather than own. The user sets up a connection once in the UI, and `modbus_connection` keeps it open and manages its lifecycle, including reconnecting after a drop. Device integrations then borrow what they need from that shared connection instead of managing their own. We have revamped the [Modbus developer documentation](/docs/modbus/introduction) to cover how that works, with example code.
+The `modbus` integration solves this by handing out units over connections it shares. A device integration collects its own connection details in its own config flow, the same as any other integration, and asks `modbus` for a unit on them. Two integrations that ask with equal details get units over one connection, so their requests serialize behind it instead of contending for the bus.
+
+Nothing about the connection is configured separately, and nothing is persisted: a connection exists only while an integration holds a unit on it, and closes when the last one unloads. That keeps the user experience where it belongs — you set up your heat pump, not a bus — while still giving the bus a single owner. The [Modbus developer documentation](/docs/modbus/introduction) covers how to ask for a unit, with example code.
 
 ## A standalone library
 
-The connection abstraction underneath `modbus_connection` lives in [`modbus-connection`](https://home-assistant-libs.github.io/modbus-connection/), a new library we designed for this purpose and published on PyPI. It is not bound to Home Assistant and can be used standalone in any Python project. It presents a common, backend-neutral interface, so device library authors write against one API regardless of the underlying Modbus implementation, and it ships a device-modelling framework and a `pytest` plugin to make building and testing a device library straightforward.
+The connection abstraction underneath `modbus` lives in [`modbus-connection`](https://home-assistant-libs.github.io/modbus-connection/), a new library we designed for this purpose and published on PyPI. It is not bound to Home Assistant and can be used standalone in any Python project. It presents a common, backend-neutral interface, so device library authors write against one API regardless of the underlying Modbus implementation, and it ships a device-modelling framework and a `pytest` plugin to make building and testing a device library straightforward.
 
 This keeps concerns where they belong. A device library is a normal PyPI package that knows how to talk to a specific device, and a consuming integration in Home Assistant wires that library up to a shared connection and exposes entities. Both can be developed and tested independently.
 

--- a/blog/2026-07-05-modernizing-modbus.md
+++ b/blog/2026-07-05-modernizing-modbus.md
@@ -14,7 +14,7 @@ A Modbus connection is a single, exclusive resource: only one party can talk on 
 
 The `modbus` integration solves this by handing out units over connections it shares. A device integration collects its own connection details in its own config flow, the same as any other integration, and asks `modbus` for a unit on them. Two integrations that ask with equal details get units over one connection, so their requests serialize behind it instead of contending for the bus.
 
-Nothing about the connection is configured separately, and nothing is persisted: a connection exists only while an integration holds a unit on it, and closes when the last one unloads. That keeps the user experience where it belongs — you set up your heat pump, not a bus — while still giving the bus a single owner. The [Modbus developer documentation](/docs/modbus/introduction) covers how to ask for a unit, with example code.
+The shared connection is not configured or persisted separately. It exists only while an integration holds a unit, and it closes when the last consumer's config entry unloads. That keeps the user experience where it belongs — you set up your heat pump, not a bus — while still giving the bus a single owner. The [Modbus developer documentation](/docs/modbus/introduction) covers how to ask for a unit, with example code.
 
 ## A standalone library
 

--- a/docs/modbus/introduction.md
+++ b/docs/modbus/introduction.md
@@ -19,12 +19,11 @@ For a complete example of the pattern, see [trovis-modbus](https://github.com/To
 
 ## Sharing one connection with other integrations
 
-A Modbus link addresses many units, and a device only answers one request at a
-time. Two integrations that open their own socket to the same device therefore
-compete for it, and neither can see the other's requests to pace itself.
+A Modbus link addresses many units, and a device answers one request at a time.
+Two integrations that each open their own socket to one device compete for it.
 
 The Modbus integration hands out units over connections it shares, so ask it for
-one instead of building your own connection:
+one instead of building your own:
 
 ```python
 from homeassistant.components.modbus import async_get_unit
@@ -43,19 +42,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
     ...
 ```
 
-Two integrations that ask with equal credentials get units over the same
-connection, so their requests serialize behind its lock rather than contending
-for the device.
+Collect the connection details in your own config flow, as you would any other.
+Two integrations that ask with equal details get units over one connection, so
+their requests serialize behind it.
 
-Your integration collects its own credentials in its own config flow, and passes
-them here. Nothing is persisted: a connection exists only while somebody holds a
-unit on it, and it closes when the last consumer's config entry unloads.
+The connection itself is not stored anywhere: it exists while an integration
+holds a unit on it, and closes when the last holder's config entry unloads. Your
+own entry data is untouched.
 
 Asking for a unit performs no I/O, so a device that is powered down does not stop
-your integration setting up. The first read establishes the link, and a dropped
-link re-establishes itself, so do not reload your config entry when the
-connection goes away.
+your integration setting up. The first read opens the link, and a dropped link
+opens again on the next request. Do not reload your entry when a connection
+drops.
 
-Asking for a device that is already in use over different link settings raises
-`HomeAssistantError`: one connection cannot honour two baud rates or framings at
-once.
+Asking for a device already in use over different link settings raises
+`HomeAssistantError`. One connection cannot honour two baud rates at once.

--- a/docs/modbus/introduction.md
+++ b/docs/modbus/introduction.md
@@ -45,9 +45,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
 
 Two integrations that ask with equal credentials get units over the same
 connection, so their requests serialize behind its lock rather than contending
-for the device. The parameters identify the device by their `endpoint`, which
-excludes link settings such as framing and baud rate, and folds the host's case,
-so `Device.local` and `device.local` are one device rather than two.
+for the device.
 
 Your integration collects its own credentials in its own config flow, and passes
 them here. Nothing is persisted: a connection exists only while somebody holds a

--- a/docs/modbus/introduction.md
+++ b/docs/modbus/introduction.md
@@ -16,3 +16,48 @@ We require each integration to implement a library that handles the device-speci
 - A `pytest` plugin to make testing your library easy.
 
 For a complete example of the pattern, see [trovis-modbus](https://github.com/Tom-Bom-badil/trovis-modbus), a device library built on `modbus-connection`, and [trovis-modbus-hass](https://github.com/Tom-Bom-badil/trovis-modbus-hass), the Home Assistant integration that consumes it.
+
+## Sharing one connection with other integrations
+
+A Modbus link addresses many units, and a device only answers one request at a
+time. Two integrations that open their own socket to the same device therefore
+compete for it, and neither can see the other's requests to pace itself.
+
+The Modbus integration hands out units over connections it shares, so ask it for
+one instead of building your own connection:
+
+```python
+from homeassistant.components.modbus import async_get_unit
+from modbus_connection import ModbusTcpParams
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
+    """Set up my device from a config entry."""
+    unit = async_get_unit(
+        hass,
+        entry,
+        ModbusTcpParams(host=entry.data[CONF_HOST], port=entry.data[CONF_PORT]),
+        entry.data[CONF_UNIT_ID],
+    )
+    device = MyDevice(unit)
+    ...
+```
+
+Two integrations that ask with equal credentials get units over the same
+connection, so their requests serialize behind its lock rather than contending
+for the device. The parameters identify the device by their `endpoint`, which
+excludes link settings such as framing and baud rate, and folds the host's case,
+so `Device.local` and `device.local` are one device rather than two.
+
+Your integration collects its own credentials in its own config flow, and passes
+them here. Nothing is persisted: a connection exists only while somebody holds a
+unit on it, and it closes when the last consumer's config entry unloads.
+
+Asking for a unit performs no I/O, so a device that is powered down does not stop
+your integration setting up. The first read establishes the link, and a dropped
+link re-establishes itself, so do not reload your config entry when the
+connection goes away.
+
+Asking for a device that is already in use over different link settings raises
+`HomeAssistantError`: one connection cannot honour two baud rates or framings at
+once.


### PR DESCRIPTION
## Proposed change

Documents `async_get_unit`, added by home-assistant/core#179658, and brings the Modbus blog post in line with what actually shipped.

A Modbus link addresses many units and a device answers one request at a time, so two integrations that each open their own socket to the same device compete for it. The `modbus` integration hands out units over connections it shares instead.

**Developer docs.** A new section on the existing Modbus page: how to ask for a unit, and what sharing means for a consumer. You collect your own credentials in your own config flow; equal credentials share a connection; nothing is persisted and the connection closes when the last holder's entry unloads; asking performs no I/O, so a powered-down device does not block setup; a dropped link re-establishes itself, so do not reload the entry; and asking for one device under two different link settings raises `HomeAssistantError`.

**Blog post.** The July 16 note said the Home Assistant side was being re-evaluated and told device integrations to hold off. That is resolved, so the note goes. The sharing section it warned about described a separate `modbus_connection` integration the user sets up in the UI, which is not what shipped — the logic lives in the `modbus` integration, and a device integration collects its own connection details in its own config flow. The section now describes that.

## Type of change

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist

- [ ] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: home-assistant/core#179658


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how integrations provide Modbus connection details through their own configuration flows.
  * Updated guidance on sharing connections with matching settings, connection lifetime, preserved configuration data, lazy opening, and reconnection.
  * Clarified handling of conflicting baud-rate settings.
  * Updated the modernization article to describe transient connections shared by matching connection details and closed when no longer in use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->