### PR TITLE
Document temporary Modbus units

### DIFF
--- a/docs/modbus/introduction.md
+++ b/docs/modbus/introduction.md
@@ -61,8 +61,6 @@ async def async_validate_input(
         await device.async_validate()
 ```
 
-Keep all communication with the temporary unit inside the context. It reuses a matching connection that an integration already holds without closing it on exit. If no integration holds the connection, it closes when the context exits, including when probing raises an exception. After the config flow creates its entry, use `async_get_unit` during setup to hold the unit until that entry unloads.
-
 The connection itself is not stored anywhere: it exists while an integration
 holds a unit on it, and closes when the last holder's config entry unloads. Your
 own entry data is untouched.

--- a/docs/modbus/introduction.md
+++ b/docs/modbus/introduction.md
@@ -46,6 +46,23 @@ Collect the connection details in your own config flow, as you would any other.
 Two integrations that ask with equal details get units over one connection, so
 their requests serialize behind it.
 
+If your config flow needs to communicate with the device before creating its config entry, hold a unit temporarily while you probe it:
+
+```python
+from homeassistant.components.modbus import async_get_temporary_unit
+
+
+async def async_validate_input(
+    hass: HomeAssistant, params: ModbusTcpParams, unit_id: int
+) -> None:
+    """Validate that the device can be reached."""
+    async with async_get_temporary_unit(hass, params, unit_id) as unit:
+        device = MyDevice(unit)
+        await device.async_validate()
+```
+
+Keep all communication with the temporary unit inside the context. It reuses a matching connection that an integration already holds without closing it on exit. If no integration holds the connection, it closes when the context exits, including when probing raises an exception. After the config flow creates its entry, use `async_get_unit` during setup to hold the unit until that entry unloads.
+
 The connection itself is not stored anywhere: it exists while an integration
 holds a unit on it, and closes when the last holder's config entry unloads. Your
 own entry data is untouched.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Document how config flows can use `async_get_temporary_unit` to probe a Modbus device before creating a config entry. Explain the temporary unit's connection-sharing and cleanup behavior, and when to switch to `async_get_unit`.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/core/pull/179939


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance and a Python example for validating Modbus devices during setup with a temporary unit context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->