### PR TITLE
Correct mmHG to mmHg in the atmospheric pressure device class tables

### DIFF
--- a/docs/core/entity/number.md
+++ b/docs/core/entity/number.md
@@ -35,7 +35,7 @@ If specifying a device class, your number entity will need to also return the co
 | `NumberDeviceClass.APPARENT_POWER` | mVA, VA, kVA | Apparent power
 | `NumberDeviceClass.AQI` | None | Air Quality Index
 | `NumberDeviceClass.AREA` | m², cm², km², mm², in², ft², yd², mi², ac, ha | Area
-| `NumberDeviceClass.ATMOSPHERIC_PRESSURE` | cbar, bar, hPa, mmHG, inHg, inH₂O, kPa, mbar, Pa, psi | Atmospheric pressure
+| `NumberDeviceClass.ATMOSPHERIC_PRESSURE` | cbar, bar, hPa, mmHg, inHg, inH₂O, kPa, mbar, Pa, psi | Atmospheric pressure
 | `NumberDeviceClass.BATTERY` | % | Percentage of battery that is left
 | `NumberDeviceClass.BLOOD_GLUCOSE_CONCENTRATION` | mg/dL, mmol/L | Blood glucose concentration```
 | `NumberDeviceClass.CO2` | ppm | Concentration of carbon dioxide.

--- a/docs/core/entity/sensor.md
+++ b/docs/core/entity/sensor.md
@@ -36,7 +36,7 @@ If specifying a device class, your sensor entity will need to also return the co
 | `SensorDeviceClass.APPARENT_POWER` | mVA, VA, kVA | Apparent power
 | `SensorDeviceClass.AQI` | None | Air Quality Index
 | `SensorDeviceClass.AREA` | m², cm², km², mm², in², ft², yd², mi², ac, ha | Area
-| `SensorDeviceClass.ATMOSPHERIC_PRESSURE` | cbar, bar, hPa, mmHG, inHg, inH₂O, kPa, mbar, Pa, psi | Atmospheric pressure
+| `SensorDeviceClass.ATMOSPHERIC_PRESSURE` | cbar, bar, hPa, mmHg, inHg, inH₂O, kPa, mbar, Pa, psi | Atmospheric pressure
 | `SensorDeviceClass.BATTERY` | % | Percentage of battery that is left
 | `SensorDeviceClass.BLOOD_GLUCOSE_CONCENTRATION` | mg/dL, mmol/L | Blood glucose concentration
 | `SensorDeviceClass.CO2` | ppm | Concentration of carbon dioxide.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The `ATMOSPHERIC_PRESSURE` rows in the number and sensor entity tables spell the unit `mmHG` with a capital G. The correct symbol for millimetres of mercury is `mmHg`, which is what the `PRESSURE` rows in the same tables already use and what `UnitOfPressure.MMHG` is defined as.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [x] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: `UnitOfPressure.MMHG` in `homeassistant/const.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected atmospheric pressure unit notation in the device-class documentation.
  * Updated the supported unit from `mmHG` to `mmHg` where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->