### PR TITLE
docs: fix typo targetting -> targeting

### DIFF
--- a/blog/2021-10-26-config-entity.md
+++ b/blog/2021-10-26-config-entity.md
@@ -27,7 +27,7 @@ or diagnostics of a device but does not allow changing it, for example, a sensor
 RSSI or MAC address with allowed values.
 
 Entities which have the `entity_category` set:
-- Are not included in a service call targetting a whole device or area.
+- Are not included in a service call targeting a whole device or area.
 - Are, by default, not exposed to Google Assistant or Alexa.
 - Are shown on a separate card on the device configuration page.
 - Do not show up on the automatically generated Lovelace Dashboards.


### PR DESCRIPTION
One-word typo fix in `blog/2021-10-26-config-entity.md:30`: "Are not included in a se..." → `targeting`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a spelling error in a blog post describing entity targeting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->