### PR TITLE
Document Supervisor NTP API

### DIFF
--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -3833,6 +3833,47 @@ Update the supervisor
 
 </ApiEndpoint>
 
+### Time
+
+<ApiEndpoint path="/time/info" method="get">
+
+Get the configured NTP servers. Requires Home Assistant OS 18.3 or newer, unavailable on Supervised.
+
+`/host/info` lists `ntp` in `features` when these endpoints are available.
+
+**Returned data:**
+
+| key              | type | description                      |
+|------------------|------|----------------------------------|
+| servers          | list | Configured NTP servers.          |
+| fallback_servers | list | Configured fallback NTP servers. |
+
+**Example response:**
+
+```json
+{
+  "servers": ["time.cloudflare.com"],
+  "fallback_servers": ["time.google.com"]
+}
+```
+
+</ApiEndpoint>
+
+<ApiEndpoint path="/time/options" method="post">
+
+Set the NTP servers. Requires Home Assistant OS 18.3 or newer, unavailable on Supervised.
+
+Omitted keys keep their current value. Pass an empty list to drop the configured servers and return to the operating system defaults. `systemd-timesyncd` is restarted whenever a value changes.
+
+**Payload:**
+
+| key              | type | optional | description                                                                       |
+|------------------|------|----------|-----------------------------------------------------------------------------------|
+| servers          | list | True     | NTP servers to use. An entry must not contain whitespace or `#`.                  |
+| fallback_servers | list | True     | Fallback NTP servers, used when no servers are configured or supplied by DHCP.    |
+
+</ApiEndpoint>
+
 ### Placeholders
 
 Some of the endpoints uses placeholders indicated with `<...>` in the endpoint URL.

--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -3843,17 +3843,27 @@ Get the configured NTP servers. Requires Home Assistant OS 18.3 or newer, unavai
 
 **Returned data:**
 
+| key    | type | description                                       |
+|--------|------|---------------------------------------------------|
+| config | dict | The NTP settings written by Supervisor, see below. |
+
+**config:**
+
 | key              | type | description                      |
 |------------------|------|----------------------------------|
 | servers          | list | Configured NTP servers.          |
 | fallback_servers | list | Configured fallback NTP servers. |
 
+These are the settings Supervisor wrote. `systemd-timesyncd` merges them with servers from other sources, such as DHCP, so the servers actually in use can differ.
+
 **Example response:**
 
 ```json
 {
-  "servers": ["time.cloudflare.com"],
-  "fallback_servers": ["time.google.com"]
+  "config": {
+    "servers": ["time.cloudflare.com"],
+    "fallback_servers": ["time.google.com"]
+  }
 }
 ```
 
@@ -3867,10 +3877,10 @@ Omitted keys keep their current value. Pass an empty list to drop the configured
 
 **Payload:**
 
-| key              | type | optional | description                                                                       |
-|------------------|------|----------|-----------------------------------------------------------------------------------|
-| servers          | list | True     | NTP servers to use. An entry must not contain whitespace or `#`.                  |
-| fallback_servers | list | True     | Fallback NTP servers, used when no servers are configured or supplied by DHCP.    |
+| key              | type | optional | description                                                                    |
+|------------------|------|----------|--------------------------------------------------------------------------------|
+| servers          | list | True     | NTP servers to use.                                                            |
+| fallback_servers | list | True     | Fallback NTP servers, used when no servers are configured or supplied by DHCP. |
 
 </ApiEndpoint>
 


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Add API endpoint documentation for home-assistant/supervisor#7181.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: home-assistant/supervisor#7181


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Documented that `GET /time/info` returns NTP server settings within a `config` object.
  - Clarified that `systemd-timesyncd` combines configured servers with servers from other sources, such as DHCP.
  - Updated the example response to reflect the current format.
  - Documented updating NTP server settings, including partial updates and resetting to operating system defaults with an empty list.
  - Clarified time synchronization behavior, feature detection, and availability requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->