### PR TITLE
Remove window.loadES5Adapter from custom panel docs

### DIFF
--- a/docs/frontend/custom-ui/creating-custom-panels.md
+++ b/docs/frontend/custom-ui/creating-custom-panels.md
@@ -90,12 +90,4 @@ The Home Assistant frontend will pass information to your panel by setting prope
 
 ## JavaScript versions
 
-The Home Assistant user interface is currently served to browsers in modern JavaScript and older JavaScript (ES5). The older version has a wider browser support but that comes at a cost of size and performance.
-
-If you do need to run with ES5 support, you will need to load the ES5 custom elements adapter before defining your element:
-
-```javascript
-window.loadES5Adapter().then(function() {
-  customElements.define('my-panel', MyCustomPanel)
-});
-```
+The Home Assistant user interface is served to browsers as a modern build and a legacy build for older browsers. Custom panels are loaded in both, so define your custom element with standard JavaScript classes (ES2015 or later). ES5-transpiled custom elements are not supported; the previously documented `window.loadES5Adapter()` hook has been removed.


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
The frontend removed the ES5 custom elements adapter and the window.loadES5Adapter hook: its legacy build no longer emits ES5, so ES5-transpiled custom panels are no longer supported. Rewrites the JavaScript versions section accordingly.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/frontend/pull/53899


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated custom panel guidance to require standard JavaScript classes (ES2015 or later).
  * Clarified that ES5-transpiled custom elements and the legacy adapter hook are no longer supported.
  * Documented that custom panels load in both modern and legacy UI builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->