### PR TITLE
Document probe-authoritative mount usage

### DIFF
--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -2064,12 +2064,15 @@ is being walked, the directory totals can disagree with `used_bytes`; in that
 case the breakdown is left out entirely and only the totals are reported, so
 the children never sum past their parent.
 
+The probe is authoritative rather than any cached mount state: measuring usage
+accesses the path, which also activates a mount that was armed but dormant. A
+usage request is therefore not strictly read-only with respect to system state.
+
 Requesting usage for a mount which does not exist returns a `404`. A `400` is
-returned for a mount which is not active, is no longer actually mounted even
-though its unit still reports active, cannot be read, or whose usage probe has
-not completed within 60 seconds. The probe keeps running after that timeout, so
-retrying the request joins the probe already underway instead of starting a new
-one.
+returned for a mount whose path is no longer actually mounted, which cannot be
+read, or whose usage probe has not completed within 60 seconds. The probe keeps
+running after that timeout, so retrying the request joins the probe already
+underway instead of starting a new one.
 
 **Example response:**
 

--- a/docs/api/supervisor/endpoints.md
+++ b/docs/api/supervisor/endpoints.md
@@ -2064,15 +2064,14 @@ is being walked, the directory totals can disagree with `used_bytes`; in that
 case the breakdown is left out entirely and only the totals are reported, so
 the children never sum past their parent.
 
-The probe is authoritative rather than any cached mount state: measuring usage
-accesses the path, which also activates a mount that was armed but dormant. A
-usage request is therefore not strictly read-only with respect to system state.
+Usage is measured by probing the path, not from cached mount state. That probe
+activates a dormant automount if needed, so a usage request can change system
+state.
 
 Requesting usage for a mount which does not exist returns a `404`. A `400` is
-returned for a mount whose path is no longer actually mounted, which cannot be
-read, or whose usage probe has not completed within 60 seconds. The probe keeps
-running after that timeout, so retrying the request joins the probe already
-underway instead of starting a new one.
+returned if the path is no longer a mount, cannot be read, or the probe has not
+finished within 60 seconds. The probe keeps running after that timeout, so a
+retry joins the probe already underway instead of starting a new one.
 
 **Example response:**
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Update the `/host/disks/<disk>/usage` documentation for home-assistant/supervisor#7188: the probe is authoritative rather than any cached mount state (so a usage request can activate a dormant automount and is not strictly read-only), and the "not active" error case is gone from the 400 list.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: home-assistant/supervisor#7188


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how disk usage is measured for host disk paths.
  - Documented that checking usage may activate dormant automounts.
  - Updated `400` error conditions to include invalid mounts, unreadable paths, and probes exceeding 60 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->