### PR TITLE
Add blog post on modbus get_hub deprecation

### DIFF
--- a/blog/2026-09-02-modbus-get-hub-deprecation.md
+++ b/blog/2026-09-02-modbus-get-hub-deprecation.md
@@ -10,7 +10,7 @@ As of Home Assistant Core 2026.10, `modbus.get_hub` is deprecated. It will be re
 
 `get_hub` attaches an integration to a Modbus hub the user configured in YAML, under a name the integration has to be told. The user has to set up the hub by hand before the integration can work, and two integrations that need the same bus cannot share it.
 
-In July we [modernized Modbus in Home Assistant](/blog/2026/07/05/modernizing-modbus) and added `async_get_unit`. An integration collects the connection details in its own config flow, the same as any other integration, and asks the Modbus integration for a unit on them. Integrations that ask with equal details share one connection. Nothing is configured in YAML and nothing extra is persisted.
+In July we announced our plan to [modernize Modbus in Home Assistant](/blog/2026/07/05/modernizing-modbus). Home Assistant Core 2026.9 delivered the first piece: `async_get_unit`. An integration collects the connection details in its own config flow, the same as any other integration, and asks the Modbus integration for a unit on them. Integrations that ask with equal details share one connection. Nothing is configured in YAML and nothing extra is persisted.
 
 ## What to do
 

--- a/blog/2026-09-02-modbus-get-hub-deprecation.md
+++ b/blog/2026-09-02-modbus-get-hub-deprecation.md
@@ -33,6 +33,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
     ...
 ```
 
-This is not a one-to-one swap. Your config flow has to collect the host, port, and unit ID that the user used to write in the YAML hub, and the device-specific communication should move into a library built on [`modbus-connection`](https://home-assistant-libs.github.io/modbus-connection/). The [Modbus developer documentation](/docs/modbus/introduction) describes both, with example code and a reference device library.
+This is not a one-to-one swap. Your config flow has to collect the connection details required by the transport, for example host and port, besides unit ID, that the user used to write in the YAML hub, and the device-specific communication should move into a library built on [`modbus-connection`](https://home-assistant-libs.github.io/modbus-connection/). The [Modbus developer documentation](/docs/modbus/introduction) describes both, with example code and a reference device library.
 
 More details can be found in the [core PR](https://github.com/home-assistant/core/pull/179933).

--- a/blog/2026-09-02-modbus-get-hub-deprecation.md
+++ b/blog/2026-09-02-modbus-get-hub-deprecation.md
@@ -1,0 +1,38 @@
+---
+author: Paulus Schoutsen
+authorURL: https://github.com/balloob
+title: "Deprecating modbus.get_hub in favor of async_get_unit"
+---
+
+As of Home Assistant Core 2026.10, `modbus.get_hub` is deprecated. It will be removed in Home Assistant Core 2027.10. Custom integrations that call it get a warning in the log until then, and stop working after that.
+
+## Background
+
+`get_hub` attaches an integration to a Modbus hub the user configured in YAML, under a name the integration has to be told. The user has to set up the hub by hand before the integration can work, and two integrations that need the same bus cannot share it.
+
+In July we [modernized Modbus in Home Assistant](/blog/2026/07/05/modernizing-modbus) and added `async_get_unit`. An integration collects the connection details in its own config flow, the same as any other integration, and asks the Modbus integration for a unit on them. Integrations that ask with equal details share one connection. Nothing is configured in YAML and nothing extra is persisted.
+
+## What to do
+
+Replace the call to `get_hub` with a call to `async_get_unit`:
+
+```python
+from homeassistant.components.modbus import async_get_unit
+from modbus_connection import ModbusTcpParams
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
+    """Set up my device from a config entry."""
+    unit = async_get_unit(
+        hass,
+        entry,
+        ModbusTcpParams(host=entry.data[CONF_HOST], port=entry.data[CONF_PORT]),
+        entry.data[CONF_UNIT_ID],
+    )
+    device = MyDevice(unit)
+    ...
+```
+
+This is not a one-to-one swap. Your config flow has to collect the host, port, and unit ID that the user used to write in the YAML hub, and the device-specific communication should move into a library built on [`modbus-connection`](https://home-assistant-libs.github.io/modbus-connection/). The [Modbus developer documentation](/docs/modbus/introduction) describes both, with example code and a reference device library.
+
+More details can be found in the [core PR](https://github.com/home-assistant/core/pull/179933).


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Adds a dev blog post announcing the deprecation of `modbus.get_hub` in Home Assistant Core 2026.10, with removal in 2027.10. The post links to the [Modernizing Modbus](https://developers.home-assistant.io/blog/2026/07/05/modernizing-modbus) post for background, shows the `async_get_unit` replacement, and links to the [Modbus developer documentation](https://developers.home-assistant.io/docs/modbus/introduction) for the full migration.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: home-assistant/core#179933

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G36qz8stJq8uQwBPYFW4DX

---
_Generated by [Claude Code](https://claude.ai/code/session_01G36qz8stJq8uQwBPYFW4DX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a blog post announcing the deprecation of `modbus.get_hub` in Home Assistant Core 2026.10 and its planned removal in 2027.10.
  * Documented migration to `async_get_unit`, including configuration considerations and a TCP example.
  * Clarified that configuration flows should collect transport-specific connection details, such as the host and port, alongside the unit ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->