### PR TITLE
Document images key for custom dashboard strategies

### DIFF
--- a/docs/frontend/custom-ui/custom-strategy.md
+++ b/docs/frontend/custom-ui/custom-strategy.md
@@ -34,6 +34,7 @@ The object supports the following keys:
 | `name`             | No       | Friendly name shown in the picker.                                             |
 | `description`      | No       | Short text shown below the name.                                               |
 | `documentationURL` | No       | Link to your documentation. This is not shown in the strategy UI yet.          |
+| `images`           | No       | `{ light, dark }` URLs of a 160x160 preview shown on the tile, one per theme mode. |
 
 Example:
 
@@ -45,6 +46,10 @@ window.customStrategies.push({
   name: "My demo dashboard",
   description: "A starter dashboard generated from JavaScript.",
   documentationURL: "https://example.com/my-demo-dashboard",
+  images: {
+    light: "/local/my-demo/preview-light.svg",
+    dark: "/local/my-demo/preview-dark.svg",
+  },
 });
 ```
 


### PR DESCRIPTION
## Proposed change

Documents the optional `images: { light, dark }` key on `window.customStrategies` entries, added in home-assistant/frontend#54008, so community dashboards can show the same 160x160 preview tile as the built-in strategies in the new dashboard dialog. Adds a row to the keys table and the key to the registration example.

## Type of change

- [ ] Document existing features within Home Assistant
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Editing or restructuring documentation guidelines
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/standards).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information

- Parent pull request: home-assistant/frontend#54008


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the optional `images` setting for community dashboard strategies, including light and dark 160×160 preview URLs displayed on strategy tiles.
  * Added an example showing how to configure theme-specific preview images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->